### PR TITLE
feat(asr): Whisper large-v3-turbo + LLM-backed fine translation (D)

### DIFF
--- a/ClassNoteAI/src-tauri/src/lib.rs
+++ b/ClassNoteAI/src-tauri/src/lib.rs
@@ -129,7 +129,8 @@ async fn download_whisper_model(
         "large" => download::get_large_model_config(output_path),
         "small-q5" => download::get_small_quantized_model_config(output_path),
         "medium-q5" => download::get_medium_quantized_model_config(output_path),
-        _ => return Err(format!("不支持的模型類型: {}。支持的類型: tiny, base, small, medium, large, small-q5, medium-q5", model_type)),
+        "large-v3-turbo-q5" => download::get_large_v3_turbo_quantized_model_config(output_path),
+        _ => return Err(format!("不支持的模型類型: {}。支持的類型: tiny, base, small, medium, large, small-q5, medium-q5, large-v3-turbo-q5", model_type)),
     };
 
     // 下載模型（通過 Tauri 事件發送進度）
@@ -237,6 +238,8 @@ async fn check_whisper_model(model_path: String) -> Result<bool, String> {
             Some(75_000_000) // Tiny 約 75MB
         } else if file_name.contains("base") {
             Some(142_000_000) // Base 約 142MB（實際約 141MB）
+        } else if file_name.contains("large-v3-turbo-q5") {
+            Some(574_000_000) // Large v3 turbo Q5 ~574MB
         } else if file_name.contains("small-q5") {
             Some(180_000_000) // Small Q5 約 180MB
         } else if file_name.contains("small") {

--- a/ClassNoteAI/src-tauri/src/whisper/download.rs
+++ b/ClassNoteAI/src-tauri/src/whisper/download.rs
@@ -88,6 +88,20 @@ pub fn get_medium_quantized_model_config(output_dir: &Path) -> ModelDownloadConf
     }
 }
 
+/// Whisper large-v3-turbo (Quantized q5_0) model download config.
+///
+/// New in v0.5.0. Turbo is ~8x faster than large-v3 at essentially the
+/// same accuracy, so this is the recommended option for users who want
+/// better-than-small accuracy without paying the full large-v3 cost.
+pub fn get_large_v3_turbo_quantized_model_config(output_dir: &Path) -> ModelDownloadConfig {
+    ModelDownloadConfig {
+        url: "https://huggingface.co/ggerganov/whisper.cpp/resolve/main/ggml-large-v3-turbo-q5_0.bin"
+            .to_string(),
+        output_path: output_dir.join("ggml-large-v3-turbo-q5_0.bin"),
+        expected_size: Some(574_000_000), // ~574 MB
+    }
+}
+
 /// 下載進度信息
 #[derive(Clone, serde::Serialize)]
 pub struct DownloadProgress {

--- a/ClassNoteAI/src/components/WhisperModelManager.tsx
+++ b/ClassNoteAI/src/components/WhisperModelManager.tsx
@@ -263,6 +263,7 @@ export default function WhisperModelManager({ onModelLoaded }: WhisperModelManag
           <option value="base">Base (142MB) - 推薦，平衡速度和準確度</option>
           <option value="small-q5">Small Quantized (180MB) - 🚀 推薦 (快且準)</option>
           <option value="medium-q5">Medium Quantized (530MB) - 🎯 最佳平衡</option>
+          <option value="large-v3-turbo-q5">Large-v3 Turbo Quantized (574MB) - ⭐ 最佳精度（v0.5.0 新增）</option>
           <option value="small">Small (466MB) - 更準確，較慢</option>
           <option value="medium">Medium (1.5GB) - 高準確度，較慢</option>
           <option value="large">Large (2.9GB) - 最高準確度，很慢</option>

--- a/ClassNoteAI/src/services/llm/index.ts
+++ b/ClassNoteAI/src/services/llm/index.ts
@@ -7,6 +7,9 @@ export {
   extractSyllabus,
   chat,
   chatStream,
+  refineTranscripts,
   type SummarizeParams,
   type SyllabusInfo,
+  type RoughSegment,
+  type FineRefinement,
 } from './tasks';

--- a/ClassNoteAI/src/services/llm/tasks.ts
+++ b/ClassNoteAI/src/services/llm/tasks.ts
@@ -162,6 +162,67 @@ export async function chat(messages: LLMMessage[]): Promise<string> {
   return res.content;
 }
 
+/**
+ * Fine-refinement of streaming ASR segments.
+ *
+ * Input: a batch of rough English transcription segments (as emitted by
+ * whisper.cpp) with stable ids. The LLM uses the surrounding context
+ * to (a) fix plausible ASR errors, and (b) produce a natural Chinese
+ * translation for each segment.
+ *
+ * Output preserves 1:1 ordering with input — one refinement per input id.
+ * On parse failure we return an empty array so the caller falls back to
+ * the rough pass.
+ */
+export interface RoughSegment {
+  id: string;
+  text: string;
+}
+
+export interface FineRefinement {
+  id: string;
+  en: string;
+  zh: string;
+}
+
+export async function refineTranscripts(batch: RoughSegment[]): Promise<FineRefinement[]> {
+  if (!batch.length) return [];
+  const { provider, model } = await activeProviderAndModel();
+
+  const numbered = batch.map((s, i) => `[${i + 1} id=${s.id}] ${s.text}`).join('\n');
+  const systemPrompt =
+    '你正在精修即時語音辨識的輸出。使用者會貼上若干條「粗糙」英文段落，它們可能有辨識錯誤或不自然的斷句。' +
+    '你的任務是：\n' +
+    '(1) 用語意上下文修正 ASR 錯誤（保留原意，不臆測未說出的內容）；\n' +
+    '(2) 產出自然流暢的繁體中文翻譯。\n' +
+    '必須回傳 JSON：{"refinements": [{"id": "<原 id>", "en": "<修正後英文>", "zh": "<翻譯>"} ...]}。\n' +
+    '一條輸入對應一條輸出，順序與 id 必須與輸入一致。不要加額外說明。';
+
+  const res = await provider!.complete({
+    model,
+    messages: [
+      { role: 'system', content: systemPrompt },
+      { role: 'user', content: numbered },
+    ],
+    temperature: 0.2,
+    jsonMode: true,
+    maxTokens: Math.min(8192, 512 * batch.length),
+  });
+
+  try {
+    const parsed = JSON.parse(res.content);
+    if (Array.isArray(parsed?.refinements)) {
+      return parsed.refinements.filter(
+        (r: any): r is FineRefinement =>
+          r && typeof r.id === 'string' && typeof r.en === 'string' && typeof r.zh === 'string'
+      );
+    }
+  } catch {
+    // fall through
+  }
+  return [];
+}
+
 /** Stream a chat response token-by-token. Caller receives incremental deltas. */
 export async function* chatStream(messages: LLMMessage[]): AsyncGenerator<string, void, void> {
   const { provider, model } = await activeProviderAndModel();

--- a/ClassNoteAI/src/services/transcriptionService.ts
+++ b/ClassNoteAI/src/services/transcriptionService.ts
@@ -51,6 +51,14 @@ export class TranscriptionService {
   private saveInterval: ReturnType<typeof setInterval> | null = null;
   private pendingSubtitles: PendingSubtitle[] = [];
 
+  // Fine-translation batch queue (v0.5.0). Every N committed rough
+  // segments (or after a short debounce) we send the batch to the
+  // configured LLM provider for contextual refinement + translation.
+  private fineQueue: Array<{ id: string; text: string }> = [];
+  private fineFlushTimer: ReturnType<typeof setTimeout> | null = null;
+  private static readonly FINE_BATCH_SIZE = 8;
+  private static readonly FINE_DEBOUNCE_MS = 20_000;
+
   constructor() {
     // 綁定方法以避免 this 丟失
     this.checkAndTranscribe = this.checkAndTranscribe.bind(this);
@@ -87,7 +95,9 @@ export class TranscriptionService {
       clearInterval(this.saveInterval);
       this.saveInterval = null;
     }
-    this.savePendingSubtitles();
+    // Fire one last fine-refinement flush so trailing segments also get
+    // the LLM pass before we persist them.
+    void this.flushFineRefinement().finally(() => this.savePendingSubtitles());
   }
 
   private async savePendingSubtitles(): Promise<void> {
@@ -531,8 +541,68 @@ export class TranscriptionService {
       // 翻譯失敗時，字幕已經在隊列中（沒有翻譯），無需額外處理
     }
 
-    // Fine translation hook removed in v0.5.0 — will be re-implemented
-    // via LLMProvider batched calls in a follow-up PR.
+    // Queue this segment for LLM-backed fine refinement (batched).
+    this.enqueueFineRefinement(id, text);
+  }
+
+  /**
+   * Fine-translation batching. Accumulates rough segments and flushes
+   * either when FINE_BATCH_SIZE is reached or after FINE_DEBOUNCE_MS of
+   * inactivity. Each flush asks the user's configured LLM provider to
+   * correct ASR errors and produce a natural Chinese translation in one
+   * shot, which we then apply to both the UI and the pending-subtitle
+   * persistence queue.
+   */
+  private enqueueFineRefinement(id: string, text: string): void {
+    this.fineQueue.push({ id, text });
+    if (this.fineQueue.length >= TranscriptionService.FINE_BATCH_SIZE) {
+      void this.flushFineRefinement();
+      return;
+    }
+    if (this.fineFlushTimer) clearTimeout(this.fineFlushTimer);
+    this.fineFlushTimer = setTimeout(
+      () => void this.flushFineRefinement(),
+      TranscriptionService.FINE_DEBOUNCE_MS
+    );
+  }
+
+  private async flushFineRefinement(): Promise<void> {
+    if (this.fineFlushTimer) {
+      clearTimeout(this.fineFlushTimer);
+      this.fineFlushTimer = null;
+    }
+    if (!this.fineQueue.length) return;
+    const batch = this.fineQueue.splice(0, this.fineQueue.length);
+
+    try {
+      const { refineTranscripts } = await import('./llm');
+      const refinements = await refineTranscripts(batch);
+      if (!refinements.length) return;
+
+      const byId = new Map(refinements.map((r) => [r.id, r]));
+      for (const item of batch) {
+        const r = byId.get(item.id);
+        if (!r) continue;
+        subtitleService.updateSegment(item.id, {
+          text: r.en,
+          displayText: r.en,
+          roughTranslation: r.zh,
+          displayTranslation: r.zh,
+          translatedText: r.zh,
+          translationSource: 'fine',
+          source: 'fine',
+        });
+
+        const pending = this.pendingSubtitles.find((s) => s.id === item.id);
+        if (pending) {
+          pending.text_en = r.en;
+          pending.text_zh = r.zh;
+          pending.type = 'fine';
+        }
+      }
+    } catch (e) {
+      console.warn('[TranscriptionService] Fine refinement batch failed; keeping rough output:', e);
+    }
   }
 
   private async processRemainingBuffer() {

--- a/ClassNoteAI/src/services/whisperService.ts
+++ b/ClassNoteAI/src/services/whisperService.ts
@@ -19,7 +19,17 @@ export interface TranscriptionSegment {
   end_ms: number;
 }
 
-export type ModelType = 'tiny' | 'base' | 'small' | 'medium' | 'large' | 'small-q5' | 'medium-q5';
+export type ModelType =
+  | 'tiny'
+  | 'base'
+  | 'small'
+  | 'medium'
+  | 'large'
+  | 'small-q5'
+  | 'medium-q5'
+  // large-v3 turbo: ~8x faster than large-v3 with almost identical accuracy.
+  // Added in v0.5.0 as the recommended default when users opt into a bigger model.
+  | 'large-v3-turbo-q5';
 
 /**
  * 獲取模型文件路徑（使用後端統一路徑 API）
@@ -34,6 +44,8 @@ async function getModelPath(modelType: ModelType = 'base'): Promise<string> {
     modelFileName = 'ggml-small-q5.bin';
   } else if (modelType === 'medium-q5') {
     modelFileName = 'ggml-medium-q5.bin';
+  } else if (modelType === 'large-v3-turbo-q5') {
+    modelFileName = 'ggml-large-v3-turbo-q5_0.bin';
   }
 
   return await path.join(whisperDir, modelFileName);
@@ -213,6 +225,7 @@ export function getModelSize(modelType: ModelType): number {
     large: 2900,
     'small-q5': 180,
     'medium-q5': 530,
+    'large-v3-turbo-q5': 574,
   };
   return sizes[modelType] || 142;
 }
@@ -229,6 +242,7 @@ export function getModelDisplayName(modelType: ModelType): string {
     large: 'Large (2.9GB) - 最高準確度，很慢',
     'small-q5': 'Small Quantized (180MB) - 🚀 推薦 (快且準)',
     'medium-q5': 'Medium Quantized (530MB) - 🎯 最佳平衡',
+    'large-v3-turbo-q5': 'Large-v3 Turbo Quantized (574MB) - ⭐ 最佳精度（v0.5.0+）',
   };
   return names[modelType] || 'Base';
 }


### PR DESCRIPTION
## Summary

Final v0.5.0 PR. Two related ASR/translation improvements:

### 1. Whisper large-v3-turbo (quantized q5_0)

New option in the WhisperModelManager dropdown. Turbo is ~8x faster than large-v3 with essentially the same accuracy, so it becomes the best "big model" choice without paying the full large-v3 cost. Rust download config + expected-size tables updated.

Moonshine-style native streaming ASR was originally planned for this PR but is deferred to v0.5.1 — Whisper turbo on its own is already a meaningful bump for users.

### 2. Fine translation batch pipeline

Replaces the never-implemented server-side fine-translation hook with batched LLM calls. Flow:

```
rough ASR segment → immediately committed to UI + rough MT (Opus-MT)
                          ↓
              queued for fine refinement
                          ↓
  every 8 segments OR 20 s silence → one LLMProvider call
                          ↓
        receives corrected en + natural zh per segment
                          ↓
  subtitleService.updateSegment(..., {type: 'fine'}) patches UI
  pendingSubtitles queue also patched for persistence
```

New `llm/tasks.ts::refineTranscripts(batch)` returns `FineRefinement[]` (`{id, en, zh}`) using JSON mode. `transcriptionService` owns the batching window and does a final flush on session stop so trailing segments get the refinement pass before persistence.

Batch failures are soft — rough output stays, error logged.

## Test plan

- [x] `cargo check` (MSVC, VS 2026)
- [x] `tsc --noEmit` clean
- [x] 121 vitest tests pass
- [ ] CI: both platforms green
- [ ] Manual post-merge: record a lecture with a provider configured, observe captions upgrade from rough → fine.

## After this merges

All four v0.5.0 work packages (A, B1-B3, C1-C3, D) are in. Next step: bump versions and tag `v0.5.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)