### PR TITLE
ci(pr-check): run cargo test --lib in CI

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -76,6 +76,14 @@ jobs:
         working-directory: ClassNoteAI/src-tauri
         run: cargo check --message-format=short
 
+      # Run Rust unit tests from the lib target. Excludes #[ignore]'d tests
+      # (e.g. ones that need network or a real model checkpoint on disk) so
+      # PR feedback stays quick and hermetic. Integration tests that need
+      # big model fixtures live in a separate nightly workflow.
+      - name: cargo test (lib)
+        working-directory: ClassNoteAI/src-tauri
+        run: cargo test --lib --message-format=short -- --nocapture
+
   pr-check-windows:
     name: pr-check-windows
     runs-on: windows-latest
@@ -136,3 +144,14 @@ jobs:
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           cd src-tauri
           cargo check --message-format=short
+
+      - name: cargo test (lib)
+        shell: cmd
+        env:
+          LIBCLANG_PATH: ${{ runner.temp }}\llvm\bin
+          CMAKE_GENERATOR: Visual Studio 17 2022
+          CMAKE_TOOLCHAIN_FILE: ${{ github.workspace }}\ClassNoteAI\src-tauri\scripts\win-toolchain.cmake
+        run: |
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          cd src-tauri
+          cargo test --lib --message-format=short -- --nocapture


### PR DESCRIPTION
## Summary

CI currently only runs `cargo check` — the 36 `#[test]` functions already in the Rust backend never actually execute on PRs. This PR adds a `cargo test --lib` step to the macOS and Windows `pr-check` jobs so they do.

## Motivation

Today's debugging session found that:
- `src-tauri/src/embedding/service.rs` has the model-load bug (nomic architecture incompat with Candle's stock BertModel) — **0 tests**, and wouldn't have been caught even if tests existed, because CI doesn't run them.
- `src-tauri/src/whisper/transcribe.rs` hardcodes \`params.set_language(\"en\")\` regardless of user config — **0 tests**, same problem.

This is the foundation PR: gets `cargo test` actually running. A separate follow-up PR will add the regression tests that protect against those two specific bugs reoccurring (and fix them structurally).

## What's included

- Add `cargo test --lib --message-format=short -- --nocapture` after `cargo check` on both runners
- Windows job reuses the same vcvars64 + LIBCLANG_PATH + CMAKE_TOOLCHAIN_FILE env as `cargo check`
- `--lib` scope intentionally excludes integration tests that would need big model fixtures (~GB)
- `#[ignore]`'d tests (e.g. the google translate test that needs an API key) continue to be skipped

## Test plan

- [ ] macOS `pr-check-macos` passes — `cargo test --lib` runs the existing 36 tests
- [ ] Windows `pr-check-windows` passes — same
- [ ] If any existing test is broken by env quirks on CI, fix it in this PR before merge
- [ ] Timing: target <+3 min per runner over current `cargo check`-only runtime

## Follow-up PR (not here)

- P0.1 Embedding swap (nomic → bge-small-en) + cross-lingual translate-query + regression test
- P0.2 Whisper language param propagation fix + regression test
- P0.3 Crash recovery / incremental WAV persistence + regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)