### PR TITLE
chore(release): bump version to 0.5.1

### DIFF
--- a/ClassNoteAI/package.json
+++ b/ClassNoteAI/package.json
@@ -1,7 +1,7 @@
 {
   "name": "classnoteai",
   "private": true,
-  "version": "0.5.0",
+  "version": "0.5.1",
   "type": "module",
   "scripts": {
     "dev": "vite --debug",

--- a/ClassNoteAI/src-tauri/Cargo.lock
+++ b/ClassNoteAI/src-tauri/Cargo.lock
@@ -728,7 +728,7 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "classnoteai"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/ClassNoteAI/src-tauri/Cargo.toml
+++ b/ClassNoteAI/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "classnoteai"
-version = "0.5.0"
+version = "0.5.1"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/ClassNoteAI/src-tauri/tauri.conf.json
+++ b/ClassNoteAI/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ClassNoteAI",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "identifier": "com.classnoteai",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
## Summary

Bumps \`package.json\`, \`Cargo.toml\`, \`tauri.conf.json\`, \`Cargo.lock\` from 0.5.0 → 0.5.1.

v0.5.1 is a Windows-polish release on top of v0.5.0:

- #18 provider polish (GitHub catalog, OAuth port fallback, LLVM override)
- #20 translation pipeline (M2M100 source/target tokens, subtitle dedup, error UX)
- #21 real OS version + disk space checks on Windows
- #22 path splits backslash-safe, updater button platform-aware, CJK font fallbacks
- #23 LibreOffice Windows install-path probing
- #24 Windows system proxy auto-detection
- #19 CI split (PR checks vs release bundles)
- #25 pr-check duplicate permissions fix

## Test plan

- [x] tsc + cargo check both pass (via pr-check)
- [ ] After merge: tag v0.5.1 → release-macos + release-windows workflows build installers