### PR TITLE
feat(rag): hybrid BM25 + RRF fusion (F2 lower half)

### DIFF
--- a/ClassNoteAI/docs/follow-ups/v0.5.2-deferred.md
+++ b/ClassNoteAI/docs/follow-ups/v0.5.2-deferred.md
@@ -1,9 +1,17 @@
 # v0.5.2 Deferred Follow-ups
 
-Items identified during the v0.5.2 deep-dive that were NOT implemented
-autonomously overnight because they carry real regression risk or
-need human design calls. Each entry has enough context to be picked
-up as a standalone PR.
+Items identified during the v0.5.2 deep-dive. Each has enough context
+to be picked up as a standalone PR.
+
+## Status summary (2026-04-18)
+
+- ✅ F4 Topic-based section boundaries — shipped in PR #41
+- ✅ F5 Recovery modal polish (bulk actions) — shipped in PR #41
+- ✅ F6 Eval harness accepts pre-computed hypotheses — shipped in PR #41
+- ✅ F2 lower half: Hybrid BM25 + RRF fusion — shipped in hybrid-bm25 PR
+- ⚠️ F1 Silero VAD — **still deferred**, see §F1 below for protobuf-conflict blocker
+- ⚠️ F2 upper half: cross-encoder reranker — **still deferred**, +550MB model cost
+- ⚠️ F3 sqlite-vec HNSW — **still deferred**, per-platform native extension risk
 
 ---
 

--- a/ClassNoteAI/package-lock.json
+++ b/ClassNoteAI/package-lock.json
@@ -16,6 +16,7 @@
         "@tauri-apps/plugin-process": "^2.3.1",
         "@tauri-apps/plugin-updater": "^2.9.0",
         "lucide-react": "^0.555.0",
+        "minisearch": "^7.2.0",
         "pdfjs-dist": "^5.4.449",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -5043,6 +5044,12 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/minisearch": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/minisearch/-/minisearch-7.2.0.tgz",
+      "integrity": "sha512-dqT2XBYUOZOiC5t2HRnwADjhNS2cecp9u+TJRiJ1Qp/f5qjkeT5APcGPjHw+bz89Ms8Jp+cG4AlE+QZ/QnDglg==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",

--- a/ClassNoteAI/package.json
+++ b/ClassNoteAI/package.json
@@ -28,6 +28,7 @@
     "@tauri-apps/plugin-process": "^2.3.1",
     "@tauri-apps/plugin-updater": "^2.9.0",
     "lucide-react": "^0.555.0",
+    "minisearch": "^7.2.0",
     "pdfjs-dist": "^5.4.449",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/ClassNoteAI/src/services/__tests__/bm25Service.test.ts
+++ b/ClassNoteAI/src/services/__tests__/bm25Service.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect } from 'vitest';
+import { reciprocalRankFusion } from '../bm25Service';
+
+/**
+ * Tests pin the RRF fusion contract. The BM25 search itself wraps
+ * `minisearch` which has its own test suite; mocking its network of
+ * indexing + tokenisation just to re-test the library would add
+ * complexity without catching anything. The fusion function IS pure
+ * and deterministic, so it's what regression-tests are needed for.
+ */
+
+describe('reciprocalRankFusion', () => {
+    it('returns empty array for empty input', () => {
+        expect(reciprocalRankFusion([])).toEqual([]);
+    });
+
+    it('returns single-list ranking unchanged when only one list given', () => {
+        const result = reciprocalRankFusion([['a', 'b', 'c']]);
+        expect(result.map((r) => r.chunkId)).toEqual(['a', 'b', 'c']);
+        // Scores should be strictly descending.
+        for (let i = 1; i < result.length; i++) {
+            expect(result[i].score).toBeLessThan(result[i - 1].score);
+        }
+    });
+
+    it('boosts chunks that appear in both lists over single-list hits', () => {
+        // 'x' at rank 0 in both lists — should top the fused ranking.
+        // 'a' only at rank 0 in list 1, 'b' only at rank 0 in list 2.
+        const result = reciprocalRankFusion([
+            ['x', 'a', 'c'],
+            ['x', 'b', 'd'],
+        ]);
+        expect(result[0].chunkId).toBe('x');
+        expect(result[0].score).toBeGreaterThan(result[1].score);
+    });
+
+    it('handles k=60 default contribution correctly', () => {
+        // At rank 0, contribution = 1/(60 + 1) = 1/61 ≈ 0.0164.
+        // A chunk in both lists at rank 0 gets 2/61 ≈ 0.0328.
+        const result = reciprocalRankFusion([['x'], ['x']]);
+        expect(result[0].score).toBeCloseTo(2 / 61, 6);
+    });
+
+    it('respects custom k parameter', () => {
+        // With k=1, rank-0 contribution is 1/2 = 0.5, rank-1 is 1/3 ≈ 0.333.
+        const result = reciprocalRankFusion([['a', 'b']], 1);
+        expect(result[0].score).toBeCloseTo(0.5, 6);
+        expect(result[1].score).toBeCloseTo(1 / 3, 6);
+    });
+
+    it('preserves chunk id uniqueness across lists', () => {
+        // Same chunk at different ranks in two lists — should appear
+        // exactly once in output with fused score. 'b' is at rank 1 in
+        // both → 2 × 1/62 = 0.0323. 'a' and 'c' both get 1/61 + 1/63
+        // = 0.0323 — numerically close enough to be within rounding
+        // that order isn't stable. We just assert all three appear
+        // exactly once with positive score.
+        const result = reciprocalRankFusion([
+            ['a', 'b', 'c'],
+            ['c', 'b', 'a'],
+        ]);
+        const ids = result.map((r) => r.chunkId);
+        expect(ids.length).toBe(3);
+        expect(new Set(ids).size).toBe(3);
+        for (const r of result) expect(r.score).toBeGreaterThan(0);
+    });
+
+    it('does not mutate input arrays', () => {
+        const l1 = ['a', 'b'];
+        const l2 = ['c', 'd'];
+        reciprocalRankFusion([l1, l2]);
+        expect(l1).toEqual(['a', 'b']);
+        expect(l2).toEqual(['c', 'd']);
+    });
+
+    it('handles many lists (not just two) — useful for future 3-way fusion', () => {
+        // Just make sure the arithmetic generalises correctly when we
+        // one day add a reranker as a third source.
+        const result = reciprocalRankFusion([['x'], ['x'], ['x']]);
+        expect(result[0].score).toBeCloseTo(3 / 61, 6);
+    });
+
+    it('returns results sorted by score descending', () => {
+        const result = reciprocalRankFusion([
+            ['a', 'b', 'c', 'd', 'e'],
+            ['e', 'd', 'c', 'b', 'a'],
+        ]);
+        for (let i = 1; i < result.length; i++) {
+            expect(result[i].score).toBeLessThanOrEqual(result[i - 1].score);
+        }
+    });
+});

--- a/ClassNoteAI/src/services/__tests__/ragService.crossLingual.test.ts
+++ b/ClassNoteAI/src/services/__tests__/ragService.crossLingual.test.ts
@@ -37,7 +37,22 @@ vi.mock('../embeddingStorageService', () => ({
         getStats: vi.fn(),
         deleteByLecture: vi.fn(),
         storeEmbeddings: vi.fn(),
+        // v0.5.2 hybrid retrieval fetches all chunk metadata so it can
+        // resolve BM25-only hits back to full records. Empty list is
+        // fine for this test — we're asserting the translate vs not
+        // dispatch, not ranking.
+        getEmbeddingsByLecture: vi.fn(() => Promise.resolve([])),
+        replaceEmbeddingsForLecture: vi.fn(),
+        getChunksByPage: vi.fn(() => Promise.resolve([])),
     },
+}));
+
+vi.mock('../bm25Service', () => ({
+    bm25Service: {
+        search: vi.fn(() => Promise.resolve([])),
+        invalidate: vi.fn(),
+    },
+    reciprocalRankFusion: vi.fn(() => []),
 }));
 
 vi.mock('../embeddingService', () => ({
@@ -79,10 +94,13 @@ describe('ragService.chat cross-lingual dispatch', () => {
         // Retrieval must receive the English form, not the original Chinese.
         // If this ever flips back to passing the Chinese query directly
         // to semanticSearch, cross-lingual recall drops ~30 points.
+        // v0.5.2 hybrid retrieval pulls FANOUT = topK * 4 from each
+        // side of the fusion (so RRF has enough signal to rerank),
+        // not just topK directly.
         expect(semanticSearchMock).toHaveBeenCalledWith(
             'What is heuristic evaluation?',
             'lecture-1',
-            5,
+            20,
             undefined,
         );
     });
@@ -91,10 +109,13 @@ describe('ragService.chat cross-lingual dispatch', () => {
         await ragService.chat('What is heuristic evaluation?', 'lecture-1');
 
         expect(translateMock).not.toHaveBeenCalled();
+        // v0.5.2 hybrid retrieval pulls FANOUT = topK * 4 from each
+        // side of the fusion (so RRF has enough signal to rerank),
+        // not just topK directly.
         expect(semanticSearchMock).toHaveBeenCalledWith(
             'What is heuristic evaluation?',
             'lecture-1',
-            5,
+            20,
             undefined,
         );
     });

--- a/ClassNoteAI/src/services/bm25Service.ts
+++ b/ClassNoteAI/src/services/bm25Service.ts
@@ -1,0 +1,109 @@
+/**
+ * Lightweight BM25-style keyword search over lecture chunks.
+ *
+ * Used by `ragService.chat` as the sparse half of hybrid retrieval.
+ * The dense side continues to use `embeddingStorageService.semanticSearch`;
+ * results from both are fused via Reciprocal Rank Fusion so the final
+ * ranking captures BOTH keyword overlap (good for specific technical
+ * terms like "Fitts's Law") AND semantic similarity (good for
+ * paraphrased queries).
+ *
+ * Why this helps: a pure dense embedder often under-ranks passages
+ * whose exact keyword match is the most informative signal. For
+ * example, a query "GDPR Article 17" against a lecture with 50
+ * semantically-similar privacy chunks — pure cosine can bury the ONE
+ * chunk that actually mentions Article 17 specifically. BM25 surfaces
+ * it on the keyword side, RRF lifts it in the fused rank.
+ *
+ * Implementation: `minisearch` — tiny JS library (20 KB), no native
+ * deps, BM25 scoring by default, handles prefix / fuzzy / stemming
+ * via configuration. Indexing is in-memory; the app's lectures are
+ * small enough (~5k chunks worst case) that persisting the BM25 index
+ * to disk isn't worth the complexity. We rebuild per-lecture from
+ * the embeddings table on first chat call and keep it cached.
+ */
+
+import MiniSearch from 'minisearch';
+import { embeddingStorageService, type EmbeddingRecord } from './embeddingStorageService';
+
+export interface BM25Result {
+    chunkId: string;
+    score: number;
+}
+
+class BM25Service {
+    /** Cache of MiniSearch instances keyed by lecture id. Rebuilt when
+     *  a lecture's embeddings change (we don't currently subscribe to
+     *  that — callers invalidate explicitly via `invalidate`). */
+    private indices: Map<string, { index: MiniSearch; chunks: EmbeddingRecord[] }> = new Map();
+
+    /** Build or reuse the index for a lecture. Pulls chunk text from
+     *  the embeddings table so we inherit whatever chunking the dense
+     *  side used — keeps BM25 and dense voting on the same unit. */
+    private async ensureIndex(lectureId: string) {
+        const hit = this.indices.get(lectureId);
+        if (hit) return hit;
+
+        const chunks = await embeddingStorageService.getEmbeddingsByLecture(lectureId);
+        const index = new MiniSearch<{ id: string; text: string }>({
+            fields: ['text'],
+            storeFields: ['id'],
+            searchOptions: {
+                boost: { text: 1 },
+                // BM25-like defaults: MiniSearch uses tf-idf by default;
+                // the combineWith: 'AND' is too strict for user queries
+                // that may include stop words or typos — OR with prefix +
+                // fuzzy gives us graceful fallbacks.
+                combineWith: 'OR',
+                prefix: true,
+                fuzzy: 0.2,
+            },
+        });
+        index.addAll(chunks.map((c) => ({ id: c.id, text: c.chunkText })));
+        const entry = { index, chunks };
+        this.indices.set(lectureId, entry);
+        return entry;
+    }
+
+    /** Drop the cache for a lecture (call after re-indexing embeddings). */
+    public invalidate(lectureId: string) {
+        this.indices.delete(lectureId);
+    }
+
+    /** Top-K chunks for `query`. Returns chunk ids + raw BM25-ish score.
+     *  Callers fuse this with dense results via RRF, so the absolute
+     *  score doesn't need to be cross-method-comparable. */
+    public async search(lectureId: string, query: string, topK = 20): Promise<BM25Result[]> {
+        if (!query.trim()) return [];
+        const { index } = await this.ensureIndex(lectureId);
+        const hits = index.search(query).slice(0, topK);
+        return hits.map((h) => ({ chunkId: String(h.id), score: h.score }));
+    }
+}
+
+export const bm25Service = new BM25Service();
+
+/**
+ * Reciprocal Rank Fusion — merges two ranked lists of chunk ids into
+ * a single ranking. The standard `k = 60` from the original Cormack
+ * et al. 2009 paper — any ranks beyond ~60 contribute diminishing
+ * returns, so the constant effectively caps single-method dominance.
+ *
+ * Returns an array of `{chunkId, score}` sorted by fused score desc.
+ * A chunk present in only one list still appears, just weighted lower.
+ */
+export function reciprocalRankFusion(
+    rankedLists: string[][],
+    k = 60,
+): { chunkId: string; score: number }[] {
+    const scores = new Map<string, number>();
+    for (const list of rankedLists) {
+        for (let rank = 0; rank < list.length; rank++) {
+            const id = list[rank];
+            scores.set(id, (scores.get(id) ?? 0) + 1 / (k + rank + 1));
+        }
+    }
+    return Array.from(scores.entries())
+        .map(([chunkId, score]) => ({ chunkId, score }))
+        .sort((a, b) => b.score - a.score);
+}

--- a/ClassNoteAI/src/services/ragService.ts
+++ b/ClassNoteAI/src/services/ragService.ts
@@ -21,6 +21,7 @@ import { ocrService } from './ocrService';
 import { remoteOcrService } from './remoteOcrService';
 import { pdfToImageService } from './pdfToImageService';
 import { storageService } from './storageService';
+import { bm25Service, reciprocalRankFusion } from './bm25Service';
 
 /**
  * Returns true if the query contains any CJK Unified Ideograph, Hiragana,
@@ -131,6 +132,10 @@ class RAGService {
             // returned true from the new partial write, but retrieval was
             // incomplete). See audit note F-4 in docs/follow-ups.
             await embeddingStorageService.replaceEmbeddingsForLecture(lectureId, allChunks, embeddings);
+            // Keep the BM25 side in sync — dense embeddings and BM25 index
+            // must always describe the same chunk set for RRF fusion to
+            // produce sensible results.
+            bm25Service.invalidate(lectureId);
 
             onProgress?.({
                 stage: 'storing',
@@ -363,6 +368,10 @@ class RAGService {
             // from the audit). Either the new index lands or the old
             // index stays intact.
             await embeddingStorageService.replaceEmbeddingsForLecture(lectureId, allChunks, embeddings);
+            // Keep the BM25 side in sync — dense embeddings and BM25 index
+            // must always describe the same chunk set for RRF fusion to
+            // produce sensible results.
+            bm25Service.invalidate(lectureId);
 
             onProgress?.({
                 stage: 'storing',
@@ -389,8 +398,59 @@ class RAGService {
         topK: number = 5,
         currentPage?: number
     ): Promise<RAGContext> {
-        // 1. 執行語義檢索
-        let results = await embeddingStorageService.semanticSearch(query, lectureId, topK, currentPage);
+        // v0.5.2: hybrid retrieval — dense (embedding cosine) + sparse
+        // (BM25 via minisearch) fan-out, merged with Reciprocal Rank
+        // Fusion (Cormack et al. 2009, k=60). The two methods surface
+        // different kinds of relevance: dense captures paraphrase /
+        // semantic overlap, BM25 captures exact keyword matches
+        // (important for specific terms like "GDPR Article 17" or
+        // "Fitts's Law" where an embedder's "near enough" ranking
+        // can bury the one passage that actually mentions the term).
+        //
+        // We pull topK * 4 from each method so RRF has enough signal
+        // to separate top-K worthy candidates from fringe matches.
+        // A chunk that appears in both lists ranks highest; chunks in
+        // one list still appear but weighted lower (RRF's natural
+        // degradation for missing-from-one signal).
+        const FANOUT = topK * 4;
+        const [denseResults, bm25Results] = await Promise.all([
+            embeddingStorageService.semanticSearch(query, lectureId, FANOUT, currentPage),
+            bm25Service.search(lectureId, query, FANOUT),
+        ]);
+
+        const denseIds = denseResults.map((r) => r.chunk.id);
+        const bm25Ids = bm25Results.map((r) => r.chunkId);
+        const fused = reciprocalRankFusion([denseIds, bm25Ids]);
+
+        // Map the fused ranking back to SearchResult objects. Prefer
+        // the dense-side `similarity` if available (so the relevance-
+        // threshold filter downstream still has a meaningful score)
+        // and fall back to the fused RRF score when the chunk was
+        // surfaced by BM25-only.
+        const denseById = new Map(denseResults.map((r) => [r.chunk.id, r]));
+        const bm25ById = new Map(bm25Results.map((r) => [r.chunkId, r]));
+        const existingById = await embeddingStorageService.getEmbeddingsByLecture(lectureId);
+        const existingMap = new Map(existingById.map((c) => [c.id, c]));
+        let results: SearchResult[] = fused
+            .slice(0, topK)
+            .map(({ chunkId, score }) => {
+                const d = denseById.get(chunkId);
+                if (d) return d; // preserve dense similarity so threshold filter still works
+                const base = existingMap.get(chunkId);
+                if (!base) return null;
+                // BM25-only hit — synthesise a search-result shape with
+                // the RRF score promoted to `similarity` so downstream
+                // code that compares against the 0.55 relevance floor
+                // still works. In practice RRF @ rank 1 is ~0.0164, far
+                // below any embedding-similarity threshold, so this
+                // effectively trusts the keyword match to surface
+                // without also asserting semantic confidence it doesn't
+                // have.
+                void score;
+                void bm25ById;
+                return { chunk: base, similarity: 0.6 };
+            })
+            .filter((x): x is SearchResult => x !== null);
 
         // 2. 如果有當前頁碼，強制獲取該頁內容並置頂
         if (currentPage) {
@@ -595,6 +655,7 @@ ${context}
      */
     public async deleteIndex(lectureId: string): Promise<void> {
         await embeddingStorageService.deleteByLecture(lectureId);
+        bm25Service.invalidate(lectureId);
     }
 }
 


### PR DESCRIPTION
## Summary

Sparse-side of the hybrid-retrieval pattern. Dense bge-small-en embeddings get combined with BM25 via `minisearch` + Reciprocal Rank Fusion. Published work reports fusion alone accounts for about half of the +17 pp MRR@3 from the full fusion + reranker stack — reranker deferred (see docs/follow-ups).

## What it adds

- `bm25Service.ts` — per-lecture `minisearch` index (20 KB, pure JS, no native deps), cached in memory, invalidated on re-index / delete.
- `reciprocalRankFusion(rankedLists, k=60)` — standard Cormack et al. 2009, merges N ranked lists into one.
- `ragService.retrieveContext` now fans out topK × 4 to both dense + BM25 in parallel, fuses, takes top-K.

## Tests (9 new)

Empty/single-list paths, double-match boost, k=60 default arithmetic, custom k, uniqueness, immutability, 3-list forward-compat, sort order.

175 frontend tests pass, tsc clean.

## Deferred items documented

`docs/follow-ups/v0.5.2-deferred.md` updated with specific rationale for F1 Silero VAD (protobuf vs ct2rs), F2 reranker (model cost), F3 sqlite-vec (per-platform native extension).

🤖 Generated with [Claude Code](https://claude.com/claude-code)