### PR TITLE
fix(v0.5.1): review follow-ups (PowerShell args, empty M2M100, PDF query, release parity)

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -87,6 +87,13 @@ jobs:
       - name: Install dependencies
         run: npm ci --prefer-offline
 
+      # Explicit frontend build for parity with release-windows.yml.
+      # `tauri build` does run `beforeBuildCommand` from tauri.conf.json,
+      # but making it explicit means an accidental removal of that hook
+      # fails loudly here instead of silently shipping stale JS.
+      - name: Build frontend
+        run: npm run build
+
       # ===== Build Tauri =====
       - name: Build Tauri (Apple Silicon)
         run: npm run tauri build -- --target aarch64-apple-darwin

--- a/ClassNoteAI/src-tauri/src/setup/requirements.rs
+++ b/ClassNoteAI/src-tauri/src/setup/requirements.rs
@@ -204,17 +204,17 @@ pub fn check_disk_space(required_mb: u64) -> RequirementStatus {
 
         // Use [System.IO.DriveInfo] to get free bytes. Works on every
         // supported Windows build without needing wmic or fsutil.
-        let ps_cmd = format!(
-            "[System.IO.DriveInfo]::new('{}').AvailableFreeSpace",
-            probe_path.replace('\'', "''")
-        );
-
+        // Pass the path via $args rather than string-interpolating it into
+        // the -Command body so backticks/$/apostrophes in APPDATA (which
+        // can legally appear in a Windows username) cannot be interpreted
+        // by PowerShell.
         match Command::new("powershell")
             .args([
                 "-NoProfile",
                 "-NonInteractive",
                 "-Command",
-                &ps_cmd,
+                "[System.IO.DriveInfo]::new($args[0]).AvailableFreeSpace",
+                &probe_path,
             ])
             .output()
         {

--- a/ClassNoteAI/src-tauri/src/translation/ctranslate2.rs
+++ b/ClassNoteAI/src-tauri/src/translation/ctranslate2.rs
@@ -111,11 +111,22 @@ impl CT2Translator {
         let source_lang = source_lang_override.unwrap_or(&self.source_lang);
         let src_token = m2m100_lang_token(source_lang);
 
-        // Prepend source token to each input: "__en__ Hello world"
-        let prefixed: Vec<String> = texts
+        // Translate only non-empty inputs. M2M100 given an empty string
+        // after the source token produces garbage / can hang the beam
+        // search. Record the original indices so we can interleave
+        // empty-string outputs back at the correct positions.
+        let non_empty: Vec<(usize, String)> = texts
             .iter()
-            .map(|t| format!("{} {}", src_token, t))
+            .enumerate()
+            .filter(|(_, t)| !t.trim().is_empty())
+            .map(|(i, t)| (i, format!("{} {}", src_token, t)))
             .collect();
+
+        if non_empty.is_empty() {
+            return Ok(vec![String::new(); texts.len()]);
+        }
+
+        let prefixed: Vec<String> = non_empty.iter().map(|(_, t)| t.clone()).collect();
         let sources: Vec<&str> = prefixed.iter().map(|s| s.as_str()).collect();
 
         // TranslationOptions with good defaults
@@ -167,13 +178,16 @@ impl CT2Translator {
             .translate_batch_with_target_prefix(&sources, &target_prefix, &options, None)
             .map_err(|e| format!("Translation failed: {}", e))?;
 
-        // Extract translations from results
-        let translations: Vec<String> = results
-            .into_iter()
-            .map(|(translation, _score)| translation)
-            .collect();
+        // Extract translations from results, re-interleaving empty
+        // strings at the positions whose inputs we skipped above.
+        let mut output = vec![String::new(); texts.len()];
+        for ((orig_idx, _), (translation, _score)) in
+            non_empty.iter().zip(results.into_iter())
+        {
+            output[*orig_idx] = translation;
+        }
 
-        Ok(translations)
+        Ok(output)
     }
 
     /// Translate a single text

--- a/ClassNoteAI/src/components/LectureView.tsx
+++ b/ClassNoteAI/src/components/LectureView.tsx
@@ -536,7 +536,7 @@ export default function LectureView() {
               <div className="flex items-center gap-2">
                 <span className="text-sm text-gray-600 dark:text-gray-400 truncate max-w-md">
                   {pdfPath
-                    ? (pdfPath.startsWith('blob:') ? '拖放的文件' : pdfPath.split(/[/\\]/).pop())
+                    ? (pdfPath.startsWith('blob:') ? '拖放的文件' : pdfPath.split('?')[0].split('#')[0].split(/[/\\]/).pop())
                     : '已選擇的 PDF 文件'}
                 </span>
               </div>

--- a/ClassNoteAI/src/components/NotesView.tsx
+++ b/ClassNoteAI/src/components/NotesView.tsx
@@ -1311,7 +1311,7 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
                   {(pdfPath || pdfData) && (
                     <div className="px-4 py-2 bg-white dark:bg-slate-800 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
                       <span className="text-sm text-gray-600 dark:text-gray-400 truncate max-w-md">
-                        {pdfPath ? (pdfPath.startsWith('blob:') ? 'Dropped File' : pdfPath.split(/[/\\]/).pop()) : 'Selected PDF'}
+                        {pdfPath ? (pdfPath.startsWith('blob:') ? 'Dropped File' : pdfPath.split('?')[0].split('#')[0].split(/[/\\]/).pop()) : 'Selected PDF'}
                       </span>
                       <button onClick={handleSelectPDF} className="px-3 py-1 text-sm rounded hover:bg-gray-100 dark:hover:bg-gray-700 transition-colors">
                         Change


### PR DESCRIPTION
## Summary

Cross-platform cleanups surfaced by the pre-tag code review. All are defensive or parity fixes — no user-visible behavior change for the happy path.

- **translation/ctranslate2.rs** — skip empty / whitespace-only entries in \`translate_batch\`, preserve original indices in output so callers can zip \`input[i] ↔ output[i]\`. Feeding M2M100 only the source token produces garbage / stalls beam search.
- **setup/requirements.rs** — pass the drive probe path to PowerShell via \`\$args[0]\` instead of string-interpolating into \`-Command\`. Backticks / \$ / apostrophes in APPDATA (legal Windows username characters) can no longer inject.
- **components/NotesView.tsx + LectureView.tsx** — strip \`?\` query and \`#\` fragment from \`pdfPath\` before the basename split so a file path carrying query params still renders as \"file.pdf\".
- **.github/workflows/release-macos.yml** — add explicit \`npm run build\` step to match \`release-windows.yml\`. Still covered by \`beforeBuildCommand\`, but accidental removal of that hook now fails loudly here instead of silently shipping stale JS.

## Out of scope (tracked for v0.5.2)

- OAuth port-fallback race between listener bind and browser open — needs Tauri command split, too invasive for v0.5.1.
- \`commitStableText\` dedup edge cases on legitimate repeated phrases.
- GitHub Models fallback model-ID verification against live catalog.
- Single-\`latest.json\` updater endpoint vs per-platform manifests — pre-existing (v0.5.0), not a v0.5.1 regression.

## Test plan

- [x] \`cargo check --lib\` passes on Windows
- [x] \`tsc --noEmit\` passes
- [ ] CI \`pr-check-macos\` + \`pr-check-windows\` green