### PR TITLE
ci: split PR checks from release bundles

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -17,6 +17,9 @@ on:
       - '.github/workflows/release-*.yml'
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 concurrency:
   group: pr-check-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -1,0 +1,135 @@
+name: PR Check
+
+# Runs on every PR against main. Intentionally lightweight: tsc + vitest
+# + cargo check on both platforms. We do NOT build the full Tauri
+# bundle here — that happens on tag push via the release workflows.
+#
+# Rationale: a full bundle takes 15–20 min per platform. On a typical
+# refactor PR that's 30–40 min of CI for a change that doesn't need an
+# installer. This trims PR feedback to roughly 5–10 min per platform.
+
+on:
+  pull_request:
+    branches: [main]
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+      - '.github/workflows/release-*.yml'
+  workflow_dispatch:
+
+concurrency:
+  group: pr-check-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  CARGO_INCREMENTAL: 0
+  CARGO_NET_RETRY: 10
+  RUSTUP_MAX_RETRIES: 10
+
+defaults:
+  run:
+    working-directory: ClassNoteAI
+
+jobs:
+  pr-check-macos:
+    name: pr-check-macos
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: ClassNoteAI/package-lock.json
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: aarch64-apple-darwin
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ClassNoteAI/src-tauri -> target
+          shared-key: "pr-check-macos-cache"
+          cache-all-crates: true
+
+      # Needed because Cargo.toml's [patch.crates-io] points at vendored
+      # crates that are gitignored — the path must exist for cargo to
+      # resolve the manifest, even if the patch is a no-op on macOS.
+      - name: Hydrate vendor/
+        run: bash src-tauri/scripts/bootstrap-vendor.sh
+
+      - name: Install npm deps
+        run: npm ci --prefer-offline
+
+      - name: Type-check frontend
+        run: npx tsc --noEmit
+
+      - name: Frontend tests
+        run: npx vitest run
+
+      - name: cargo check
+        working-directory: ClassNoteAI/src-tauri
+        run: cargo check --message-format=short
+
+  pr-check-windows:
+    name: pr-check-windows
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: ClassNoteAI/package-lock.json
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-pc-windows-msvc
+
+      - name: Install LLVM 18
+        uses: KyleMayes/install-llvm-action@v2
+        with:
+          version: "18"
+          directory: ${{ runner.temp }}/llvm
+
+      - uses: Swatinem/rust-cache@v2
+        with:
+          workspaces: ClassNoteAI/src-tauri -> target
+          shared-key: "pr-check-windows-cache"
+          cache-all-crates: true
+
+      - name: Cache native C++ builds
+        uses: actions/cache@v4
+        with:
+          path: |
+            ClassNoteAI/src-tauri/target/debug/build/ct2rs-*
+            ClassNoteAI/src-tauri/target/debug/build/whisper-rs-sys-*
+            ClassNoteAI/src-tauri/target/debug/build/sentencepiece-sys-*
+          key: pr-check-native-windows-${{ hashFiles('ClassNoteAI/src-tauri/Cargo.lock', 'ClassNoteAI/src-tauri/vendor-patches/**') }}
+
+      - name: Hydrate vendor/
+        shell: bash
+        run: bash src-tauri/scripts/bootstrap-vendor.sh
+
+      - name: Install npm deps
+        run: npm ci --prefer-offline
+
+      - name: Type-check frontend
+        run: npx tsc --noEmit
+
+      - name: Frontend tests
+        run: npx vitest run
+
+      - name: cargo check
+        shell: cmd
+        env:
+          LIBCLANG_PATH: ${{ runner.temp }}\llvm\bin
+          CMAKE_GENERATOR: Visual Studio 17 2022
+          CMAKE_TOOLCHAIN_FILE: ${{ github.workspace }}\ClassNoteAI\src-tauri\scripts\win-toolchain.cmake
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          cd src-tauri
+          cargo check --message-format=short

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -21,6 +21,9 @@ concurrency:
   group: pr-check-${{ github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -1,16 +1,12 @@
 name: Build and Release (macOS)
 
 on:
+  # Release bundles are expensive (~15–20 min). Only on tag push or
+  # manual dispatch. PR feedback lives in pr-check.yml.
   push:
     tags:
       - 'v*'
-  pull_request:
-    branches:
-      - main
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
-  # 每週日 UTC 00:00 自動觸發，保持快取活躍
+  # 每週日 UTC 00:00 自動觸發，保持 Rust + ct2rs cache 活躍
   schedule:
     - cron: '0 0 * * 0'
   workflow_dispatch:

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -1,15 +1,12 @@
 name: Build and Release (Windows)
 
 on:
+  # Release bundles are expensive (~15–20 min). Only run when we're
+  # actually cutting a release (tag push) or when someone manually
+  # kicks it off. Lightweight PR feedback lives in pr-check.yml.
   push:
     tags:
       - 'v*'
-  pull_request:
-    branches:
-      - main
-    paths-ignore:
-      - '**.md'
-      - 'docs/**'
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
## Summary

PRs used to trigger the full Tauri bundle workflow on both platforms (~15-20 min each). That's appropriate when we're actually cutting a release, but wasteful for a typical refactor / doc / test change that only needs "does this still compile and test".

## New

- **`.github/workflows/pr-check.yml`** — lightweight, parallel on both OSes. Each side runs: checkout → setup Node/Rust/LLVM → npm ci → `tsc --noEmit` → `vitest run` → `cargo check`. No bundle. Target runtime: ~5-10 min per platform.
- Jobs are named `pr-check-macos` and `pr-check-windows` to distinguish from the release workflow's `build-macos` / `build-windows`.

## Modified

- `release-macos.yml` / `release-windows.yml` — removed the `pull_request` trigger. Keeps `push: tags: v*` + `workflow_dispatch`. Release bundles now only run when tagged.
- Repo branch ruleset on `main` updated (via API) to require the new `pr-check-*` contexts.

## Caveats

- PR #18 (currently in flight) is still running the OLD release workflow because it was queued before this change; its `build-*` check names no longer match what the ruleset requires, so merging it will need one admin bypass. Future PRs will use pr-check automatically.

## Test plan

- [ ] CI on this PR: expect `build-*` (old) to run one last time because this PR itself hasn't changed main yet. Once merged, future PRs get `pr-check-*`.
- [ ] After merge: open a trivial test PR, confirm pr-check runs and release workflows do NOT.
- [ ] Tag `v0.5.1` when ready: confirm release workflows fire and produce installers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)