### PR TITLE
fix(ui): Windows-safe path splits, platform-aware updater, CJK fonts (E4)

### DIFF
--- a/ClassNoteAI/src/App.css
+++ b/ClassNoteAI/src/App.css
@@ -6,7 +6,8 @@
   filter: drop-shadow(0 0 2em #61dafb);
 }
 :root {
-  font-family: Inter, Avenir, Helvetica, Arial, sans-serif;
+  font-family: Inter, Avenir, Helvetica, Arial, "PingFang TC", "Microsoft JhengHei",
+    "Microsoft YaHei", "Noto Sans TC", "Noto Sans SC", "Heiti TC", sans-serif;
   font-size: 16px;
   line-height: 24px;
   font-weight: 400;

--- a/ClassNoteAI/src/components/LectureView.tsx
+++ b/ClassNoteAI/src/components/LectureView.tsx
@@ -536,7 +536,7 @@ export default function LectureView() {
               <div className="flex items-center gap-2">
                 <span className="text-sm text-gray-600 dark:text-gray-400 truncate max-w-md">
                   {pdfPath
-                    ? (pdfPath.startsWith('blob:') ? '拖放的文件' : pdfPath.split("/").pop())
+                    ? (pdfPath.startsWith('blob:') ? '拖放的文件' : pdfPath.split(/[/\\]/).pop())
                     : '已選擇的 PDF 文件'}
                 </span>
               </div>

--- a/ClassNoteAI/src/components/NotesView.tsx
+++ b/ClassNoteAI/src/components/NotesView.tsx
@@ -1297,7 +1297,7 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
                   {(pdfPath || pdfData) && (
                     <div className="px-4 py-2 bg-white dark:bg-slate-800 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
                       <span className="text-sm text-gray-600 dark:text-gray-400 truncate max-w-md">
-                        {pdfPath ? (pdfPath.startsWith('blob:') ? 'Dropped File' : pdfPath.split("/").pop()) : 'Selected PDF'}
+                        {pdfPath ? (pdfPath.startsWith('blob:') ? 'Dropped File' : pdfPath.split(/[/\\]/).pop()) : 'Selected PDF'}
                       </span>
                       <button onClick={handleSelectPDF} className="px-3 py-1 text-sm rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
                         Change

--- a/ClassNoteAI/src/components/SettingsView.tsx
+++ b/ClassNoteAI/src/components/SettingsView.tsx
@@ -724,23 +724,27 @@ export default function SettingsView({ }: SettingsViewProps) {
                           )}
                         </button>
 
-                        <div className="relative flex py-1 items-center">
-                          <div className="flex-grow border-t border-gray-200 dark:border-gray-700"></div>
-                          <span className="flex-shrink-0 mx-2 text-xs text-gray-400">或</span>
-                          <div className="flex-grow border-t border-gray-200 dark:border-gray-700"></div>
-                        </div>
+                        {!navigator.userAgent.includes('Windows') && (
+                          <>
+                            <div className="relative flex py-1 items-center">
+                              <div className="flex-grow border-t border-gray-200 dark:border-gray-700"></div>
+                              <span className="flex-shrink-0 mx-2 text-xs text-gray-400">或</span>
+                              <div className="flex-grow border-t border-gray-200 dark:border-gray-700"></div>
+                            </div>
 
-                        <button
-                          onClick={handleManualDownload}
-                          disabled={isDownloading}
-                          className="w-full flex items-center justify-center gap-2 px-4 py-2 bg-white dark:bg-slate-800 text-green-600 dark:text-green-400 border border-green-600 dark:border-green-500 hover:bg-green-50 dark:hover:bg-green-900/20 disabled:bg-gray-100 dark:disabled:bg-gray-800 disabled:text-gray-400 disabled:border-gray-300 dark:disabled:border-gray-700 rounded-lg transition-colors"
-                        >
-                          {isDownloading ? (
-                            <>下載中 {downloadProgress}%</>
-                          ) : (
-                            <><Download className="w-4 h-4" /> 下載 .dmg 並開啟 (手動安裝)</>
-                          )}
-                        </button>
+                            <button
+                              onClick={handleManualDownload}
+                              disabled={isDownloading}
+                              className="w-full flex items-center justify-center gap-2 px-4 py-2 bg-white dark:bg-slate-800 text-green-600 dark:text-green-400 border border-green-600 dark:border-green-500 hover:bg-green-50 dark:hover:bg-green-900/20 disabled:bg-gray-100 dark:disabled:bg-gray-800 disabled:text-gray-400 disabled:border-gray-300 dark:disabled:border-gray-700 rounded-lg transition-colors"
+                            >
+                              {isDownloading ? (
+                                <>下載中 {downloadProgress}%</>
+                              ) : (
+                                <><Download className="w-4 h-4" /> 下載 .dmg 並開啟 (手動安裝)</>
+                              )}
+                            </button>
+                          </>
+                        )}
                       </div>
                     ) : (
                       <div className="flex items-center gap-2 text-gray-600 dark:text-gray-400">

--- a/ClassNoteAI/src/index.css
+++ b/ClassNoteAI/src/index.css
@@ -3,7 +3,9 @@
 @tailwind utilities;
 
 :root {
-  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI", system-ui, sans-serif;
+  font-family: -apple-system, BlinkMacSystemFont, "SF Pro Display", "Segoe UI",
+    system-ui, "PingFang TC", "Microsoft JhengHei", "Microsoft YaHei",
+    "Noto Sans TC", "Noto Sans SC", "Heiti TC", sans-serif;
   font-size: 16px;
   line-height: 24px;
   font-weight: 400;


### PR DESCRIPTION
## Summary

Three UI issues that surfaced when running on Windows:

- PDF filename display in \`NotesView.tsx\` and \`LectureView.tsx\` split on \`/\` only, so on Windows (paths with \`\\`) the whole path rendered. Switch both sites to \`split(/[/\\]/).pop()\` (regex already used in \`CourseCreationDialog\` + \`syncService\`).
- The \"下載 .dmg 並開啟 (手動安裝)\" fallback button hardcodes an Apple Silicon DMG filename. Hide it on Windows — the standard updater handles MSI/NSIS bundles natively.
- Global font stacks in \`App.css\` + \`index.css\` had no CJK fallback, so Chinese UI text on Windows rendered via the default serif fallback. Add Microsoft JhengHei / YaHei / Noto Sans TC/SC / PingFang TC / Heiti TC fallbacks.

## Test plan

- [x] \`tsc --noEmit\` passes
- [ ] Windows: PDF name shows just the filename, not the whole path
- [ ] Windows: Settings > updater tab has no DMG button
- [ ] Windows: Chinese text renders with JhengHei, not default serif
- [ ] macOS: DMG fallback button still visible and works