### PR TITLE
ci(pr-check): remove duplicate permissions block

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -24,9 +24,6 @@ concurrency:
   group: pr-check-${{ github.ref }}
   cancel-in-progress: true
 
-permissions:
-  contents: read
-
 env:
   CARGO_TERM_COLOR: always
   CARGO_INCREMENTAL: 0


### PR DESCRIPTION
## Summary

\`pr-check.yml\` introduced in #19 has two \`permissions:\` blocks (once before and once after \`concurrency:\`). GitHub Actions parses this as an invalid workflow and every run since #19 merged has come back as completed/failure with zero jobs scheduled. The \`pr-check-windows\` / \`pr-check-macos\` status checks never register on any PR, so the branch protection rule that requires them is blocking every subsequent PR.

Remove the duplicate key. No other changes.

## Test plan

- [ ] This PR's own \`pr-check-windows\` + \`pr-check-macos\` should actually run (not come back with zero jobs)