### PR TITLE
fix(v0.5.2): audit follow-ups — PDF/note/subtitle/migration

### DIFF
--- a/ClassNoteAI/src-tauri/src/lib.rs
+++ b/ClassNoteAI/src-tauri/src/lib.rs
@@ -1822,6 +1822,8 @@ pub fn run() {
             get_audio_dir,
             get_documents_dir,
             try_recover_audio_path,
+            try_recover_pdf_path,
+            consume_migration_notices,
             // Offline Queue
             add_pending_action,
             list_pending_actions,
@@ -1850,6 +1852,102 @@ pub fn run() {
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
+}
+
+/// Returns + clears any migration notices the DB init queued up.
+///
+/// Called by the frontend at app-ready so the user sees a toast when
+/// an irreversible migration touched their data (e.g. v0.5.2's drop
+/// of old-dimension embedding vectors). Drain-once semantics — if
+/// the frontend calls twice without a new migration running, the
+/// second call returns empty.
+#[tauri::command]
+async fn consume_migration_notices() -> Result<Vec<String>, String> {
+    Ok(storage::drain_migration_notices())
+}
+
+/// Attempt to recover a missing `lecture.pdf_path`.
+///
+/// Mirrors `try_recover_audio_path`. If the DB column is empty but a
+/// file matching `lecture_<id>_*` exists in `{app_data}/lecture-pdfs/`,
+/// pick the newest and relink it. Orphans can happen when
+/// `write_temp_file` succeeded but the subsequent `save_lecture`
+/// failed (logged-only before v0.5.2 audit fix).
+#[tauri::command]
+async fn try_recover_pdf_path(lecture_id: String) -> Result<Option<String>, String> {
+    use std::fs;
+
+    let manager = storage::get_db_manager()
+        .await
+        .map_err(|e| format!("DB Error: {}", e))?;
+    let db = manager
+        .get_db()
+        .map_err(|e| format!("DB Connection Error: {}", e))?;
+
+    let lecture_opt = db
+        .get_lecture(&lecture_id)
+        .map_err(|e| format!("Get Lecture Error: {}", e))?;
+
+    if let Some(ref lecture) = lecture_opt {
+        if let Some(ref path) = lecture.pdf_path {
+            if !path.is_empty() {
+                return Ok(Some(path.clone()));
+            }
+        }
+    } else {
+        return Ok(None);
+    }
+
+    let pdfs_dir = paths::get_lecture_pdfs_dir().map_err(|e| format!("Path Error: {}", e))?;
+    if !pdfs_dir.exists() {
+        return Ok(None);
+    }
+
+    // Look for `lecture_<id>_*.pdf` (or any extension) — pick newest.
+    let prefix = format!("lecture_{}_", lecture_id);
+    let mut candidates: Vec<(std::path::PathBuf, std::time::SystemTime)> = Vec::new();
+    if let Ok(entries) = fs::read_dir(&pdfs_dir) {
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if !path.is_file() {
+                continue;
+            }
+            let name = match path.file_name().and_then(|n| n.to_str()) {
+                Some(s) => s,
+                None => continue,
+            };
+            if !name.starts_with(&prefix) {
+                continue;
+            }
+            let mtime = entry
+                .metadata()
+                .and_then(|m| m.modified())
+                .unwrap_or(std::time::UNIX_EPOCH);
+            candidates.push((path, mtime));
+        }
+    }
+    candidates.sort_by(|a, b| b.1.cmp(&a.1));
+    let recovered = match candidates.into_iter().next() {
+        Some((p, _)) => p,
+        None => return Ok(None),
+    };
+
+    let path_str = recovered.to_string_lossy().to_string();
+    println!("[Recovery] 找到丟失的 PDF 文件: {}", path_str);
+
+    if let Some(mut lecture) = db.get_lecture(&lecture_id).unwrap_or(None) {
+        lecture.pdf_path = Some(path_str.clone());
+        let user_id = if let Some(course) = db.get_course(&lecture.course_id).unwrap_or(None) {
+            course.user_id
+        } else {
+            "default_user".to_string()
+        };
+        db.save_lecture(&lecture, &user_id)
+            .map_err(|e| format!("Update DB Error: {}", e))?;
+        return Ok(Some(path_str));
+    }
+
+    Ok(None)
 }
 
 /// 嘗試恢復丟失的 audio_path.

--- a/ClassNoteAI/src-tauri/src/paths/app_dirs.rs
+++ b/ClassNoteAI/src-tauri/src/paths/app_dirs.rs
@@ -80,6 +80,18 @@ pub fn get_documents_dir() -> Result<PathBuf, String> {
     Ok(get_app_data_dir()?.join("documents"))
 }
 
+/// Get the lecture-PDFs directory.
+///
+/// Returns: {app_data_dir}/lecture-pdfs/
+///
+/// Where the frontend writes a PDF the user drops onto a lecture. The
+/// filename convention since v0.5.2 is `lecture_<id>_<unix_ms>_<name>.pdf`
+/// so `try_recover_pdf_path` can reverse-map a file back to its lecture
+/// when the DB column was never populated (write-succeeded-DB-save-failed).
+pub fn get_lecture_pdfs_dir() -> Result<PathBuf, String> {
+    Ok(get_app_data_dir()?.join("lecture-pdfs"))
+}
+
 /// Get the audio directory
 ///
 /// Returns: {app_data_dir}/audio/

--- a/ClassNoteAI/src-tauri/src/storage/database.rs
+++ b/ClassNoteAI/src-tauri/src/storage/database.rs
@@ -2,6 +2,35 @@ use crate::storage::models::{Course, Lecture, Note, Setting, Subtitle};
 use chrono::Utc;
 use rusqlite::{Connection, Result as SqlResult};
 use std::path::PathBuf;
+use std::sync::{Mutex, OnceLock};
+
+/// Global queue of "things the user deserves to know about" that ran
+/// during DB init — principally irreversible migrations that touched
+/// user data (e.g. dropping stale embedding vectors on the v0.5.2
+/// model swap). The frontend drains this via `consume_migration_notices`
+/// on app-ready and toasts each entry, so the user finds out about
+/// a silent background change instead of discovering it weeks later.
+/// Drops are logged to stdout in addition so the record survives the
+/// consume-once flow.
+static MIGRATION_NOTICES: OnceLock<Mutex<Vec<String>>> = OnceLock::new();
+
+fn migration_notices() -> &'static Mutex<Vec<String>> {
+    MIGRATION_NOTICES.get_or_init(|| Mutex::new(Vec::new()))
+}
+
+pub fn record_migration_notice(msg: String) {
+    if let Ok(mut v) = migration_notices().lock() {
+        v.push(msg);
+    }
+}
+
+pub fn drain_migration_notices() -> Vec<String> {
+    if let Ok(mut v) = migration_notices().lock() {
+        std::mem::take(&mut *v)
+    } else {
+        Vec::new()
+    }
+}
 
 /// 數據庫管理器
 pub struct Database {
@@ -521,6 +550,10 @@ impl Database {
                 "DELETE FROM embeddings WHERE LENGTH(embedding) != ?1",
                 [EXPECTED_EMBEDDING_BYTES],
             )?;
+            record_migration_notice(format!(
+                "v0.5.2: 已清除 {} 筆舊 embedding 向量（768→384 維模型切換）。該堂課的 AI 助教功能在首次打開時會自動重新索引。",
+                mismatched
+            ));
         }
 
         Ok(())

--- a/ClassNoteAI/src-tauri/src/storage/mod.rs
+++ b/ClassNoteAI/src-tauri/src/storage/mod.rs
@@ -1,7 +1,7 @@
 pub mod database;
 pub mod models;
 
-pub use database::{Database, EmbeddingRow};
+pub use database::{drain_migration_notices, Database, EmbeddingRow};
 pub use models::{Course, Lecture, Note, Setting, Subtitle};
 
 use rusqlite::Result as SqlResult;

--- a/ClassNoteAI/src/App.tsx
+++ b/ClassNoteAI/src/App.tsx
@@ -51,6 +51,33 @@ function App() {
     initTheme();
   }, []);
 
+  // v0.5.2 audit follow-up: surface migration notices to the user.
+  // The DB init runs migrations eagerly (e.g. dropping stale embedding
+  // vectors on model swaps). Previously those only hit stdout, so users
+  // had no way to know their RAG index silently got wiped until they
+  // noticed AI 助教 stopped returning relevant passages. Now we drain
+  // the in-memory notice queue on app-ready and toast each one.
+  useEffect(() => {
+    if (appState !== 'ready') return;
+    const t = setTimeout(async () => {
+      try {
+        const { invoke } = await import('@tauri-apps/api/core');
+        const notices = await invoke<string[]>('consume_migration_notices');
+        if (notices.length > 0) {
+          const { toastService } = await import('./services/toastService');
+          for (const msg of notices) {
+            // `durationMs: 0` → sticky; these are important enough that
+            // auto-dismiss would be the wrong default.
+            toastService.show({ message: '資料庫遷移通知', detail: msg, type: 'warning', durationMs: 0 });
+          }
+        }
+      } catch (err) {
+        console.warn('[App] consume_migration_notices failed (non-fatal):', err);
+      }
+    }, 2000);
+    return () => clearTimeout(t);
+  }, [appState]);
+
   // v0.5.2: crash-recovery scan on launch. If the app died mid-
   // recording last session, there's a .pcm file on disk and a DB row
   // stuck at status='recording'. We populate `recoverableSessions`

--- a/ClassNoteAI/src/components/NotesView.tsx
+++ b/ClassNoteAI/src/components/NotesView.tsx
@@ -603,6 +603,23 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
           try {
             // ...
           } catch (e) { /* ... */ }
+        } else {
+          // v0.5.2 audit follow-up: attempt PDF recovery when DB column
+          // is empty. `try_recover_pdf_path` looks for `lecture_<id>_*`
+          // files in the lecture-pdfs dir (the filename convention
+          // used for all newly-dropped PDFs since v0.5.2). If it finds
+          // one, DB is relinked and we use the recovered path.
+          try {
+            const recoveredPdf = await invoke<string | null>('try_recover_pdf_path', { lectureId: lecture.id });
+            if (recoveredPdf) {
+              console.log('[NotesView] PDF path recovered:', recoveredPdf);
+              lecture.pdf_path = recoveredPdf;
+              setPdfPath(recoveredPdf);
+              setCurrentLectureData({ ...lecture });
+            }
+          } catch (e) {
+            console.warn('[NotesView] PDF recovery attempt failed (non-fatal):', e);
+          }
         }
 
         // Try to recover audio path if missing (Fix for Schema migration issue)
@@ -1061,14 +1078,37 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
           generated_at: now,
         };
 
-        try {
-          await storageService.saveNote(note);
+        // v0.5.2 audit follow-up: never show the user an in-UI note that
+        // isn't actually in the DB. The old path did
+        // `setSelectedNote(note)` in the catch block too, which meant
+        // the user could edit a "note" they saw, close the app, and
+        // the edits would vanish silently on reload. Now: if the save
+        // fails, we retry once (network blip / lock contention), and
+        // on second failure we toast an explicit error AND leave
+        // `selectedNote` at its prior value (which may be null —
+        // fine, the summary generator still works manually).
+        let noteSaved = false;
+        let lastSaveErr: unknown = null;
+        for (let attempt = 0; attempt < 2 && !noteSaved; attempt++) {
+          try {
+            await storageService.saveNote(note);
+            noteSaved = true;
+          } catch (noteError) {
+            lastSaveErr = noteError;
+            console.warn(`[NotesView] Note save attempt ${attempt + 1} failed:`, noteError);
+            if (attempt === 0) await new Promise((r) => setTimeout(r, 250));
+          }
+        }
+        if (noteSaved) {
           setSelectedNote(note);
           console.log('[NotesView] Note auto-generated with', sections.length, 'sections');
-        } catch (noteError) {
-          console.error('[NotesView] Failed to save auto-generated note:', noteError);
-          // Still show the note in UI even if DB save failed
-          setSelectedNote(note);
+        } else {
+          console.error('[NotesView] Auto-generated note save failed after retry:', lastSaveErr);
+          toastService.error(
+            '自動筆記儲存失敗',
+            '錄音和字幕已保存；重新打開此課堂時系統會再次嘗試產生筆記。' +
+              (lastSaveErr instanceof Error ? ` (${lastSaveErr.message})` : ''),
+          );
         }
         // ===== END AUTO-GENERATE NOTE =====
       }
@@ -1175,16 +1215,42 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
           const appData = await invoke<string>('get_app_data_dir');
           const sep = navigator.userAgent.includes('Windows') ? '\\' : '/';
           const safeName = file.name.replace(/[^A-Za-z0-9._-]/g, '_');
-          const target = `${appData}${sep}lecture-pdfs${sep}${Date.now()}-${safeName}`;
+          // v0.5.2 audit follow-up: prefix the filename with the
+          // lecture id. The prior scheme was `{ts}-{name}.pdf` which
+          // had no link back to the lecture, so a `write_temp_file`
+          // success followed by an `updateLecturePDF` DB failure left
+          // an orphan file we couldn't auto-recover. The new pattern
+          // `lecture_{id}_{ts}_{name}.pdf` mirrors the audio convention
+          // and is what `try_recover_pdf_path` (next commit) scans for.
+          const target = `${appData}${sep}lecture-pdfs${sep}lecture_${currentLectureData?.id ?? 'unknown'}_${Date.now()}_${safeName}`;
           await invoke('write_temp_file', {
             path: target,
             data: Array.from(new Uint8Array(arrayBuffer)),
           });
           setPdfPath(target);
-          await updateLecturePDF(target);
+          try {
+            await updateLecturePDF(target);
+          } catch (dbErr) {
+            // The FILE is already on disk at `target`. Surface the DB
+            // failure to the user so they know to retry — previously
+            // this was only `console.error`, so the UI showed the PDF
+            // loaded (from in-memory buffer) but the DB didn't know
+            // about it, and the PDF vanished on next reload. With the
+            // new filename pattern, `try_recover_pdf_path` will recover
+            // on next load anyway, but a loud toast prevents confusion.
+            console.error('[NotesView] PDF file written but DB save failed:', dbErr);
+            toastService.error(
+              'PDF 已儲存但資料庫更新失敗',
+              '下次開啟此課堂時系統會自動重新連結。' +
+                (dbErr instanceof Error ? ` (${dbErr.message})` : ''),
+            );
+          }
         } catch (err) {
           console.error('[NotesView] Failed to persist dropped PDF:', err);
-          // Fallback: at least the in-memory buffer still drives the viewer
+          toastService.error(
+            'PDF 儲存失敗',
+            err instanceof Error ? err.message : String(err),
+          );
           setPdfPath(null);
         }
       };

--- a/ClassNoteAI/src/services/transcriptionService.ts
+++ b/ClassNoteAI/src/services/transcriptionService.ts
@@ -129,7 +129,27 @@ export class TranscriptionService {
     }
     // Fire one last fine-refinement flush so trailing segments also get
     // the LLM pass before we persist them.
-    void this.flushFineRefinement().finally(() => this.savePendingSubtitles());
+    //
+    // v0.5.2 audit follow-up: the old form
+    // `void this.flushFineRefinement().finally(() => this.savePendingSubtitles())`
+    // swallowed BOTH exceptions silently. If the fine-refinement LLM
+    // call 429'd or the persist call hit a DB lock, no retry, no log,
+    // no visible error. Now we explicitly log each leg so `console.error`
+    // produces actionable output, and the save still fires regardless
+    // of refinement outcome (saving rough-only subtitles is strictly
+    // better than saving nothing).
+    void (async () => {
+      try {
+        await this.flushFineRefinement();
+      } catch (err) {
+        console.error('[TranscriptionService] final flushFineRefinement failed:', err);
+      }
+      try {
+        await this.savePendingSubtitles();
+      } catch (err) {
+        console.error('[TranscriptionService] final savePendingSubtitles failed:', err);
+      }
+    })();
   }
 
   private async savePendingSubtitles(): Promise<void> {


### PR DESCRIPTION
## Summary

Four items from the flow-correctness audit (post PR #39). Each addresses a bug analogous to the audio-flow root-cause previously fixed.

### 1. PDF `try_recover_pdf_path`

Before: dropped PDF saved as `{app_data}/lecture-pdfs/{ts}-{name}.pdf` (no lecture id in filename), then `updateLecturePDF` wrote the path to DB. A silent DB-write failure left the file on disk unreachable — no way to recover since filename ↔ lecture mapping was gone.

Now:
- Filename pattern includes lecture id: `lecture-pdfs/lecture_{id}_{ts}_{name}.pdf`
- New `try_recover_pdf_path(lecture_id)` Tauri command scans for matches, picks newest
- `loadLecture` calls it when `pdf_path` is null
- DB-save failure after a successful file-write toasts loud ("PDF 已儲存但資料庫更新失敗；下次開啟此課堂時系統會自動重新連結")

### 2. Note auto-gen save reliability

Before: if `saveNote()` threw, `handleSaveLecture` still called `setSelectedNote(note)` — UI showed a note the DB didn't have. User edits → closes app → edits vanished on reload.

Now: retry once with 250 ms backoff; on second failure leave `selectedNote` unchanged and toast explicit error ("錄音和字幕已保存；重新打開此課堂時系統會再次嘗試產生筆記").

### 3. Subtitle `flushFineRefinement` error swallow

Before: `void this.flushFineRefinement().finally(() => this.savePendingSubtitles())` — both promises swallowed into `void`. Failed LLM flush or DB-lock on persist produced no log, no retry, no visible error.

Now: explicit async IIFE with try/catch on each leg; each failure console.errors with context. Save still fires regardless of refinement outcome.

### 4. v0.5.2 migration toast to UI

Before: init-time embedding dim-mismatch migration dropped stale vectors with `println!` only. Users had no way to know their AI 助教 index got wiped.

Now:
- `database.rs` static `MIGRATION_NOTICES` mutex that `record_migration_notice(...)` pushes into
- New `consume_migration_notices` Tauri command drains it (called once per app-ready)
- Each notice toasts as sticky warning with specific text ("v0.5.2: 已清除 N 筆舊 embedding 向量...")

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 166 passing (no behaviour change in tested code paths)
- [ ] PR CI green on macOS + Windows (cargo test + tsc + vitest)
- [ ] Manual: drop PDF, delete pdf_path from DB manually, reload lecture → recovery auto-picks the file
- [ ] Manual: cause a `saveNote` failure (DB locked) → toast appears, selectedNote unchanged
- [ ] Manual: trigger embedding migration (simulate old nomic-dim row) → sticky toast on next launch

🤖 Generated with [Claude Code](https://claude.com/claude-code)