### PR TITLE
feat(llm): add OpenAI/Gemini providers and Settings UI

### DIFF
--- a/ClassNoteAI/src/components/AIProviderSettings.tsx
+++ b/ClassNoteAI/src/components/AIProviderSettings.tsx
@@ -1,0 +1,246 @@
+/**
+ * Settings UI for LLM providers.
+ *
+ * Lists the registered providers, lets the user paste a PAT / API key
+ * per provider, and runs a smoke test against the provider's endpoint.
+ * No functional wiring yet — the LLMProvider isn't called from anywhere
+ * in the app until PR C/D. This just covers configuration.
+ */
+
+import { useEffect, useState } from 'react';
+import { CheckCircle, XCircle, Loader2, Eye, EyeOff, ExternalLink } from 'lucide-react';
+import {
+  getProvider,
+  keyStore,
+  listProviders,
+  LLMProviderDescriptor,
+  LLMTestResult,
+} from '../services/llm';
+
+type ProviderState = {
+  descriptor: LLMProviderDescriptor;
+  value: string;
+  saved: boolean;
+  testing: boolean;
+  result?: LLMTestResult;
+  show: boolean;
+};
+
+const AUTH_FIELD_BY_PROVIDER: Record<string, string> = {
+  'github-models': 'pat',
+  anthropic: 'apiKey',
+  openai: 'apiKey',
+  gemini: 'apiKey',
+};
+
+const HELP_LINKS: Record<string, { label: string; href: string }> = {
+  'github-models': {
+    label: 'Generate PAT (scope: models:read)',
+    href: 'https://github.com/settings/tokens?type=beta',
+  },
+  anthropic: {
+    label: 'Get API key from Anthropic console',
+    href: 'https://console.anthropic.com/settings/keys',
+  },
+  openai: {
+    label: 'Get API key from OpenAI platform',
+    href: 'https://platform.openai.com/api-keys',
+  },
+  gemini: {
+    label: 'Get API key from Google AI Studio',
+    href: 'https://aistudio.google.com/apikey',
+  },
+};
+
+const DEFAULT_PROVIDER_KEY = 'llm.defaultProvider';
+
+export default function AIProviderSettings() {
+  const [states, setStates] = useState<ProviderState[]>(() =>
+    listProviders().map((d) => {
+      const field = AUTH_FIELD_BY_PROVIDER[d.id];
+      return {
+        descriptor: d,
+        value: (field && keyStore.get(d.id, field)) || '',
+        saved: !!(field && keyStore.has(d.id, field)),
+        testing: false,
+        show: false,
+      };
+    })
+  );
+  const [defaultProvider, setDefaultProvider] = useState<string>(
+    () => localStorage.getItem(DEFAULT_PROVIDER_KEY) || ''
+  );
+
+  useEffect(() => {
+    if (defaultProvider) {
+      localStorage.setItem(DEFAULT_PROVIDER_KEY, defaultProvider);
+    } else {
+      localStorage.removeItem(DEFAULT_PROVIDER_KEY);
+    }
+  }, [defaultProvider]);
+
+  const updateState = (id: string, patch: Partial<ProviderState>) => {
+    setStates((prev) => prev.map((s) => (s.descriptor.id === id ? { ...s, ...patch } : s)));
+  };
+
+  const onSave = (id: string) => {
+    const field = AUTH_FIELD_BY_PROVIDER[id];
+    const s = states.find((x) => x.descriptor.id === id);
+    if (!field || !s) return;
+    if (s.value.trim()) {
+      keyStore.set(id, field, s.value.trim());
+      updateState(id, { saved: true, result: undefined });
+    } else {
+      keyStore.clear(id, field);
+      updateState(id, { saved: false, result: undefined });
+    }
+  };
+
+  const onTest = async (id: string) => {
+    updateState(id, { testing: true, result: undefined });
+    try {
+      const result = await getProvider(id).testConnection();
+      updateState(id, { testing: false, result });
+    } catch (err) {
+      updateState(id, {
+        testing: false,
+        result: { ok: false, message: String(err) },
+      });
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div>
+        <label className="block text-sm font-medium mb-1">Default provider</label>
+        <select
+          className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-slate-900 px-3 py-2 text-sm"
+          value={defaultProvider}
+          onChange={(e) => setDefaultProvider(e.target.value)}
+        >
+          <option value="">(auto — first configured)</option>
+          {states
+            .filter((s) => s.saved)
+            .map((s) => (
+              <option key={s.descriptor.id} value={s.descriptor.id}>
+                {s.descriptor.displayName}
+              </option>
+            ))}
+        </select>
+      </div>
+
+      <div className="space-y-3">
+        {states.map((s) => (
+          <ProviderCard
+            key={s.descriptor.id}
+            state={s}
+            help={HELP_LINKS[s.descriptor.id]}
+            onChange={(v) => updateState(s.descriptor.id, { value: v })}
+            onToggleShow={() => updateState(s.descriptor.id, { show: !s.show })}
+            onSave={() => onSave(s.descriptor.id)}
+            onTest={() => onTest(s.descriptor.id)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function ProviderCard(props: {
+  state: ProviderState;
+  help?: { label: string; href: string };
+  onChange: (v: string) => void;
+  onToggleShow: () => void;
+  onSave: () => void;
+  onTest: () => void;
+}) {
+  const { state, help, onChange, onToggleShow, onSave, onTest } = props;
+  const { descriptor, value, saved, testing, result, show } = state;
+  const fieldLabel = descriptor.authType === 'pat' ? 'GitHub PAT' : 'API key';
+
+  return (
+    <div className="border border-gray-200 dark:border-gray-700 rounded-lg p-4 bg-gray-50 dark:bg-slate-900/50">
+      <div className="flex items-start justify-between gap-2 mb-2">
+        <div>
+          <div className="font-medium flex items-center gap-2">
+            {descriptor.displayName}
+            {saved && (
+              <span className="text-xs px-2 py-0.5 rounded bg-green-100 text-green-700 dark:bg-green-900/40 dark:text-green-400">
+                configured
+              </span>
+            )}
+          </div>
+          {descriptor.notes && (
+            <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">{descriptor.notes}</div>
+          )}
+        </div>
+      </div>
+
+      <label className="block text-xs text-gray-600 dark:text-gray-400 mb-1">{fieldLabel}</label>
+      <div className="flex gap-2 items-center">
+        <div className="relative flex-1">
+          <input
+            type={show ? 'text' : 'password'}
+            value={value}
+            onChange={(e) => onChange(e.target.value)}
+            placeholder={descriptor.authType === 'pat' ? 'ghp_...' : 'sk-...'}
+            className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-slate-900 px-3 py-2 pr-10 text-sm font-mono"
+          />
+          <button
+            type="button"
+            onClick={onToggleShow}
+            className="absolute right-2 top-1/2 -translate-y-1/2 text-gray-400 hover:text-gray-600"
+            title={show ? 'Hide' : 'Show'}
+          >
+            {show ? <EyeOff className="w-4 h-4" /> : <Eye className="w-4 h-4" />}
+          </button>
+        </div>
+        <button
+          type="button"
+          onClick={onSave}
+          className="px-3 py-2 text-sm rounded-lg bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50"
+        >
+          Save
+        </button>
+        <button
+          type="button"
+          onClick={onTest}
+          disabled={!saved || testing}
+          className="px-3 py-2 text-sm rounded-lg border border-gray-300 dark:border-gray-600 hover:bg-gray-100 dark:hover:bg-gray-700 disabled:opacity-50 flex items-center gap-1.5"
+        >
+          {testing && <Loader2 className="w-3.5 h-3.5 animate-spin" />}
+          Test
+        </button>
+      </div>
+
+      {help && (
+        <a
+          href={help.href}
+          target="_blank"
+          rel="noreferrer"
+          className="text-xs text-blue-600 dark:text-blue-400 hover:underline mt-2 inline-flex items-center gap-1"
+        >
+          {help.label}
+          <ExternalLink className="w-3 h-3" />
+        </a>
+      )}
+
+      {result && (
+        <div
+          className={`mt-2 text-xs flex items-start gap-1.5 ${
+            result.ok
+              ? 'text-green-700 dark:text-green-400'
+              : 'text-red-700 dark:text-red-400'
+          }`}
+        >
+          {result.ok ? (
+            <CheckCircle className="w-3.5 h-3.5 flex-shrink-0 mt-0.5" />
+          ) : (
+            <XCircle className="w-3.5 h-3.5 flex-shrink-0 mt-0.5" />
+          )}
+          <span className="break-all">{result.message}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/ClassNoteAI/src/components/SettingsView.tsx
+++ b/ClassNoteAI/src/components/SettingsView.tsx
@@ -5,6 +5,7 @@ import { getVersion } from "@tauri-apps/api/app";
 
 import WhisperModelManager from './WhisperModelManager';
 import TranslationModelManager from './TranslationModelManager';
+import AIProviderSettings from './AIProviderSettings';
 import { ollamaService, OllamaModel } from "../services/ollamaService";
 
 import { storageService } from "../services/storageService";
@@ -648,6 +649,21 @@ export default function SettingsView({ }: SettingsViewProps) {
       case 'ollama-settings':
         return (
           <div className="space-y-6 animate-in fade-in duration-300">
+            <div className="bg-white dark:bg-slate-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden">
+              <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-slate-900/50">
+                <h3 className="text-lg font-medium flex items-center gap-2">
+                  <Brain className="w-5 h-5 text-indigo-500" />
+                  雲端 AI Providers
+                </h3>
+                <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                  配置 LLM 訂閱或 API key，供翻譯、摘要、Q&amp;A 等功能使用（接入於 v0.5.0+）。
+                </p>
+              </div>
+              <div className="p-6">
+                <AIProviderSettings />
+              </div>
+            </div>
+
             <div className="bg-white dark:bg-slate-800 rounded-xl shadow-sm border border-gray-200 dark:border-gray-700 overflow-hidden">
               <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-slate-900/50">
                 <h3 className="text-lg font-medium flex items-center gap-2">

--- a/ClassNoteAI/src/services/llm/__tests__/openai-and-gemini.test.ts
+++ b/ClassNoteAI/src/services/llm/__tests__/openai-and-gemini.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+import { fetch } from '@tauri-apps/plugin-http';
+import { keyStore } from '../keyStore';
+import { OpenAIProvider } from '../providers/openai';
+import { GeminiProvider } from '../providers/gemini';
+
+const mockedFetch = vi.mocked(fetch);
+
+function jsonResponse(body: unknown, status = 200): Response {
+    return {
+        ok: status >= 200 && status < 300,
+        status,
+        json: () => Promise.resolve(body),
+        text: () => Promise.resolve(typeof body === 'string' ? body : JSON.stringify(body)),
+        body: null,
+    } as unknown as Response;
+}
+
+describe('OpenAIProvider', () => {
+    beforeEach(() => {
+        keyStore.set('openai', 'apiKey', 'sk-test');
+    });
+
+    it('sends Bearer auth header and hits the OpenAI chat endpoint', async () => {
+        mockedFetch.mockResolvedValueOnce(
+            jsonResponse({
+                model: 'gpt-5.4',
+                choices: [{ message: { content: 'ok' }, finish_reason: 'stop' }],
+                usage: { prompt_tokens: 1, completion_tokens: 1 },
+            }) as never
+        );
+
+        const provider = new OpenAIProvider();
+        await provider.complete({
+            model: 'gpt-5.4',
+            messages: [{ role: 'user', content: 'hi' }],
+        });
+
+        const [url, init] = mockedFetch.mock.calls[0];
+        expect(url).toBe('https://api.openai.com/v1/chat/completions');
+        expect((init!.headers as Record<string, string>).Authorization).toBe('Bearer sk-test');
+    });
+
+    it('rejects with auth error when no key is stored', async () => {
+        keyStore.clear('openai', 'apiKey');
+        const provider = new OpenAIProvider();
+        await expect(
+            provider.complete({ model: 'gpt-5.4', messages: [{ role: 'user', content: 'hi' }] })
+        ).rejects.toMatchObject({ kind: 'auth' });
+    });
+});
+
+describe('GeminiProvider', () => {
+    beforeEach(() => {
+        keyStore.set('gemini', 'apiKey', 'AIza-test');
+    });
+
+    it('uses the OpenAI-compatible Gemini endpoint with Bearer auth', async () => {
+        mockedFetch.mockResolvedValueOnce(
+            jsonResponse({
+                model: 'gemini-2.5-pro',
+                choices: [{ message: { content: 'hi' }, finish_reason: 'stop' }],
+            }) as never
+        );
+
+        const provider = new GeminiProvider();
+        await provider.complete({
+            model: 'gemini-2.5-pro',
+            messages: [{ role: 'user', content: 'hi' }],
+        });
+
+        const [url, init] = mockedFetch.mock.calls[0];
+        expect(url).toBe('https://generativelanguage.googleapis.com/v1beta/openai/chat/completions');
+        expect((init!.headers as Record<string, string>).Authorization).toBe('Bearer AIza-test');
+    });
+
+    it('reports not configured when key missing', async () => {
+        keyStore.clear('gemini', 'apiKey');
+        const provider = new GeminiProvider();
+        expect(await provider.isConfigured()).toBe(false);
+    });
+});

--- a/ClassNoteAI/src/services/llm/openai-compat.ts
+++ b/ClassNoteAI/src/services/llm/openai-compat.ts
@@ -1,0 +1,156 @@
+/**
+ * Shared request/response helpers for OpenAI Chat Completions-compatible
+ * endpoints: OpenAI Platform, GitHub Models, Google Gemini's OpenAI
+ * compat layer, Azure OpenAI, etc.
+ *
+ * Providers build the auth headers themselves, then hand off to these
+ * helpers for the wire-level work.
+ */
+
+import { fetch } from '@tauri-apps/plugin-http';
+import { parseSSE } from './sse';
+import { LLMError, LLMErrorKind, LLMRequest, LLMResponse, LLMStreamChunk } from './types';
+
+export interface OpenAICompatConfig {
+  endpoint: string;
+  headers: Record<string, string>;
+  providerId: string;
+  /** Some providers (Gemini) rename/strip fields; lets us rewrite the body at the edge. */
+  transformBody?: (body: Record<string, unknown>, request: LLMRequest) => Record<string, unknown>;
+}
+
+export function errorKindFromStatus(status: number): LLMErrorKind {
+  if (status === 401 || status === 403) return 'auth';
+  if (status === 429) return 'rate_limit';
+  if (status === 413 || status === 400) return 'context_length'; // heuristic; caller can override
+  if (status >= 500) return 'provider';
+  return 'unknown';
+}
+
+function buildBody(request: LLMRequest, stream: boolean): Record<string, unknown> {
+  const body: Record<string, unknown> = {
+    model: request.model,
+    messages: request.messages,
+    stream,
+  };
+  if (request.temperature !== undefined) body.temperature = request.temperature;
+  if (request.maxTokens !== undefined) body.max_tokens = request.maxTokens;
+  if (request.jsonMode) body.response_format = { type: 'json_object' };
+  return body;
+}
+
+export async function completeOpenAICompatible(
+  config: OpenAICompatConfig,
+  request: LLMRequest
+): Promise<LLMResponse> {
+  let body = buildBody(request, false);
+  if (config.transformBody) body = config.transformBody(body, request);
+
+  const res = await fetch(config.endpoint, {
+    method: 'POST',
+    headers: config.headers,
+    body: JSON.stringify(body),
+    signal: request.signal,
+  });
+
+  if (!res.ok) {
+    const errText = await res.text().catch(() => '');
+    throw new LLMError(
+      `HTTP ${res.status}: ${errText.slice(0, 200)}`,
+      errorKindFromStatus(res.status),
+      config.providerId
+    );
+  }
+
+  const data = await res.json();
+  const choice = data.choices?.[0];
+  return {
+    content: choice?.message?.content ?? '',
+    model: data.model ?? request.model,
+    finishReason: choice?.finish_reason,
+    usage: data.usage && {
+      inputTokens: data.usage.prompt_tokens ?? 0,
+      outputTokens: data.usage.completion_tokens ?? 0,
+    },
+  };
+}
+
+export async function* streamOpenAICompatible(
+  config: OpenAICompatConfig,
+  request: LLMRequest
+): AsyncIterable<LLMStreamChunk> {
+  let body = buildBody(request, true);
+  if (config.transformBody) body = config.transformBody(body, request);
+
+  const res = await fetch(config.endpoint, {
+    method: 'POST',
+    headers: config.headers,
+    body: JSON.stringify(body),
+    signal: request.signal,
+  });
+
+  if (!res.ok || !res.body) {
+    const errText = !res.ok ? await res.text().catch(() => '') : '';
+    throw new LLMError(
+      `HTTP ${res.status}: ${errText.slice(0, 200)}`,
+      errorKindFromStatus(res.status),
+      config.providerId
+    );
+  }
+
+  let lastUsage: LLMStreamChunk['usage'];
+  let lastFinish: LLMStreamChunk['finishReason'];
+
+  for await (const payload of parseSSE(res.body, request.signal)) {
+    let parsed: any;
+    try {
+      parsed = JSON.parse(payload);
+    } catch {
+      continue;
+    }
+    const choice = parsed.choices?.[0];
+    const delta = choice?.delta?.content ?? '';
+    if (choice?.finish_reason) lastFinish = choice.finish_reason;
+    if (parsed.usage) {
+      lastUsage = {
+        inputTokens: parsed.usage.prompt_tokens ?? 0,
+        outputTokens: parsed.usage.completion_tokens ?? 0,
+      };
+    }
+    if (delta) yield { delta, done: false };
+  }
+
+  yield { delta: '', done: true, usage: lastUsage, finishReason: lastFinish };
+}
+
+/** Smoke-test helper: posts the minimal legal request to check auth. */
+export async function smokeTestOpenAICompatible(
+  config: OpenAICompatConfig,
+  modelId: string
+): Promise<{ ok: boolean; message: string }> {
+  try {
+    let body: Record<string, unknown> = {
+      model: modelId,
+      messages: [{ role: 'user', content: 'ping' }],
+      max_tokens: 1,
+    };
+    if (config.transformBody) {
+      body = config.transformBody(body, {
+        model: modelId,
+        messages: [{ role: 'user', content: 'ping' }],
+        maxTokens: 1,
+      });
+    }
+
+    const res = await fetch(config.endpoint, {
+      method: 'POST',
+      headers: config.headers,
+      body: JSON.stringify(body),
+    });
+    if (res.ok) return { ok: true, message: `Authenticated against ${config.endpoint}` };
+    const errText = await res.text().catch(() => '');
+    return { ok: false, message: `HTTP ${res.status}: ${errText.slice(0, 200)}` };
+  } catch (err) {
+    return { ok: false, message: String(err) };
+  }
+}

--- a/ClassNoteAI/src/services/llm/providers/gemini.ts
+++ b/ClassNoteAI/src/services/llm/providers/gemini.ts
@@ -1,0 +1,85 @@
+/**
+ * Google Gemini provider.
+ *
+ * Uses Gemini's OpenAI-compatible endpoint so we can reuse the shared
+ * OpenAI-compat helpers. Auth is a Bearer API key obtained from AI
+ * Studio (aistudio.google.com). Pay-per-token; Gemini Advanced
+ * subscription (via Google One) does NOT grant API access.
+ */
+
+import { keyStore } from '../keyStore';
+import {
+  completeOpenAICompatible,
+  smokeTestOpenAICompatible,
+  streamOpenAICompatible,
+  type OpenAICompatConfig,
+} from '../openai-compat';
+import {
+  LLMError,
+  LLMModelInfo,
+  LLMProvider,
+  LLMProviderDescriptor,
+  LLMRequest,
+  LLMResponse,
+  LLMStreamChunk,
+  LLMTestResult,
+} from '../types';
+
+const PROVIDER_ID = 'gemini';
+const ENDPOINT = 'https://generativelanguage.googleapis.com/v1beta/openai/chat/completions';
+const AUTH_FIELD = 'apiKey';
+
+const CURATED_MODELS: LLMModelInfo[] = [
+  { id: 'gemini-2.5-pro', displayName: 'Gemini 2.5 Pro', contextWindow: 2_000_000, capabilities: { streaming: true, jsonMode: true, vision: true, audio: true } },
+  { id: 'gemini-2.5-flash', displayName: 'Gemini 2.5 Flash', contextWindow: 1_000_000, capabilities: { streaming: true, jsonMode: true, vision: true, audio: true } },
+  { id: 'gemini-2.0-flash', displayName: 'Gemini 2.0 Flash', contextWindow: 1_000_000, capabilities: { streaming: true, jsonMode: true, vision: true } },
+  { id: 'gemini-2.0-flash-lite', displayName: 'Gemini 2.0 Flash Lite', contextWindow: 1_000_000, capabilities: { streaming: true } },
+];
+
+export const geminiDescriptor: LLMProviderDescriptor = {
+  id: PROVIDER_ID,
+  displayName: 'Google Gemini (API key)',
+  authType: 'apiKey',
+  notes: 'API key from aistudio.google.com. Gemini Advanced / Google One subscriptions don\'t grant API access.',
+};
+
+export class GeminiProvider implements LLMProvider {
+  readonly descriptor = geminiDescriptor;
+
+  private config(): OpenAICompatConfig {
+    const key = keyStore.get(PROVIDER_ID, AUTH_FIELD);
+    if (!key) throw new LLMError('Gemini API key not configured', 'auth', PROVIDER_ID);
+    return {
+      endpoint: ENDPOINT,
+      providerId: PROVIDER_ID,
+      headers: {
+        Authorization: `Bearer ${key}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+    };
+  }
+
+  async isConfigured(): Promise<boolean> {
+    return keyStore.has(PROVIDER_ID, AUTH_FIELD);
+  }
+
+  async testConnection(): Promise<LLMTestResult> {
+    if (!keyStore.has(PROVIDER_ID, AUTH_FIELD)) {
+      return { ok: false, message: 'No API key saved.' };
+    }
+    return smokeTestOpenAICompatible(this.config(), CURATED_MODELS[0].id);
+  }
+
+  async listModels(): Promise<LLMModelInfo[]> {
+    return CURATED_MODELS;
+  }
+
+  async complete(request: LLMRequest): Promise<LLMResponse> {
+    return completeOpenAICompatible(this.config(), request);
+  }
+
+  async *stream(request: LLMRequest): AsyncIterable<LLMStreamChunk> {
+    yield* streamOpenAICompatible(this.config(), request);
+  }
+}

--- a/ClassNoteAI/src/services/llm/providers/github-models.ts
+++ b/ClassNoteAI/src/services/llm/providers/github-models.ts
@@ -1,20 +1,21 @@
 /**
  * GitHub Models provider.
  *
- * Uses the user's GitHub Personal Access Token (with `models:read` scope)
- * or a Copilot Pro/Business/Enterprise subscription to call the
- * OpenAI-compatible inference endpoint at https://models.github.ai.
+ * Uses the user's GitHub Personal Access Token (with `models:read` scope).
+ * Quota included with Copilot Pro/Business/Enterprise subscription.
  *
- * Model catalog is a curated subset — GitHub Models hosts dozens of
- * models but only a handful are useful for transcription refinement.
+ * Wire format is OpenAI-compatible, so we delegate to the shared helper.
  */
 
-import { fetch } from '@tauri-apps/plugin-http';
 import { keyStore } from '../keyStore';
-import { parseSSE } from '../sse';
+import {
+  completeOpenAICompatible,
+  smokeTestOpenAICompatible,
+  streamOpenAICompatible,
+  type OpenAICompatConfig,
+} from '../openai-compat';
 import {
   LLMError,
-  LLMErrorKind,
   LLMModelInfo,
   LLMProvider,
   LLMProviderDescriptor,
@@ -44,18 +45,21 @@ export const githubModelsDescriptor: LLMProviderDescriptor = {
   notes: 'Uses your GitHub PAT (scope: models:read). Quota included with Copilot Pro/Business/Enterprise subscription.',
 };
 
-function errorKindFromStatus(status: number): LLMErrorKind {
-  if (status === 401 || status === 403) return 'auth';
-  if (status === 429) return 'rate_limit';
-  if (status >= 500) return 'provider';
-  return 'unknown';
-}
-
 export class GitHubModelsProvider implements LLMProvider {
   readonly descriptor = githubModelsDescriptor;
 
-  private pat(): string | null {
-    return keyStore.get(PROVIDER_ID, AUTH_FIELD);
+  private config(): OpenAICompatConfig {
+    const pat = keyStore.get(PROVIDER_ID, AUTH_FIELD);
+    if (!pat) throw new LLMError('GitHub PAT not configured', 'auth', PROVIDER_ID);
+    return {
+      endpoint: ENDPOINT,
+      providerId: PROVIDER_ID,
+      headers: {
+        Authorization: `Bearer ${pat}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+    };
   }
 
   async isConfigured(): Promise<boolean> {
@@ -63,25 +67,10 @@ export class GitHubModelsProvider implements LLMProvider {
   }
 
   async testConnection(): Promise<LLMTestResult> {
-    const pat = this.pat();
-    if (!pat) return { ok: false, message: 'No PAT saved.' };
-
-    try {
-      const res = await fetch(ENDPOINT, {
-        method: 'POST',
-        headers: this.buildHeaders(pat),
-        body: JSON.stringify({
-          model: CURATED_MODELS[0].id,
-          messages: [{ role: 'user', content: 'ping' }],
-          max_tokens: 1,
-        }),
-      });
-      if (res.ok) return { ok: true, message: `Authenticated against ${ENDPOINT}` };
-      const body = await res.text();
-      return { ok: false, message: `HTTP ${res.status}: ${body.slice(0, 200)}` };
-    } catch (err) {
-      return { ok: false, message: String(err) };
+    if (!keyStore.has(PROVIDER_ID, AUTH_FIELD)) {
+      return { ok: false, message: 'No PAT saved.' };
     }
+    return smokeTestOpenAICompatible(this.config(), CURATED_MODELS[0].id);
   }
 
   async listModels(): Promise<LLMModelInfo[]> {
@@ -89,96 +78,10 @@ export class GitHubModelsProvider implements LLMProvider {
   }
 
   async complete(request: LLMRequest): Promise<LLMResponse> {
-    const pat = this.requirePat();
-    const res = await fetch(ENDPOINT, {
-      method: 'POST',
-      headers: this.buildHeaders(pat),
-      body: JSON.stringify(this.buildBody(request, false)),
-      signal: request.signal,
-    });
-
-    if (!res.ok) {
-      const body = await res.text().catch(() => '');
-      throw new LLMError(`HTTP ${res.status}: ${body.slice(0, 200)}`, errorKindFromStatus(res.status), PROVIDER_ID);
-    }
-
-    const data = await res.json();
-    const choice = data.choices?.[0];
-    return {
-      content: choice?.message?.content ?? '',
-      model: data.model ?? request.model,
-      finishReason: choice?.finish_reason,
-      usage: data.usage && {
-        inputTokens: data.usage.prompt_tokens ?? 0,
-        outputTokens: data.usage.completion_tokens ?? 0,
-      },
-    };
+    return completeOpenAICompatible(this.config(), request);
   }
 
   async *stream(request: LLMRequest): AsyncIterable<LLMStreamChunk> {
-    const pat = this.requirePat();
-    const res = await fetch(ENDPOINT, {
-      method: 'POST',
-      headers: this.buildHeaders(pat),
-      body: JSON.stringify(this.buildBody(request, true)),
-      signal: request.signal,
-    });
-
-    if (!res.ok || !res.body) {
-      const body = !res.ok ? await res.text().catch(() => '') : '';
-      throw new LLMError(`HTTP ${res.status}: ${body.slice(0, 200)}`, errorKindFromStatus(res.status), PROVIDER_ID);
-    }
-
-    let lastUsage: LLMStreamChunk['usage'];
-    let lastFinish: LLMStreamChunk['finishReason'];
-
-    for await (const payload of parseSSE(res.body, request.signal)) {
-      let parsed: any;
-      try {
-        parsed = JSON.parse(payload);
-      } catch {
-        continue;
-      }
-      const choice = parsed.choices?.[0];
-      const delta = choice?.delta?.content ?? '';
-      if (choice?.finish_reason) lastFinish = choice.finish_reason;
-      if (parsed.usage) {
-        lastUsage = {
-          inputTokens: parsed.usage.prompt_tokens ?? 0,
-          outputTokens: parsed.usage.completion_tokens ?? 0,
-        };
-      }
-      if (delta) yield { delta, done: false };
-    }
-
-    yield { delta: '', done: true, usage: lastUsage, finishReason: lastFinish };
-  }
-
-  // ---------- helpers ----------
-
-  private requirePat(): string {
-    const pat = this.pat();
-    if (!pat) throw new LLMError('GitHub PAT not configured', 'auth', PROVIDER_ID);
-    return pat;
-  }
-
-  private buildHeaders(pat: string): Record<string, string> {
-    return {
-      Authorization: `Bearer ${pat}`,
-      'Content-Type': 'application/json',
-      Accept: 'application/json',
-    };
-  }
-
-  private buildBody(request: LLMRequest, stream: boolean): Record<string, unknown> {
-    const body: Record<string, unknown> = {
-      model: request.model,
-      messages: request.messages,
-      stream,
-    };
-    if (request.temperature !== undefined) body.temperature = request.temperature;
-    if (request.maxTokens !== undefined) body.max_tokens = request.maxTokens;
-    if (request.jsonMode) body.response_format = { type: 'json_object' };
-    return body;
+    yield* streamOpenAICompatible(this.config(), request);
   }
 }

--- a/ClassNoteAI/src/services/llm/providers/openai.ts
+++ b/ClassNoteAI/src/services/llm/providers/openai.ts
@@ -1,0 +1,86 @@
+/**
+ * OpenAI Platform provider (direct API, pay-per-token).
+ *
+ * Not a subscription channel — ChatGPT Plus/Pro doesn't grant general API
+ * access. Users who want subscription-based access should use either the
+ * GitHubModels provider (via Copilot Pro) or the ChatGPTOAuth provider
+ * added in a later PR (unofficial channel).
+ */
+
+import { keyStore } from '../keyStore';
+import {
+  completeOpenAICompatible,
+  smokeTestOpenAICompatible,
+  streamOpenAICompatible,
+  type OpenAICompatConfig,
+} from '../openai-compat';
+import {
+  LLMError,
+  LLMModelInfo,
+  LLMProvider,
+  LLMProviderDescriptor,
+  LLMRequest,
+  LLMResponse,
+  LLMStreamChunk,
+  LLMTestResult,
+} from '../types';
+
+const PROVIDER_ID = 'openai';
+const ENDPOINT = 'https://api.openai.com/v1/chat/completions';
+const AUTH_FIELD = 'apiKey';
+
+const CURATED_MODELS: LLMModelInfo[] = [
+  { id: 'gpt-5.4', displayName: 'GPT-5.4', contextWindow: 272_000, capabilities: { streaming: true, jsonMode: true, vision: true, audio: true } },
+  { id: 'gpt-5.4-mini', displayName: 'GPT-5.4 mini', contextWindow: 272_000, capabilities: { streaming: true, jsonMode: true, vision: true } },
+  { id: 'gpt-5.4-nano', displayName: 'GPT-5.4 nano', contextWindow: 272_000, capabilities: { streaming: true, jsonMode: true } },
+  { id: 'o3', displayName: 'o3 (reasoning)', contextWindow: 200_000, capabilities: { streaming: true, jsonMode: true } },
+  { id: 'o3-mini', displayName: 'o3 mini (reasoning)', contextWindow: 200_000, capabilities: { streaming: true, jsonMode: true } },
+];
+
+export const openaiDescriptor: LLMProviderDescriptor = {
+  id: PROVIDER_ID,
+  displayName: 'OpenAI Platform (API key)',
+  authType: 'apiKey',
+  notes: 'Pay-per-token API billing. Separate from any ChatGPT Plus/Pro subscription — those don\'t grant API access.',
+};
+
+export class OpenAIProvider implements LLMProvider {
+  readonly descriptor = openaiDescriptor;
+
+  private config(): OpenAICompatConfig {
+    const key = keyStore.get(PROVIDER_ID, AUTH_FIELD);
+    if (!key) throw new LLMError('OpenAI API key not configured', 'auth', PROVIDER_ID);
+    return {
+      endpoint: ENDPOINT,
+      providerId: PROVIDER_ID,
+      headers: {
+        Authorization: `Bearer ${key}`,
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+    };
+  }
+
+  async isConfigured(): Promise<boolean> {
+    return keyStore.has(PROVIDER_ID, AUTH_FIELD);
+  }
+
+  async testConnection(): Promise<LLMTestResult> {
+    if (!keyStore.has(PROVIDER_ID, AUTH_FIELD)) {
+      return { ok: false, message: 'No API key saved.' };
+    }
+    return smokeTestOpenAICompatible(this.config(), CURATED_MODELS[0].id);
+  }
+
+  async listModels(): Promise<LLMModelInfo[]> {
+    return CURATED_MODELS;
+  }
+
+  async complete(request: LLMRequest): Promise<LLMResponse> {
+    return completeOpenAICompatible(this.config(), request);
+  }
+
+  async *stream(request: LLMRequest): AsyncIterable<LLMStreamChunk> {
+    yield* streamOpenAICompatible(this.config(), request);
+  }
+}

--- a/ClassNoteAI/src/services/llm/registry.ts
+++ b/ClassNoteAI/src/services/llm/registry.ts
@@ -8,12 +8,16 @@
  */
 
 import { AnthropicProvider } from './providers/anthropic';
+import { GeminiProvider } from './providers/gemini';
 import { GitHubModelsProvider } from './providers/github-models';
+import { OpenAIProvider } from './providers/openai';
 import { LLMProvider, LLMProviderDescriptor } from './types';
 
 const PROVIDERS: Record<string, () => LLMProvider> = {
   'github-models': () => new GitHubModelsProvider(),
   anthropic: () => new AnthropicProvider(),
+  openai: () => new OpenAIProvider(),
+  gemini: () => new GeminiProvider(),
 };
 
 /** Cached instances so provider state (e.g. cached tokens) sticks around. */


### PR DESCRIPTION
## Summary

Third of four v0.5.0 PRs. Builds on PR #10's LLMProvider foundation.

- **Refactor**: extract OpenAI-compatible request/response/streaming logic into `openai-compat.ts`. GitHubModels, OpenAI Platform, and Gemini all delegate to it.
- **OpenAI Platform** provider: direct pay-per-token API. Descriptor explicitly calls out that ChatGPT Plus/Pro subscriptions do NOT grant API access — for subscription access, users should use GitHubModels (Copilot Pro) or the ChatGPT OAuth provider in PR B3.
- **Google Gemini** provider: uses Gemini's OpenAI-compatible endpoint — drop-in with the same auth style.
- **Settings UI** (`AIProviderSettings.tsx`): per-provider card with masked input, show/hide, save + smoke-test. Default-provider dropdown. Wired into the existing "AI 增強" tab in SettingsView as a new card above the Ollama section.
- **4 new tests** — total LLM test count 23.

## Screenshots (conceptual)

Under Settings → AI 增強:
```
┌─ 雲端 AI Providers ─────────────────────────────────┐
│ Default provider: [ GitHub Models ▾ ]               │
│                                                     │
│ ◻ GitHub Models  [ configured ]                     │
│   Uses your GitHub PAT (scope: models:read)...      │
│   [••••••••] [👁] [Save] [Test]  Generate PAT →     │
│   ✓ Authenticated against https://...               │
│                                                     │
│ ◻ Anthropic (direct API)                            │
│   [••••••••] [👁] [Save] [Test]  Get API key →      │
│                                                     │
│ ◻ OpenAI Platform (API key)                         │
│ ◻ Google Gemini (API key)                           │
└─────────────────────────────────────────────────────┘
```

## Deferred

- Azure OpenAI provider (trivial follow-up on top of openai-compat).
- Credential encryption / OS keychain (localStorage is fine for the Tauri single-user threat model).
- Wiring translation / summary / Q&A callers to the configured provider — PR C (server-task migration) and PR D (ASR + fine pipeline).

## Test plan

- [x] `tsc --noEmit` clean
- [x] 23 vitest tests pass locally
- [ ] CI: `build-windows` and `build-macos` green
- [ ] Manual: open the app, go to Settings → AI 增強, paste a real Copilot PAT, click Test, see "Authenticated against..."

🤖 Generated with [Claude Code](https://claude.com/claude-code)