### PR TITLE
fix(ci): --force on git fetch in macOS release changelog step

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -150,7 +150,8 @@ jobs:
       - name: Generate Changelog
         if: startsWith(github.ref, 'refs/tags/')
         run: |
-          git fetch --tags --unshallow 2>/dev/null || git fetch --tags
+          # --force so local/remote v<current> tag doesn't clobber-reject the fetch
+          git fetch --tags --force --unshallow 2>/dev/null || git fetch --tags --force
           
           # Get current tag
           CURRENT_TAG=${GITHUB_REF#refs/tags/}


### PR DESCRIPTION
## Summary

v0.4.0's macOS release run failed at the Generate Changelog step because `git fetch --tags` without `--force` is rejected when actions/checkout already populated the tag being pushed. The fetch tries to update the local tag ref to the remote one (identical commit) and git refuses with "would clobber existing tag".

Windows isn't affected because its workflow doesn't generate a changelog.

## Fix

Add `--force` to both fetch attempts in the fallback chain. Tags point at the same commit either way — the force just allows git to overwrite its own ref.

## Test plan

- [ ] After merge: delete + re-push v0.4.0 tag, verify the macOS release build runs through Generate Changelog and uploads dmg + app.tar.gz + latest.json to the existing Release

🤖 Generated with [Claude Code](https://claude.com/claude-code)