### PR TITLE
fix(setup): parse Windows version locale-independently (v0.5.1 blocker)

### DIFF
--- a/ClassNoteAI/src-tauri/src/setup/requirements.rs
+++ b/ClassNoteAI/src-tauri/src/setup/requirements.rs
@@ -108,14 +108,26 @@ pub fn check_os_version() -> RequirementStatus {
                     );
                 }
                 let raw = String::from_utf8_lossy(&output.stdout);
-                // Expect "Microsoft Windows [Version 10.0.22631.4890]"
-                let version_str = raw
+                // Expect `Microsoft Windows [Version 10.0.22631.4890]` on
+                // English systems. On localized Windows the word "Version"
+                // is translated (e.g. "版本" in zh-TW/zh-CN), so parse the
+                // dot-separated version number inside the brackets instead
+                // of relying on the keyword.
+                let inside_brackets = raw
                     .split('[')
                     .nth(1)
                     .and_then(|s| s.split(']').next())
-                    .and_then(|s| s.split("Version").nth(1))
-                    .map(|s| s.trim().to_string())
-                    .unwrap_or_default();
+                    .unwrap_or("");
+
+                let version_str = inside_brackets
+                    .split_whitespace()
+                    .find(|tok| {
+                        tok.chars()
+                            .all(|c| c.is_ascii_digit() || c == '.')
+                            && tok.contains('.')
+                    })
+                    .unwrap_or("")
+                    .to_string();
 
                 let build: u32 = version_str
                     .split('.')


### PR DESCRIPTION
## Summary

Pre-tag code review surfaced a regression introduced by #21: \`check_os_version()\` splits \`cmd /c ver\` output on the English keyword \"Version\", which is translated on localized Windows (e.g. \"版本\" on zh-TW / zh-CN). Taiwan/China users would see the setup wizard report an Error with an unparseable version string instead of the real build number.

Fix by parsing the dot-separated numeric token inside the \`[...]\` section directly — that numeric format is identical across all Windows locales.

- English: \`Microsoft Windows [Version 10.0.22631.4890]\` → \"10.0.22631.4890\"
- zh-TW:   \`Microsoft Windows [版本 10.0.22631.4890]\` → \"10.0.22631.4890\"

## Why v0.5.1 blocker

- This codepath was changed in v0.5.1 (#21). On main Taiwan users would hit a bogus setup error on first run.
- Must land before the v0.5.1 tag otherwise we ship a broken setup wizard to the primary target audience (zh-TW).

## Test plan

- [x] \`cargo check --lib\` passes
- [ ] zh-TW Windows machine: setup wizard reports \"Windows 版本: 10.0.x OK\"
- [ ] en-US Windows: same (no regression)