### PR TITLE
ci(updater): merge per-platform manifest fragments into unified latest.json (v0.5.2, closes #33)

### DIFF
--- a/.github/workflows/merge-update-manifest.yml
+++ b/.github/workflows/merge-update-manifest.yml
@@ -130,3 +130,17 @@ jobs:
           gh release upload "$TAG" latest.json \
             -R "${GITHUB_REPOSITORY}" \
             --clobber
+
+      # Both release workflows upload as draft so users never see a
+      # half-populated release. Now that both platforms' assets are
+      # on the release AND the merged latest.json is uploaded, flip
+      # the draft to published.
+      - name: Publish release
+        if: steps.wait.outputs.ok == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.ctx.outputs.tag }}
+        run: |
+          gh release edit "$TAG" \
+            -R "${GITHUB_REPOSITORY}" \
+            --draft=false

--- a/.github/workflows/merge-update-manifest.yml
+++ b/.github/workflows/merge-update-manifest.yml
@@ -1,0 +1,132 @@
+name: Merge Update Manifest
+
+# Fires after either release workflow completes on a tag. Waits for the peer
+# release workflow to also finish successfully, then downloads both per-platform
+# manifest fragments from the release and merges them into a single
+# `latest.json` with both `darwin-aarch64` and `windows-x86_64` entries.
+#
+# The Tauri updater in v0.5.1+ reads a single URL from each binary's
+# compiled-in `tauri.conf.json`:
+#   https://github.com/.../releases/latest/download/latest.json
+#
+# Without a merged manifest, Windows clients find no `windows-x86_64` entry
+# (macOS-only `latest.json`) and silently report "no update." This workflow
+# closes that gap server-side, so v0.5.1 Windows users can auto-update to
+# v0.5.2+ without re-downloading the MSI. See issue #33.
+
+on:
+  workflow_run:
+    workflows:
+      - "Build and Release (macOS)"
+      - "Build and Release (Windows)"
+    types:
+      - completed
+
+permissions:
+  contents: write
+
+jobs:
+  merge:
+    # Only proceed when the triggering workflow succeeded AND was triggered
+    # by a tag push (head_branch is the tag name for tag-triggered runs,
+    # e.g. "v0.5.2").
+    if: >
+      github.event.workflow_run.conclusion == 'success' &&
+      startsWith(github.event.workflow_run.head_branch, 'v')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Determine tag + peer workflow
+        id: ctx
+        env:
+          THIS: ${{ github.event.workflow_run.name }}
+          TAG: ${{ github.event.workflow_run.head_branch }}
+        run: |
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+          case "$THIS" in
+            "Build and Release (macOS)")   echo "peer=Build and Release (Windows)" >> "$GITHUB_OUTPUT" ;;
+            "Build and Release (Windows)") echo "peer=Build and Release (macOS)"   >> "$GITHUB_OUTPUT" ;;
+            *) echo "Unknown triggering workflow: $THIS"; exit 1 ;;
+          esac
+
+      - name: Wait for peer release workflow
+        id: wait
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.ctx.outputs.tag }}
+          PEER: ${{ steps.ctx.outputs.peer }}
+        run: |
+          # Poll for the peer workflow's run on the same tag to complete.
+          # Timeout after ~40 min (release bundles historically 15–20 min each,
+          # but allow generous slack for cache misses + queue time).
+          for i in $(seq 1 40); do
+            PEER_RUN=$(gh run list \
+              -R "${GITHUB_REPOSITORY}" \
+              --workflow "$PEER" \
+              --branch "$TAG" \
+              --limit 1 \
+              --json status,conclusion \
+              --jq '.[0]')
+            STATUS=$(echo "$PEER_RUN" | jq -r '.status // "missing"')
+            CONCLUSION=$(echo "$PEER_RUN" | jq -r '.conclusion // ""')
+            echo "attempt=$i peer status=$STATUS conclusion=$CONCLUSION"
+            if [ "$STATUS" = "completed" ]; then
+              if [ "$CONCLUSION" = "success" ]; then
+                echo "ok=true" >> "$GITHUB_OUTPUT"
+                exit 0
+              else
+                echo "Peer finished with non-success conclusion ($CONCLUSION) — aborting merge."
+                exit 0
+              fi
+            fi
+            sleep 60
+          done
+          echo "Peer did not complete within 40 minutes."
+
+      - name: Download manifest fragments
+        if: steps.wait.outputs.ok == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.ctx.outputs.tag }}
+        run: |
+          gh release download "$TAG" \
+            -R "${GITHUB_REPOSITORY}" \
+            --pattern "latest-macos-aarch64.json" \
+            --pattern "latest-windows-x86_64.json" \
+            --clobber
+
+      - name: Merge into latest.json
+        if: steps.wait.outputs.ok == 'true'
+        run: |
+          # Take version/notes/pub_date from the macOS fragment (arbitrary —
+          # both fragments carry the same version for a given tag) and union
+          # the `platforms` objects.
+          jq -s '.[0] * {platforms: (.[0].platforms + .[1].platforms)}' \
+            latest-macos-aarch64.json \
+            latest-windows-x86_64.json \
+            > latest.json
+          echo "--- merged latest.json ---"
+          cat latest.json
+
+      - name: Sanity check merged manifest
+        if: steps.wait.outputs.ok == 'true'
+        run: |
+          # Both platform keys must be present, otherwise we would regress
+          # the very bug this workflow was added to fix.
+          for key in "darwin-aarch64" "windows-x86_64"; do
+            if ! jq -e ".platforms[\"$key\"].url" latest.json > /dev/null; then
+              echo "ERROR: merged latest.json missing platforms.$key.url"
+              cat latest.json
+              exit 1
+            fi
+          done
+          echo "OK: latest.json has both platforms."
+
+      - name: Upload merged manifest
+        if: steps.wait.outputs.ok == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          TAG: ${{ steps.ctx.outputs.tag }}
+        run: |
+          gh release upload "$TAG" latest.json \
+            -R "${GITHUB_REPOSITORY}" \
+            --clobber

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -119,11 +119,15 @@ jobs:
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
         working-directory: .
 
-      - name: Generate latest.json for updater
+      # Per-platform manifest fragment. The unified `latest.json` is produced
+      # later by `merge-update-manifest.yml` once both release workflows
+      # finish, so a v0.5.1 Windows client polling `latest.json` sees BOTH
+      # platforms. See #33 for why the server-side merge is required.
+      - name: Generate macOS updater manifest fragment
         if: startsWith(github.ref, 'refs/tags/')
         run: |
           VERSION="${{ steps.get_version.outputs.VERSION }}"
-          cat > latest.json << EOF
+          cat > latest-macos-aarch64.json << EOF
           {
             "version": "${VERSION}",
             "notes": "ClassNoteAI ${VERSION} 更新",
@@ -142,13 +146,13 @@ jobs:
         run: |
           VERSION="${{ steps.get_version.outputs.VERSION }}"
           mkdir -p release-assets
-          
+
           # Apple Silicon
           cp src-tauri/target/aarch64-apple-darwin/release/bundle/dmg/*.dmg "release-assets/ClassNoteAI_${VERSION}_aarch64.dmg" || true
           cp src-tauri/target/aarch64-apple-darwin/release/bundle/macos/*.app.tar.gz "release-assets/ClassNoteAI_${VERSION}_aarch64.app.tar.gz" || true
-          
-          # latest.json
-          cp latest.json release-assets/
+
+          # per-platform updater fragment
+          cp latest-macos-aarch64.json release-assets/
 
       - name: Generate Changelog
         if: startsWith(github.ref, 'refs/tags/')

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -220,7 +220,11 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
         with:
-          draft: false
+          # Upload as draft. The release is flipped to published by
+          # merge-update-manifest.yml once both platforms' builds have
+          # succeeded and the unified latest.json is uploaded. This way,
+          # users never see a half-populated release.
+          draft: true
           prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') }}
           files: |
             ClassNoteAI/release-assets/*

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -149,7 +149,11 @@ jobs:
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1
         with:
-          draft: false
+          # Upload as draft. The release is flipped to published by
+          # merge-update-manifest.yml once both platforms' builds have
+          # succeeded and the unified latest.json is uploaded. This way,
+          # users never see a half-populated release.
+          draft: true
           prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') }}
           files: |
             ClassNoteAI/release-assets/*

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -155,15 +155,10 @@ jobs:
             ClassNoteAI/release-assets/*
 
 # NOTES ----------------------------------------------------------------
-# Tauri updater expects a single `latest.json` listing all platforms.
 # This workflow uploads `latest-windows-x86_64.json`; the macOS workflow
-# uploads its own fragment. Add a final job (in either workflow or a
-# third `merge-updater-manifest.yml` that runs on release:published) to
-# download both fragments from the release, merge their `.platforms`
-# objects, and upload `latest.json`. Until that exists, point
-# `tauri.conf.json -> plugins.updater.endpoints` at multiple URLs so the
-# client falls back:
-#   "endpoints": [
-#     "https://github.com/<you>/<repo>/releases/latest/download/latest-macos-aarch64.json",
-#     "https://github.com/<you>/<repo>/releases/latest/download/latest-windows-x86_64.json"
-#   ]
+# uploads `latest-macos-aarch64.json`. Neither alone is a valid Tauri
+# updater manifest. The unified `latest.json` (which a v0.5.1+ client
+# polls via the single endpoint compiled into its binary) is produced
+# by `.github/workflows/merge-update-manifest.yml`, which fires once
+# both release workflows finish on a tag and merges both fragments.
+# See issue #33.


### PR DESCRIPTION
## Summary

Closes #33. First v0.5.2 PR. Two related release-pipeline fixes:

### A. Unified update manifest

v0.5.1 Windows clients cannot auto-update because \`releases/latest/download/latest.json\` (the single endpoint baked into every binary) was written only by release-macos.yml and omits the \`windows-x86_64\` platform entry. The endpoint is compile-time, so no client-side fix in v0.5.2 can unblock v0.5.1 — we have to fix what the server serves.

- \`release-macos.yml\` now uploads \`latest-macos-aarch64.json\` (per-platform fragment) instead of \`latest.json\`.
- \`release-windows.yml\` already uploaded \`latest-windows-x86_64.json\`; no build change, just refreshed the NOTES block.
- **\`merge-update-manifest.yml\` (NEW)** — fires on \`workflow_run.completed\` of either release workflow, waits up to ~40 min for the peer to succeed on the same tag, downloads both fragments, \`jq\`-merges them, sanity-checks that both \`darwin-aarch64\` and \`windows-x86_64\` are present, and uploads \`latest.json\` with \`--clobber\`.

### B. Release stays hidden until both platforms done

v0.5.1 exposed a half-populated release for >40 minutes while Windows was still building — macOS assets visible on the releases page, no EXE/MSI yet. Fixed:

- Both release workflows now set \`draft: true\` on \`softprops/action-gh-release@v1\`.
- \`merge-update-manifest.yml\` flips draft → published as its final step, after both platforms' assets + the merged manifest are attached.
- If either build fails, the draft stays hidden for maintainer investigation — no broken release is ever visible.

### Why this unblocks v0.5.1

\`/releases/latest/download/latest.json\` always redirects to the newest release's asset. When v0.5.2 ships through this pipeline, that URL returns the merged manifest. v0.5.1 Windows users check for updates → find \`windows-x86_64\` entry → auto-update installs the v0.5.2 NSIS bundle.

### Test plan

- [x] \`cargo check\` + \`tsc\` untouched (no app-code changes)
- [x] YAML validated via js-yaml parse
- [ ] pr-check-macos + pr-check-windows CI green
- [ ] Post-merge, next tag push: release stays draft until both platforms done, then publishes with a unified \`latest.json\` containing both platforms.

### Risk

- If either release workflow fails, the merge exits early AND the release stays draft (user investigates). Same exposure as today's failure mode, minus the broken-half-release.
- \`gh release download\` / \`upload\` / \`edit\` all work on drafts with a token that has \`contents: write\` — granted in the workflow.