### PR TITLE
feat(llm): route summary/syllabus/keyword/chat through LLMProvider (C1)

### DIFF
--- a/ClassNoteAI/src/components/AIChatPanel.tsx
+++ b/ClassNoteAI/src/components/AIChatPanel.tsx
@@ -4,6 +4,7 @@ import ReactMarkdown from 'react-markdown';
 import { ollamaService } from '../services/ollamaService';
 import { ragService, IndexingProgress } from '../services/ragService';
 import { chatSessionService, ChatSession, ChatMessage } from '../services/chatSessionService';
+import { chat as llmChat } from '../services/llm';
 
 // 重新導出 ChatMessage 類型供其他組件使用
 export type { ChatMessage } from '../services/chatSessionService';
@@ -295,12 +296,14 @@ export default function AIChatPanel({
                     }
                 }
 
-                // 使用對話式 API (標準模型)
-                const standardModel = await ollamaService.getStandardModel();
-                const response = await ollamaService.chat(
-                    chatHistory as Array<{ role: 'user' | 'assistant' | 'system'; content: string }>,
-                    { system: systemPrompt, model: standardModel }
-                );
+                // Route Q&A through the user's configured LLM provider
+                const response = await llmChat([
+                    { role: 'system', content: systemPrompt },
+                    ...chatHistory.map((m: { role: string; content: string }) => ({
+                        role: m.role as 'user' | 'assistant' | 'system',
+                        content: m.content,
+                    })),
+                ]);
 
                 assistantMessage = {
                     id: crypto.randomUUID(),

--- a/ClassNoteAI/src/components/CourseCreationDialog.tsx
+++ b/ClassNoteAI/src/components/CourseCreationDialog.tsx
@@ -2,7 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import { X, BookOpen, FileText, Cpu, Loader2 } from "lucide-react";
 import { selectPDFFile } from "../services/fileService";
 import { pdfService } from "../services/pdfService";
-import { taskService } from "../services/taskService";
+import { extractKeywords as llmExtractKeywords } from "../services/llm";
 
 interface CourseCreationDialogProps {
   isOpen: boolean;
@@ -109,37 +109,19 @@ export default function CourseCreationDialog({
         throw new Error("無法保存課程草稿，無法啟動後台任務");
       }
 
-      // 4. Trigger Server Task
-      const task = await taskService.triggerKeywordExtract(courseId, text);
+      // 4. Extract keywords via the user's configured LLM provider
+      llmExtractKeywords(text)
+        .then((extracted) => {
+          setKeywords((prev) => {
+            const current = prev ? prev.split(',').map((k) => k.trim()).filter(Boolean) : [];
+            const merged = [...new Set([...current, ...extracted])];
+            return merged.join(', ');
+          });
+        })
+        .catch((err) => console.error('Keyword extraction failed:', err))
+        .finally(() => setIsGeneratingKeywords(false));
 
-      if (task) {
-        // 5. Non-blocking Wait
-        // We start a detached promise to poll for results
-        taskService.pollUntilCompletion(task.id)
-          .then((result) => {
-            if (result.status === 'completed' && result.result?.keywords) {
-              const extracted = result.result.keywords as string[];
-              console.log('[CourseCreationDialog] Keywords generated:', extracted);
-
-              // Update Local State (if component still mounted)
-              // Note: accessing state from async closure is fine, usually.
-              setKeywords(prev => {
-                const current = prev ? prev.split(',').map(k => k.trim()).filter(Boolean) : [];
-                const merged = [...new Set([...current, ...extracted])];
-                return merged.join(', ');
-              });
-            }
-          })
-          .catch(err => console.error("Background keyword task failed:", err))
-          .finally(() => setIsGeneratingKeywords(false));
-
-        // Notify User
-        alert("關鍵詞生成任務已在後台啟動！\n您可以繼續編輯或關閉此視窗，完成後關鍵詞將自動填入。");
-      } else {
-        // Offline queue
-        alert("已離線，任務已加入佇列。恢復連線後將自動執行。");
-        setIsGeneratingKeywords(false);
-      }
+      alert('關鍵詞生成已在後台啟動！完成後會自動填入。');
 
     } catch (error) {
       console.error("生成關鍵詞失敗:", error);

--- a/ClassNoteAI/src/components/CourseDetailView.tsx
+++ b/ClassNoteAI/src/components/CourseDetailView.tsx
@@ -19,7 +19,7 @@ import {
 } from 'lucide-react';
 import { Course, Lecture } from '../types';
 import { storageService } from '../services/storageService';
-import { ollamaService } from '../services/ollamaService';
+import { extractSyllabus as llmExtractSyllabus } from '../services/llm';
 import { syncService } from '../services/syncService';
 import { taskService } from '../services/taskService';
 import CourseCreationDialog from './CourseCreationDialog';
@@ -170,14 +170,14 @@ const CourseDetailView: React.FC<CourseDetailViewProps> = ({
             const descriptionChanged = description !== course.description;
 
             if (descriptionChanged && description && description.trim().length > 50) {
-                // 如果有足夠長的描述，嘗試提取結構化信息
-                console.log('[CourseDetailView] Extracting syllabus info...');
-                const extracted = await ollamaService.extractSyllabusInfo(description);
-                console.log('[CourseDetailView] Extracted syllabus info:', extracted);
-
-                // Only use if extraction was successful (has keys)
-                if (extracted && Object.keys(extracted).length > 0) {
-                    syllabusInfo = extracted;
+                // 嘗試透過 LLM 提取結構化資訊
+                try {
+                    const extracted = await llmExtractSyllabus(course.title, description, 'zh');
+                    if (extracted && Object.keys(extracted).length > 0) {
+                        syllabusInfo = extracted;
+                    }
+                } catch (e) {
+                    console.warn('[CourseDetailView] Syllabus extraction skipped:', e);
                 }
             }
 

--- a/ClassNoteAI/src/components/CourseListView.tsx
+++ b/ClassNoteAI/src/components/CourseListView.tsx
@@ -14,7 +14,7 @@ import {
 import { Course } from '../types';
 import { storageService } from '../services/storageService';
 import CourseCreationDialog from './CourseCreationDialog';
-import { taskService } from '../services/taskService';
+import { extractSyllabus as llmExtractSyllabus } from '../services/llm';
 
 interface CourseListViewProps {
     onSelectCourse: (courseId: string) => void;
@@ -75,15 +75,15 @@ const CourseListView: React.FC<CourseListViewProps> = ({ onSelectCourse }) => {
                 };
                 await storageService.saveCourse(updatedCourse);
 
-                // Trigger Async Syllabus Update if description changed
+                // Trigger async syllabus extraction via LLM if description changed
                 if (descriptionChanged && description && description.trim().length > 10) {
-                    // Non-blocking: Fetch settings then trigger task
-                    storageService.getAppSettings().then(settings => {
-                        const targetLang = settings?.translation?.target_language || 'zh-TW';
-                        return taskService.triggerSyllabus(editingCourse.id, title, description, targetLang);
-                    })
-                        .then(() => console.log('[CourseListView] Syllabus task triggered'))
-                        .catch(err => console.error('[CourseListView] Failed to trigger syllabus task:', err));
+                    storageService.getAppSettings().then(async (settings) => {
+                        const targetLang = settings?.translation?.target_language?.startsWith('en') ? 'en' : 'zh';
+                        const syllabus = await llmExtractSyllabus(title, description, targetLang);
+                        if (syllabus && Object.keys(syllabus).length > 0) {
+                            await storageService.saveCourse({ ...updatedCourse, syllabus_info: syllabus });
+                        }
+                    }).catch(err => console.error('[CourseListView] Syllabus extraction failed:', err));
                 }
 
             } else {
@@ -102,13 +102,16 @@ const CourseListView: React.FC<CourseListViewProps> = ({ onSelectCourse }) => {
                 await storageService.saveCourse(newCourse);
 
                 if (description && description.trim().length > 10) {
-                    // Non-blocking: Fetch settings then trigger task
-                    storageService.getAppSettings().then(settings => {
-                        const targetLang = settings?.translation?.target_language || 'zh-TW';
-                        return taskService.triggerSyllabus(newCourseId, title, description, targetLang);
-                    })
-                        .then(() => console.log('[CourseListView] Syllabus task triggered'))
-                        .catch(err => console.error('[CourseListView] Failed to trigger syllabus task:', err));
+                    storageService.getAppSettings().then(async (settings) => {
+                        const targetLang = settings?.translation?.target_language?.startsWith('en') ? 'en' : 'zh';
+                        const syllabus = await llmExtractSyllabus(title, description, targetLang);
+                        if (syllabus && Object.keys(syllabus).length > 0) {
+                            const refreshed = await storageService.getCourse(newCourseId);
+                            if (refreshed) {
+                                await storageService.saveCourse({ ...refreshed, syllabus_info: syllabus });
+                            }
+                        }
+                    }).catch(err => console.error('[CourseListView] Syllabus extraction failed:', err));
                 }
 
                 // Return ID for auto-save use cases

--- a/ClassNoteAI/src/components/NotesView.tsx
+++ b/ClassNoteAI/src/components/NotesView.tsx
@@ -10,6 +10,7 @@ import rehypeRaw from 'rehype-raw';
 import { storageService } from "../services/storageService";
 import { ollamaService } from "../services/ollamaService";
 import { taskService } from "../services/taskService";
+import { summarize as llmSummarize } from "../services/llm";
 import { Lecture, Note, RecordingStatus } from "../types";
 import CourseCreationDialog from "./CourseCreationDialog";
 import { AudioRecorder } from "../services/audioRecorder";
@@ -1057,29 +1058,18 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
         console.warn('[NotesView] Pre-task sync failed, task might fail if lecture is missing on server:', e);
       }
 
-      // Trigger generation on server
-      const task = await taskService.triggerSummary(currentLectureData.id, language, content, pdfContext);
+      // Generate summary via the user's configured LLM provider
+      const summary = await llmSummarize({
+        content,
+        language,
+        pdfContext,
+        title: selectedNote.title,
+      });
 
-      if (!task) {
-        alert("已離線，任務已加入佇列。");
-        setIsGeneratingSummary(false);
-        return;
-      }
-
-      console.log('[NotesView] Summary task started:', task.id);
-
-      // Poll for result
-      const completedTask = await taskService.pollUntilCompletion(task.id);
-
-      if (completedTask.status === 'completed' && completedTask.result) {
-        const summary = completedTask.result.summary;
-        const updatedNote = { ...selectedNote, summary };
-        await storageService.saveNote(updatedNote);
-        setSelectedNote(updatedNote);
-        alert('Summary generated successfully!');
-      } else {
-        throw new Error(completedTask.error || 'Task completed via unknown status');
-      }
+      const updatedNote = { ...selectedNote, summary };
+      await storageService.saveNote(updatedNote);
+      setSelectedNote(updatedNote);
+      alert('Summary generated successfully!');
 
     } catch (error) {
       console.error('Failed to generate summary:', error);

--- a/ClassNoteAI/src/services/llm/index.ts
+++ b/ClassNoteAI/src/services/llm/index.ts
@@ -1,3 +1,12 @@
 export * from './types';
 export { keyStore } from './keyStore';
 export { listProviders, getProvider, resolveActiveProvider } from './registry';
+export {
+  summarize,
+  extractKeywords,
+  extractSyllabus,
+  chat,
+  chatStream,
+  type SummarizeParams,
+  type SyllabusInfo,
+} from './tasks';

--- a/ClassNoteAI/src/services/llm/tasks.ts
+++ b/ClassNoteAI/src/services/llm/tasks.ts
@@ -1,0 +1,176 @@
+/**
+ * High-level LLM tasks used across the app: summarisation, syllabus
+ * extraction, keyword extraction, Q&A chat. Everything routes through
+ * `resolveActiveProvider()` so the user's configured provider
+ * (GitHub Models, ChatGPT OAuth, Anthropic, OpenAI, Gemini) transparently
+ * powers all of them.
+ *
+ * Replaces the pre-v0.5.0 taskService + ClassNoteServer round-trip.
+ */
+
+import { resolveActiveProvider } from './registry';
+import type { LLMMessage } from './types';
+import { LLMError } from './types';
+
+const DEFAULT_PROVIDER_KEY = 'llm.defaultProvider';
+
+function preferredProvider(): string | undefined {
+  return localStorage.getItem(DEFAULT_PROVIDER_KEY) || undefined;
+}
+
+/** Resolve the active provider + default model, or throw a friendly error. */
+async function activeProviderAndModel(): Promise<{ providerId: string; model: string; provider: Awaited<ReturnType<typeof resolveActiveProvider>> }> {
+  const provider = await resolveActiveProvider(preferredProvider());
+  if (!provider) {
+    throw new LLMError(
+      'No AI provider configured. Open Settings → AI 增強 to set one up.',
+      'auth'
+    );
+  }
+  const models = await provider.listModels();
+  if (!models.length) {
+    throw new LLMError('Active provider returned no models.', 'provider', provider.descriptor.id);
+  }
+  return { providerId: provider.descriptor.id, model: models[0].id, provider };
+}
+
+export interface SummarizeParams {
+  content: string;
+  language: 'zh' | 'en';
+  pdfContext?: string;
+  title?: string;
+  /** Optional override of the model id exposed by the provider. */
+  model?: string;
+}
+
+export async function summarize(params: SummarizeParams): Promise<string> {
+  const { provider, model: defaultModel } = await activeProviderAndModel();
+  const model = params.model ?? defaultModel;
+
+  const languageLine =
+    params.language === 'zh'
+      ? '以繁體中文輸出。使用 Markdown（# 標題、項目符號、程式碼區塊）。'
+      : 'Respond in English. Use Markdown (# headings, bullet points, code fences).';
+
+  const messages: LLMMessage[] = [
+    {
+      role: 'system',
+      content: `You are a teaching assistant that produces high-quality study notes from a lecture transcript. ${languageLine}\nSections to include: overview, key concepts, worked examples, questions to review. Skip fluff.`,
+    },
+  ];
+  if (params.pdfContext) {
+    messages.push({
+      role: 'user',
+      content: `Slides / PDF excerpts for context:\n\n${params.pdfContext}`,
+    });
+  }
+  messages.push({
+    role: 'user',
+    content: `Lecture transcript${params.title ? ` (${params.title})` : ''}:\n\n${params.content}`,
+  });
+
+  const res = await provider!.complete({
+    model,
+    messages,
+    temperature: 0.3,
+    maxTokens: 4096,
+  });
+  return res.content;
+}
+
+export async function extractKeywords(text: string, max = 20): Promise<string[]> {
+  const { provider, model } = await activeProviderAndModel();
+  const res = await provider!.complete({
+    model,
+    messages: [
+      {
+        role: 'system',
+        content: `Extract up to ${max} unique technical keywords or named entities from the user's text. Output JSON only: {"keywords": ["term1", "term2", ...]}. No commentary.`,
+      },
+      { role: 'user', content: text },
+    ],
+    temperature: 0,
+    jsonMode: true,
+    maxTokens: 1024,
+  });
+  try {
+    const parsed = JSON.parse(res.content);
+    if (Array.isArray(parsed?.keywords)) {
+      return parsed.keywords.filter((k: unknown): k is string => typeof k === 'string');
+    }
+  } catch {
+    // fall through
+  }
+  // Fallback: naive line-split in case the model ignored jsonMode.
+  return res.content
+    .split(/[\n,]/)
+    .map((s) => s.replace(/^[-*\d.]+\s*/, '').trim())
+    .filter(Boolean)
+    .slice(0, max);
+}
+
+export interface SyllabusInfo {
+  topic?: string;
+  time?: string;
+  instructor?: string;
+  office_hours?: string;
+  teaching_assistants?: string;
+  location?: string;
+  grading?: { item: string; percentage: string }[];
+  schedule?: string[];
+}
+
+export async function extractSyllabus(
+  title: string,
+  description: string | undefined,
+  targetLanguage: 'zh' | 'en' = 'zh'
+): Promise<SyllabusInfo> {
+  const { provider, model } = await activeProviderAndModel();
+  const sys =
+    targetLanguage === 'zh'
+      ? '從使用者提供的課程描述中抽取結構化資訊並回傳 JSON。欄位：topic, time, instructor, office_hours, teaching_assistants, location, grading（陣列，每項 {item, percentage}）, schedule（陣列，每項為一週進度字串）。找不到的欄位省略。'
+      : 'Extract structured syllabus info from the user\'s course description. Return JSON with fields: topic, time, instructor, office_hours, teaching_assistants, location, grading (array of {item, percentage}), schedule (array of week strings). Omit fields you can\'t determine.';
+
+  const res = await provider!.complete({
+    model,
+    messages: [
+      { role: 'system', content: sys },
+      {
+        role: 'user',
+        content: `Course title: ${title}\n\n${description ?? '(no additional description provided)'}`,
+      },
+    ],
+    temperature: 0.1,
+    jsonMode: true,
+    maxTokens: 2048,
+  });
+  try {
+    return JSON.parse(res.content) as SyllabusInfo;
+  } catch {
+    return {};
+  }
+}
+
+export async function chat(messages: LLMMessage[]): Promise<string> {
+  const { provider, model } = await activeProviderAndModel();
+  const res = await provider!.complete({
+    model,
+    messages,
+    temperature: 0.3,
+    maxTokens: 2048,
+  });
+  return res.content;
+}
+
+/** Stream a chat response token-by-token. Caller receives incremental deltas. */
+export async function* chatStream(messages: LLMMessage[]): AsyncGenerator<string, void, void> {
+  const { provider, model } = await activeProviderAndModel();
+  for await (const chunk of provider!.stream({
+    model,
+    messages,
+    temperature: 0.3,
+    maxTokens: 2048,
+  })) {
+    if (chunk.delta) yield chunk.delta;
+  }
+}


### PR DESCRIPTION
## Summary

Part 1 of the server-task migration for v0.5.0 (original PR C split into C1/C2/C3 for easier review). Replaces the ClassNoteServer RPC paths (which were broken when the server was archived in PR #9) with direct `LLMProvider` calls. Summary, syllabus extraction, keyword extraction, and Q&A chat now run against whichever provider the user configured in Settings → AI 增強.

## Added

- **`src/services/llm/tasks.ts`**: high-level wrappers over `resolveActiveProvider()` — `summarize`, `extractKeywords`, `extractSyllabus`, `chat`, `chatStream`. Each uses the provider's first listed model; errors surface a friendly "Open Settings → AI 增強…" message if nothing is configured.

## Migrated callers

- **NotesView** → summarise via `llmSummarize()`
- **AIChatPanel** → Q&A via `llmChat()`
- **CourseCreationDialog** → keyword extraction via `llmExtractKeywords()`
- **CourseListView** → syllabus extraction via `llmExtractSyllabus()` (persists directly; no task polling)
- **CourseDetailView** → same syllabus path

## Deferred

- **PR C2**: embeddings localStorage → SQLite (local Candle).
- **PR C3**: delete `ollamaService`, `taskService`, and the Ollama section of SettingsView.

Leaving those in place means this PR is purely additive on the call-site and the app continues to compile with both old and new paths available.

## Test plan

- [x] `tsc --noEmit` clean
- [x] 121 vitest tests pass locally
- [ ] CI: build-windows + build-macos green
- [ ] Manual (post-merge): configure a provider in Settings, generate a lecture summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)