### PR TITLE
feat(translation): source/target language config + pipeline fixes (F1)

### DIFF
--- a/ClassNoteAI/src-tauri/src/translation/ctranslate2.rs
+++ b/ClassNoteAI/src-tauri/src/translation/ctranslate2.rs
@@ -87,11 +87,16 @@ impl CT2Translator {
         self.translator.is_some()
     }
 
-    /// Translate a batch of texts with optional target language override
+    /// Translate a batch of texts with optional source/target language override.
+    ///
+    /// For M2M100 we prepend the source language token (e.g. `__en__`) to each
+    /// input. Without it the model sometimes refuses to cross-translate and
+    /// echoes the source instead — especially on short / repetitive inputs.
     pub fn translate_batch(
         &self,
         texts: &[String],
         target_lang_override: Option<&str>,
+        source_lang_override: Option<&str>,
     ) -> Result<Vec<String>, String> {
         let translator = self
             .translator
@@ -102,8 +107,16 @@ impl CT2Translator {
             return Ok(vec![]);
         }
 
-        // Convert to Vec<&str> for the API
-        let sources: Vec<&str> = texts.iter().map(|s| s.as_str()).collect();
+        // Source language token (for M2M100 input prefix)
+        let source_lang = source_lang_override.unwrap_or(&self.source_lang);
+        let src_token = m2m100_lang_token(source_lang);
+
+        // Prepend source token to each input: "__en__ Hello world"
+        let prefixed: Vec<String> = texts
+            .iter()
+            .map(|t| format!("{} {}", src_token, t))
+            .collect();
+        let sources: Vec<&str> = prefixed.iter().map(|s| s.as_str()).collect();
 
         // TranslationOptions with good defaults
         let options = TranslationOptions::<String, String> {
@@ -143,19 +156,8 @@ impl CT2Translator {
         let target_lang = target_lang_override.unwrap_or(&self.target_lang);
 
         // Prepare target prefix (language token)
-        // M2M100 requires the target language token as the first token
-        // Map common codes to M2M100 tokens
-        let lang_token = match target_lang {
-            "zh" | "zh-CN" | "zh-TW" => "__zh__",
-            "en" => "__en__",
-            "ja" => "__ja__",
-            "ko" => "__ko__",
-            "fr" => "__fr__",
-            "de" => "__de__",
-            "es" => "__es__",
-            "ru" => "__ru__",
-            _ => "__en__", // Default to English if unknown
-        };
+        // M2M100 requires the target language token as the first decoded token.
+        let lang_token = m2m100_lang_token(target_lang);
 
         // Prepare target prefix (language token)
         let target_prefix = vec![vec![lang_token.to_string()]; sources.len()];
@@ -176,11 +178,33 @@ impl CT2Translator {
 
     /// Translate a single text
     pub fn translate(&self, text: &str) -> Result<String, String> {
-        let results = self.translate_batch(&[text.to_string()], None)?;
+        let results = self.translate_batch(&[text.to_string()], None, None)?;
         results
             .into_iter()
             .next()
             .ok_or_else(|| "No translation result".to_string())
+    }
+}
+
+/// Map ISO-ish language codes to the M2M100 language token used by
+/// CTranslate2's target_prefix and by the source-side text prefix we
+/// prepend manually. Keep this list aligned with the dropdown in
+/// SettingsView / SetupWizard.
+fn m2m100_lang_token(lang: &str) -> &'static str {
+    match lang {
+        "zh" | "zh-CN" | "zh-TW" => "__zh__",
+        "en" => "__en__",
+        "ja" => "__ja__",
+        "ko" => "__ko__",
+        "fr" => "__fr__",
+        "de" => "__de__",
+        "es" => "__es__",
+        "ru" => "__ru__",
+        // `auto` falls back to English as a conservative default.
+        // Whisper's language auto-detect should have reported a concrete
+        // code by the time we reach translate_batch, so this branch is
+        // mostly defensive.
+        _ => "__en__",
     }
 }
 
@@ -226,7 +250,7 @@ pub async fn translate_ct2(text: &str) -> Result<String, String> {
 pub async fn translate_ct2_batch(texts: &[String]) -> Result<Vec<String>, String> {
     let translator = get_translator().await;
     let guard = translator.read().await;
-    guard.translate_batch(texts, None)
+    guard.translate_batch(texts, None, None)
 }
 
 // ========== Aliases for compatibility with rough.rs ==========
@@ -239,14 +263,18 @@ pub async fn is_loaded() -> bool {
 /// Translate text with language parameters (uses configured languages)
 pub async fn translate_text(
     text: &str,
-    _source_lang: &str,
+    source_lang: &str,
     target_lang: &str,
 ) -> Result<String, String> {
-    // Use the provided target_lang instead of the default
+    // Pass BOTH source and target through so M2M100 knows how to cross.
     let translator = get_translator().await;
     let guard = translator.read().await;
 
-    let results = guard.translate_batch(&[text.to_string()], Some(target_lang))?;
+    let results = guard.translate_batch(
+        &[text.to_string()],
+        Some(target_lang),
+        Some(source_lang),
+    )?;
     results
         .into_iter()
         .next()

--- a/ClassNoteAI/src/components/NotesView.tsx
+++ b/ClassNoteAI/src/components/NotesView.tsx
@@ -116,7 +116,7 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
         }
 
         // Embedding Model: 使用 Ollama 遠程 nomic-embed-text，無需本地加載
-        console.log('[NotesView] Using Ollama remote nomic-embed-text for auto-alignment');
+        console.log('[NotesView] Using local Candle nomic-embed-text-v1 for auto-alignment');
         // Load Translation Model if provider is local
         const translationProvider = settings?.translation?.provider || 'local';
         if (translationProvider === 'local') {
@@ -611,9 +611,23 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
       await storageService.saveLecture(updatedLecture);
       setCurrentLectureData(updatedLecture);
 
-      // Now it's safe to set lectureId and start transcription
+      // Now it's safe to set lectureId and start transcription.
       transcriptionService.clear();
       transcriptionService.setLectureId(currentLectureData.id);
+
+      // v0.5.1: wire the user's configured source/target languages and
+      // pre-check whether the LLM fine-refinement queue should be active
+      // for this session.
+      try {
+        const settings = await storageService.getAppSettings();
+        const src = settings?.translation?.source_language || 'auto';
+        const tgt = settings?.translation?.target_language || 'zh-TW';
+        transcriptionService.setLanguages(src, tgt);
+      } catch {
+        transcriptionService.setLanguages('auto', 'zh-TW');
+      }
+      await transcriptionService.refreshFineRefinementAvailability();
+
       transcriptionService.start();
 
       await audioRecorderRef.current.start();

--- a/ClassNoteAI/src/components/SettingsView.tsx
+++ b/ClassNoteAI/src/components/SettingsView.tsx
@@ -404,30 +404,63 @@ export default function SettingsView({ }: SettingsViewProps) {
                   </div>
                 )}
 
-                <div className="mt-4 pt-4 border-t border-gray-200 dark:border-gray-700">
-                  <label className="block text-sm font-medium mb-2">目標語言 (AI 生成內容)</label>
-                  <select
-                    value={settings.translation?.target_language || 'zh-TW'}
-                    onChange={(e) => {
-                      setSettings({
-                        ...settings,
-                        translation: {
-                          ...settings.translation,
-                          target_language: e.target.value,
-                        },
-                      });
-                    }}
-                    className="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-                  >
-                    <option value="zh-TW">繁體中文 (Traditional Chinese)</option>
-                    <option value="zh-CN">簡體中文 (Simplified Chinese)</option>
-                    <option value="en">English</option>
-                    <option value="ja">日本語 (Japanese)</option>
-                    <option value="ko">한국어 (Korean)</option>
-                  </select>
-                  <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
-                    此設置將應用於 AI 自動生成的課程大綱、總結與筆記翻譯。
-                  </p>
+                <div className="mt-4 pt-4 border-t border-gray-200 dark:border-gray-700 grid grid-cols-1 md:grid-cols-2 gap-4">
+                  <div>
+                    <label className="block text-sm font-medium mb-2">講者語言（來源）</label>
+                    <select
+                      value={settings.translation?.source_language || 'auto'}
+                      onChange={(e) => {
+                        setSettings({
+                          ...settings,
+                          translation: {
+                            ...settings.translation,
+                            source_language: e.target.value as
+                              | 'auto' | 'en' | 'ja' | 'ko' | 'fr' | 'de' | 'es' | 'zh-TW' | 'zh-CN',
+                          },
+                        });
+                      }}
+                      className="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                    >
+                      <option value="auto">自動偵測</option>
+                      <option value="en">English</option>
+                      <option value="ja">日本語 (Japanese)</option>
+                      <option value="ko">한국어 (Korean)</option>
+                      <option value="fr">Français (French)</option>
+                      <option value="de">Deutsch (German)</option>
+                      <option value="es">Español (Spanish)</option>
+                      <option value="zh-TW">繁體中文</option>
+                      <option value="zh-CN">簡體中文</option>
+                    </select>
+                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                      課堂上講者使用的語言，影響 ASR 與翻譯方向。
+                    </p>
+                  </div>
+
+                  <div>
+                    <label className="block text-sm font-medium mb-2">目標語言</label>
+                    <select
+                      value={settings.translation?.target_language || 'zh-TW'}
+                      onChange={(e) => {
+                        setSettings({
+                          ...settings,
+                          translation: {
+                            ...settings.translation,
+                            target_language: e.target.value,
+                          },
+                        });
+                      }}
+                      className="w-full px-3 py-2 rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-800 focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
+                    >
+                      <option value="zh-TW">繁體中文 (Traditional Chinese)</option>
+                      <option value="zh-CN">簡體中文 (Simplified Chinese)</option>
+                      <option value="en">English</option>
+                      <option value="ja">日本語 (Japanese)</option>
+                      <option value="ko">한국어 (Korean)</option>
+                    </select>
+                    <p className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                      字幕、摘要、問答都會翻譯成這個語言。
+                    </p>
+                  </div>
                 </div>
               </div>
             </div>

--- a/ClassNoteAI/src/components/SetupWizard.tsx
+++ b/ClassNoteAI/src/components/SetupWizard.tsx
@@ -34,7 +34,9 @@ interface SetupWizardProps {
     onComplete: () => void;
 }
 
-type WizardStep = 'welcome' | 'checking' | 'review' | 'installing' | 'complete';
+type WizardStep = 'welcome' | 'language' | 'checking' | 'review' | 'installing' | 'complete';
+
+type SourceLang = 'auto' | 'en' | 'ja' | 'ko' | 'fr' | 'de' | 'es' | 'zh-TW' | 'zh-CN';
 
 export default function SetupWizard({ onComplete }: SetupWizardProps) {
     const [step, setStep] = useState<WizardStep>('welcome');
@@ -43,6 +45,12 @@ export default function SetupWizard({ onComplete }: SetupWizardProps) {
     const [includeOptional, setIncludeOptional] = useState(false);
     const [progressMap, setProgressMap] = useState<Record<string, Progress>>({});
     const [isInstalling, setIsInstalling] = useState(false);
+
+    // v0.5.1: first-run language pair. Persisted to AppSettings at the
+    // end of the language step so transcriptionService picks it up when
+    // the user eventually starts a lecture.
+    const [sourceLang, setSourceLang] = useState<SourceLang>('auto');
+    const [targetLang, setTargetLang] = useState<string>('zh-TW');
 
     // Check requirements when entering checking step
     const checkRequirements = useCallback(async () => {
@@ -191,8 +199,90 @@ export default function SetupWizard({ onComplete }: SetupWizardProps) {
                 首次使用需要下載必要的 AI 模型，請確保網路連線穩定。
             </p>
 
-            <button className="setup-button primary" onClick={checkRequirements}>
+            <button className="setup-button primary" onClick={() => setStep('language')}>
                 開始設置 <ArrowRight className="w-5 h-5" />
+            </button>
+        </div>
+    );
+
+    // Render language step (v0.5.1)
+    const renderLanguage = () => (
+        <div className="setup-step welcome-step">
+            <div className="setup-icon-container">
+                <div className="setup-icon">
+                    <Languages className="w-16 h-16 text-green-500" />
+                </div>
+            </div>
+
+            <h2 className="setup-subtitle">選擇語言</h2>
+            <p className="setup-description">
+                設定課堂的講者語言（來源）和你想看到的翻譯語言（目標）。
+                之後隨時可以在「設定 → 轉錄與翻譯」修改。
+            </p>
+
+            <div style={{ width: '100%', maxWidth: 480, margin: '1.5rem auto', display: 'flex', flexDirection: 'column', gap: '1rem' }}>
+                <label style={{ display: 'block' }}>
+                    <span style={{ display: 'block', fontSize: 14, fontWeight: 500, marginBottom: 6 }}>
+                        講者語言（來源）
+                    </span>
+                    <select
+                        value={sourceLang}
+                        onChange={(e) => setSourceLang(e.target.value as SourceLang)}
+                        style={{ width: '100%', padding: '10px 12px', borderRadius: 8, border: '1px solid #d1d5db', background: 'white' }}
+                    >
+                        <option value="auto">自動偵測（推薦）</option>
+                        <option value="en">English</option>
+                        <option value="ja">日本語 (Japanese)</option>
+                        <option value="ko">한국어 (Korean)</option>
+                        <option value="fr">Français (French)</option>
+                        <option value="de">Deutsch (German)</option>
+                        <option value="es">Español (Spanish)</option>
+                        <option value="zh-TW">繁體中文</option>
+                        <option value="zh-CN">簡體中文</option>
+                    </select>
+                </label>
+
+                <label style={{ display: 'block' }}>
+                    <span style={{ display: 'block', fontSize: 14, fontWeight: 500, marginBottom: 6 }}>
+                        目標語言
+                    </span>
+                    <select
+                        value={targetLang}
+                        onChange={(e) => setTargetLang(e.target.value)}
+                        style={{ width: '100%', padding: '10px 12px', borderRadius: 8, border: '1px solid #d1d5db', background: 'white' }}
+                    >
+                        <option value="zh-TW">繁體中文 (Traditional Chinese)</option>
+                        <option value="zh-CN">簡體中文 (Simplified Chinese)</option>
+                        <option value="en">English</option>
+                        <option value="ja">日本語 (Japanese)</option>
+                        <option value="ko">한국어 (Korean)</option>
+                    </select>
+                </label>
+            </div>
+
+            <button
+                className="setup-button primary"
+                onClick={async () => {
+                    // Persist the pair to AppSettings before moving on so
+                    // transcriptionService reads it when a lecture starts.
+                    try {
+                        const { storageService } = await import('../services/storageService');
+                        const existing = (await storageService.getAppSettings()) || ({} as any);
+                        await storageService.saveAppSettings({
+                            ...existing,
+                            translation: {
+                                ...(existing.translation || {}),
+                                source_language: sourceLang,
+                                target_language: targetLang,
+                            },
+                        });
+                    } catch (e) {
+                        console.warn('[SetupWizard] Could not persist language pair:', e);
+                    }
+                    await checkRequirements();
+                }}
+            >
+                繼續 <ArrowRight className="w-5 h-5" />
             </button>
         </div>
     );
@@ -416,11 +506,11 @@ export default function SetupWizard({ onComplete }: SetupWizardProps) {
             <div className="setup-container">
                 {/* Progress indicator */}
                 <div className="step-indicator">
-                    {['welcome', 'checking', 'review', 'installing', 'complete'].map((s, i) => (
+                    {(['welcome', 'language', 'checking', 'review', 'installing', 'complete'] as const).map((s, i) => (
                         <div
                             key={s}
                             className={`step-dot ${s === step ? 'active' :
-                                ['welcome', 'checking', 'review', 'installing', 'complete'].indexOf(step) > i ? 'done' : ''
+                                (['welcome', 'language', 'checking', 'review', 'installing', 'complete'] as const).indexOf(step) > i ? 'done' : ''
                                 }`}
                         />
                     ))}
@@ -428,6 +518,7 @@ export default function SetupWizard({ onComplete }: SetupWizardProps) {
 
                 {/* Step content */}
                 {step === 'welcome' && renderWelcome()}
+                {step === 'language' && renderLanguage()}
                 {step === 'checking' && renderChecking()}
                 {step === 'review' && renderReview()}
                 {step === 'installing' && renderInstalling()}

--- a/ClassNoteAI/src/services/transcriptionService.ts
+++ b/ClassNoteAI/src/services/transcriptionService.ts
@@ -59,9 +59,41 @@ export class TranscriptionService {
   private static readonly FINE_BATCH_SIZE = 8;
   private static readonly FINE_DEBOUNCE_MS = 20_000;
 
+  // Language pair for rough translation. Read from AppSettings when a
+  // lecture starts. `auto` means "let Whisper detect". Introduced v0.5.1.
+  private sourceLang: string = 'auto';
+  private targetLang: string = 'zh-TW';
+
+  // Cached check: is an LLM provider configured? If not, we skip the
+  // fine-refinement queue entirely instead of spamming errors every
+  // FINE_DEBOUNCE_MS. Re-checked each new recording session.
+  private fineRefinementEnabled: boolean = false;
+
   constructor() {
     // 綁定方法以避免 this 丟失
     this.checkAndTranscribe = this.checkAndTranscribe.bind(this);
+  }
+
+  /** Update the language pair used for rough translation. Called from
+   *  NotesView right before a recording starts so settings changes take
+   *  effect mid-session. */
+  public setLanguages(source: string, target: string): void {
+    this.sourceLang = source || 'auto';
+    this.targetLang = target || 'zh-TW';
+    console.log('[TranscriptionService] Language pair:', this.sourceLang, '→', this.targetLang);
+  }
+
+  /** Pre-flight: check if any LLM provider is configured. We skip the
+   *  fine-refinement queue entirely if not. */
+  public async refreshFineRefinementAvailability(): Promise<void> {
+    try {
+      const { resolveActiveProvider } = await import('./llm');
+      const defaultId = localStorage.getItem('llm.defaultProvider') || undefined;
+      const provider = await resolveActiveProvider(defaultId);
+      this.fineRefinementEnabled = !!provider;
+    } catch {
+      this.fineRefinementEnabled = false;
+    }
   }
 
   /**
@@ -388,31 +420,39 @@ export class TranscriptionService {
         if (this.isValidText(cleaned)) {
           const segmentId = this.commitStableText(cleaned);
 
-          // 根據時間戳清理緩衝區
-          if (result.segments && result.segments.length > 0) {
-            const lastSegment = result.segments[result.segments.length - 1];
-            const endMs = lastSegment.end_ms;
-            const samplesToRemove = Math.floor((endMs * CONFIG.SAMPLE_RATE) / 1000);
+          // Buffer clearing after commit. v0.5.1: be more aggressive —
+          // if endMs is 0 / undefined / out-of-range we still clear the
+          // whole rolling buffer rather than leaving the audio around,
+          // because leaving it causes Whisper to re-transcribe the same
+          // sentence on the next polling tick, which then duplicates the
+          // committed subtitle when processRemainingBuffer fires.
+          const lastSegment = result.segments?.[result.segments.length - 1];
+          const endMs = lastSegment?.end_ms ?? 0;
+          const samplesToRemove = Math.floor((endMs * CONFIG.SAMPLE_RATE) / 1000);
+          const validTimestamp = samplesToRemove > 0 && samplesToRemove <= this.rollingBuffer.length;
 
-            if (samplesToRemove > 0 && samplesToRemove <= this.rollingBuffer.length) {
-              // 捕獲音頻數據用於精修
-              const audioForRefinement = this.rollingBuffer.slice(0, samplesToRemove);
-              refinementService.addToQueue(
-                segmentId,
-                audioForRefinement,
-                cleaned,
-                Date.now(),
-                this.keywords
-              );
+          if (validTimestamp && segmentId) {
+            const audioForRefinement = this.rollingBuffer.slice(0, samplesToRemove);
+            refinementService.addToQueue(
+              segmentId,
+              audioForRefinement,
+              cleaned,
+              Date.now(),
+              this.keywords
+            );
 
-              const overlapSamples = Math.floor(CONFIG.SAMPLE_RATE * 0.2);
-              const safeRemove = Math.max(0, samplesToRemove - overlapSamples);
-              console.log(`[TranscriptionService] 清理緩衝區: 移除 ${safeRemove} 樣本`);
-              this.rollingBuffer = this.rollingBuffer.slice(safeRemove);
-            } else {
-              this.rollingBuffer = new Int16Array(0);
-            }
+            const overlapSamples = Math.floor(CONFIG.SAMPLE_RATE * 0.2);
+            const safeRemove = Math.max(0, samplesToRemove - overlapSamples);
+            console.log(`[TranscriptionService] 清理緩衝區: 移除 ${safeRemove} 樣本`);
+            this.rollingBuffer = this.rollingBuffer.slice(safeRemove);
           } else {
+            // No usable timestamp (whisper-rs bindings vary by platform
+            // and segmentation mode) OR the commit was a duplicate that
+            // we just deduped — nuke the whole buffer. Losing audio
+            // overlap is the lesser evil compared to duplicate captions.
+            if (!validTimestamp) {
+              console.log('[TranscriptionService] 無有效時間戳，全清緩衝區');
+            }
             this.rollingBuffer = new Int16Array(0);
           }
         } else {
@@ -463,6 +503,23 @@ export class TranscriptionService {
   }
 
   private commitStableText(text: string): string {
+    // v0.5.1 dedup: guard against the "same sentence committed twice"
+    // bug that showed up on Windows (see bug report 00:00 / 00:03 in
+    // the release notes). Root cause is Whisper re-transcribing the
+    // same audio when rollingBuffer clearing after commit is incomplete,
+    // plus processRemainingBuffer firing on stop and committing the
+    // re-transcribed partial text. Even with the buffer fix below, a
+    // cheap tail-match is the most robust safety net.
+    const normalized = text.trim();
+    const tail = this.stableText.trim();
+    if (normalized && tail.endsWith(normalized)) {
+      console.log('[TranscriptionService] 重複文本，跳過提交:', normalized.slice(0, 40));
+      // Return an empty id so the caller can decide what to do. The
+      // buffer-cleanup branch uses this id only to enqueue refinement,
+      // and refinement is fine to skip on dupes.
+      return '';
+    }
+
     console.log('[TranscriptionService] 提交穩定文本:', text);
     this.stableText += (this.stableText ? ' ' : '') + text;
 
@@ -511,34 +568,55 @@ export class TranscriptionService {
   }
 
   /**
-   * 異步翻譯並更新現有字幕段落
+   * 異步翻譯並更新現有字幕段落。v0.5.1 改動：
+   *  - 使用使用者在 Settings 設定的 source/target language，不再寫死 en/zh
+   *  - 翻譯失敗時把錯誤標記寫入字幕，讓 UI 能顯示 "⚠️ 翻譯模型未載入"
+   *    而不是空白（先前使用者會誤以為是字幕自己重複）
    */
   private async translateAndUpdateSegment(id: string, text: string) {
+    // If source is 'auto' we let M2M100 default to English; Whisper's
+    // language-detect result should eventually feed back via setLanguages
+    // but we don't want to block translation waiting for it.
+    const src = this.sourceLang === 'auto' ? 'en' : this.sourceLang;
+    const tgt = this.targetLang || 'zh-TW';
+
     try {
-      const res = await translateRough(text, 'en', 'zh');
+      const res = await translateRough(text, src, tgt);
       const translation = res.translated_text;
+
+      if (!translation || !translation.trim()) {
+        throw new Error('translator returned empty string');
+      }
 
       console.log('[TranscriptionService] 翻譯完成，更新字幕:', {
         id,
-        translation: translation?.substring(0, 30),
+        translation: translation.substring(0, 30),
       });
 
-      // 更新現有字幕的翻譯
       subtitleService.updateSegment(id, {
         roughTranslation: translation,
         displayTranslation: translation,
         translationSource: 'rough',
-        translatedText: translation
+        translatedText: translation,
       });
 
-      // 更新待保存隊列中的翻譯
-      const pending = this.pendingSubtitles.find(s => s.id === id);
+      const pending = this.pendingSubtitles.find((s) => s.id === id);
       if (pending) {
         pending.text_zh = translation;
       }
     } catch (e) {
       console.warn('[TranscriptionService] 翻譯失敗', e);
-      // 翻譯失敗時，字幕已經在隊列中（沒有翻譯），無需額外處理
+      // Surface the failure to the UI so the user knows what's going on
+      // instead of seeing a blank gray row (which used to look like the
+      // caption duplicated itself).
+      const marker = '⚠️ 翻譯失敗（模型可能未載入，請至設定檢查）';
+      subtitleService.updateSegment(id, {
+        displayTranslation: marker,
+        translationSource: 'error',
+        translatedText: marker,
+      });
+      // Don't write the marker into the persistence queue — store leaves
+      // text_zh null so a successful retry later can populate it.
     }
 
     // Queue this segment for LLM-backed fine refinement (batched).
@@ -552,8 +630,15 @@ export class TranscriptionService {
    * correct ASR errors and produce a natural Chinese translation in one
    * shot, which we then apply to both the UI and the pending-subtitle
    * persistence queue.
+   *
+   * v0.5.1: completely skips the queue when no LLM provider is
+   * configured, so the console doesn't get spammed every 20 s with
+   * "No AI provider configured" errors. `refreshFineRefinementAvailability`
+   * is called once per recording session from NotesView.
    */
   private enqueueFineRefinement(id: string, text: string): void {
+    if (!this.fineRefinementEnabled) return;
+
     this.fineQueue.push({ id, text });
     if (this.fineQueue.length >= TranscriptionService.FINE_BATCH_SIZE) {
       void this.flushFineRefinement();

--- a/ClassNoteAI/src/types/index.ts
+++ b/ClassNoteAI/src/types/index.ts
@@ -103,7 +103,10 @@ export interface AppSettings {
   translation?: {
     provider?: 'local' | 'google'; // 翻譯提供商：本地 ONNX 或 Google API
     google_api_key?: string; // Google Cloud Translation API 密鑰
-    target_language?: string; // 目標語言 (e.g. "zh-TW", "en")，用於 AI 生成內容的翻譯
+    // Spoken language of the lecture. `auto` lets Whisper detect per
+    // session; once detected we pass it to M2M100. Introduced in v0.5.1.
+    source_language?: 'auto' | 'en' | 'ja' | 'ko' | 'fr' | 'de' | 'es' | 'zh-TW' | 'zh-CN';
+    target_language?: string; // 目標語言 (e.g. "zh-TW", "en")。v0.5.1 預設 zh-TW。
   };
   ollama?: {
     host: string;

--- a/ClassNoteAI/src/types/subtitle.ts
+++ b/ClassNoteAI/src/types/subtitle.ts
@@ -24,7 +24,7 @@ export interface SubtitleSegment {
   endTime: number; // 毫秒
   language?: string; // 檢測到的語言
   source: 'rough' | 'fine';     // 當前顯示的來源
-  translationSource?: 'rough' | 'fine'; // 當前翻譯的來源
+  translationSource?: 'rough' | 'fine' | 'error'; // 當前翻譯的來源 ('error' = 本地模型失敗)
   
   // 精層狀態
   fineStatus?: 'pending' | 'transcribing' | 'translating' | 'completed' | 'failed';


### PR DESCRIPTION
## Summary

Fixes the translation / subtitle bugs reported after v0.5.0. Adds first-class source + target language config (onboarding step + Settings dropdowns). Root-causes M2M100's "echo English instead of translate" behaviour and the "same sentence committed twice" duplicate-subtitle bug.

## Root causes traced

1. **M2M100 was echoing English** because input lacked the `__en__ ` source-language prefix. M2M100 needs BOTH a target prefix AND the source token at the start of input — we were only passing target. Short/repetitive sentences like `"Thank you. Thank you."` are the worst offenders.
2. **Duplicate subtitles** (`00:00` + `00:03` with identical text) came from `processRemainingBuffer()` on stop committing `lastPartialText` that Whisper had just re-transcribed because the rolling-buffer cleanup had skipped when `endMs` didn't resolve to a usable sample count.
3. **Console spam** from fine-refinement firing every 20s without an LLM provider configured.
4. **Empty translation row** because `translateAndUpdateSegment` swallowed errors — users couldn't tell the difference between "working, just same as source" and "model not loaded".

## Changes

- **Rust** `ctranslate2.rs`: `translate_batch` now prepends the M2M100 source-language token. Shared `m2m100_lang_token` helper. `translate_text` stops discarding its `source_lang` arg.
- **Frontend** `transcriptionService`:
  - `setLanguages` + `refreshFineRefinementAvailability` called from NotesView when recording starts.
  - Commit dedup against `stableText` tail.
  - Rolling-buffer cleanup falls back to clearing the whole buffer when whisper-rs doesn't report usable `end_ms`.
  - Translation failure → visible "⚠️ 翻譯失敗" marker in the gray row.
  - Fine-refinement queue becomes a no-op when no provider is configured (no more 20s spam).
  - Stale "Ollama remote" log string fixed.
- **UI**:
  - `SetupWizard` gets a new `language` step between welcome and checking. Defaults: Source=auto, Target=zh-TW.
  - `SettingsView` → 轉錄與翻譯 tab now has Source/Target side-by-side.
  - `subtitle.ts` type: `translationSource` union expanded with `'error'`.
- **Types**: `AppSettings.translation.source_language` added.

## Test plan

- [x] `tsc --noEmit` clean
- [x] `cargo check` clean (MSVC, VS 2026, LLVM 18)
- [x] 121 vitest tests still pass
- [ ] CI: both platforms green
- [ ] Manual: fresh install → SetupWizard shows language step → pick Auto + zh-TW → record a repetitive sentence → gray row shows Chinese, not duplicated English.
- [ ] Manual: record, stop, verify subtitle list has exactly one entry per sentence (not the 00:00/00:03 duplicate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)