### PR TITLE
v0.6.0: import recorded lecture videos (+ subtitles, streaming UX, layouts)

### DIFF
--- a/ClassNoteAI/scripts/cdp.cjs
+++ b/ClassNoteAI/scripts/cdp.cjs
@@ -113,8 +113,12 @@ function serializeConsoleArg(arg) {
     return '[unserializable]';
 }
 
+function escapeRegExpLiteral(input) {
+    return input.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
 async function cmdTail(flags) {
-    const grep = flags.grep ? new RegExp(flags.grep) : null;
+    const grep = flags.grep ? new RegExp(escapeRegExpLiteral(String(flags.grep))) : null;
     const session = await connect();
     await session.send('Runtime.enable');
     session.on((msg) => {

--- a/ClassNoteAI/scripts/cdp.cjs
+++ b/ClassNoteAI/scripts/cdp.cjs
@@ -1,0 +1,241 @@
+#!/usr/bin/env node
+/**
+ * Tiny CDP client for the running Tauri dev app.
+ *
+ * `tauri.conf.json` now has `devtools: true` + the WebView2 process
+ * exposes Chrome DevTools Protocol on 127.0.0.1:9222 while the dev
+ * server is running. This wrapper saves the ~20 lines of boilerplate
+ * every time you want to peek at the app from the shell / an agent.
+ *
+ * Usage:
+ *   node scripts/cdp.cjs tail                 # stream console logs
+ *   node scripts/cdp.cjs tail --grep videoImp # only lines matching
+ *   node scripts/cdp.cjs eval '<js>'          # evaluate a JS snippet
+ *   node scripts/cdp.cjs text                 # dump body.innerText
+ *   node scripts/cdp.cjs screenshot out.png   # save viewport PNG
+ *   node scripts/cdp.cjs dom '<selector>'     # outerHTML of first match
+ *   node scripts/cdp.cjs sql "<SELECT ...>"   # run a read-only query
+ *                                               via window __cdp_sql
+ *
+ * Default port 9222 can be overridden with CDP_PORT.
+ *
+ * All subcommands exit 0 on success, 1 on failure so the agent can
+ * chain them in Bash.
+ */
+const fs = require('fs');
+const http = require('http');
+
+let WebSocket;
+try {
+    WebSocket = require('ws');
+} catch {
+    console.error(
+        "This script needs the 'ws' package. Run from the app's project root where ws is already installed, or `npm i ws`.",
+    );
+    process.exit(1);
+}
+
+const PORT = parseInt(process.env.CDP_PORT || '9222', 10);
+
+function httpGetJson(path) {
+    return new Promise((resolve, reject) => {
+        const url = `http://127.0.0.1:${PORT}${path}`;
+        http.get(url, (res) => {
+            let body = '';
+            res.on('data', (c) => (body += c));
+            res.on('end', () => {
+                try {
+                    resolve(JSON.parse(body));
+                } catch (e) {
+                    reject(new Error(`bad JSON from CDP: ${body.slice(0, 200)}`));
+                }
+            });
+        }).on('error', reject);
+    });
+}
+
+async function pickPage() {
+    const pages = await httpGetJson('/json/list');
+    const page = pages.find((p) => p.type === 'page');
+    if (!page) throw new Error('no "page" target — is the app running?');
+    return page;
+}
+
+class CdpSession {
+    constructor(ws) {
+        this.ws = ws;
+        this.id = 1;
+        this.pending = new Map();
+        this.listeners = [];
+        ws.on('message', (m) => {
+            let msg;
+            try {
+                msg = JSON.parse(m.toString());
+            } catch {
+                return;
+            }
+            if (msg.id && this.pending.has(msg.id)) {
+                const { resolve, reject } = this.pending.get(msg.id);
+                this.pending.delete(msg.id);
+                if (msg.error) reject(new Error(msg.error.message));
+                else resolve(msg.result);
+            } else if (msg.method) {
+                for (const l of this.listeners) l(msg);
+            }
+        });
+    }
+    send(method, params = {}) {
+        return new Promise((resolve, reject) => {
+            const id = this.id++;
+            this.pending.set(id, { resolve, reject });
+            this.ws.send(JSON.stringify({ id, method, params }));
+        });
+    }
+    on(fn) {
+        this.listeners.push(fn);
+    }
+}
+
+async function connect() {
+    const page = await pickPage();
+    const ws = new WebSocket(page.webSocketDebuggerUrl);
+    await new Promise((r, j) => {
+        ws.once('open', r);
+        ws.once('error', j);
+    });
+    return new CdpSession(ws);
+}
+
+function serializeConsoleArg(arg) {
+    if (arg.value !== undefined) return String(arg.value);
+    if (arg.unserializableValue) return arg.unserializableValue;
+    if (arg.description) return arg.description;
+    return '[unserializable]';
+}
+
+async function cmdTail(flags) {
+    const grep = flags.grep ? new RegExp(flags.grep) : null;
+    const session = await connect();
+    await session.send('Runtime.enable');
+    session.on((msg) => {
+        if (msg.method === 'Runtime.consoleAPICalled') {
+            const { type, args, timestamp } = msg.params;
+            const text = (args || []).map(serializeConsoleArg).join(' ');
+            const line = `[${new Date(timestamp).toISOString().slice(11, 19)}][${type}] ${text}`;
+            if (!grep || grep.test(line)) console.log(line);
+        } else if (msg.method === 'Runtime.exceptionThrown') {
+            const d = msg.params.exceptionDetails;
+            const line = `[EXC] ${d.text} ${d.exception?.description || ''}`;
+            if (!grep || grep.test(line)) console.log(line);
+        }
+    });
+    // Keep open until SIGINT.
+    process.on('SIGINT', () => process.exit(0));
+    console.error(`[cdp] tailing console on :${PORT} (Ctrl-C to stop)`);
+    await new Promise(() => {}); // forever
+}
+
+async function cmdEval(expr) {
+    if (!expr) {
+        console.error('usage: cdp.cjs eval <expression>');
+        process.exit(1);
+    }
+    const session = await connect();
+    const r = await session.send('Runtime.evaluate', {
+        expression: `(async () => { try { const v = await (${expr}); return typeof v === 'string' ? v : JSON.stringify(v, null, 2); } catch (e) { return 'ERR: ' + (e?.stack || String(e)); } })()`,
+        awaitPromise: true,
+        returnByValue: true,
+    });
+    if (r.exceptionDetails) {
+        console.error(r.exceptionDetails.text);
+        process.exit(1);
+    }
+    console.log(r.result?.value ?? '');
+    process.exit(0);
+}
+
+async function cmdText() {
+    const session = await connect();
+    const r = await session.send('Runtime.evaluate', {
+        expression: 'document.body.innerText',
+        returnByValue: true,
+    });
+    console.log(r.result?.value || '');
+    process.exit(0);
+}
+
+async function cmdDom(selector) {
+    if (!selector) {
+        console.error('usage: cdp.cjs dom <css-selector>');
+        process.exit(1);
+    }
+    const session = await connect();
+    const r = await session.send('Runtime.evaluate', {
+        expression: `document.querySelector(${JSON.stringify(selector)})?.outerHTML ?? null`,
+        returnByValue: true,
+    });
+    console.log(r.result?.value || '(no match)');
+    process.exit(0);
+}
+
+async function cmdScreenshot(outPath) {
+    const session = await connect();
+    await session.send('Page.enable');
+    const r = await session.send('Page.captureScreenshot', { format: 'png' });
+    const buf = Buffer.from(r.data, 'base64');
+    const out = outPath || 'cdp-screenshot.png';
+    fs.writeFileSync(out, buf);
+    console.log(out + ' (' + buf.length + ' bytes)');
+    process.exit(0);
+}
+
+function parseFlags(argv) {
+    const flags = {};
+    const rest = [];
+    for (let i = 0; i < argv.length; i++) {
+        const a = argv[i];
+        if (a.startsWith('--')) {
+            const key = a.slice(2);
+            const val = argv[i + 1];
+            if (!val || val.startsWith('--')) {
+                flags[key] = true;
+            } else {
+                flags[key] = val;
+                i++;
+            }
+        } else {
+            rest.push(a);
+        }
+    }
+    return { flags, rest };
+}
+
+async function main() {
+    const [, , cmd, ...raw] = process.argv;
+    const { flags, rest } = parseFlags(raw);
+    try {
+        switch (cmd) {
+            case 'tail':
+                return cmdTail(flags);
+            case 'eval':
+                return cmdEval(rest.join(' '));
+            case 'text':
+                return cmdText();
+            case 'dom':
+                return cmdDom(rest[0]);
+            case 'screenshot':
+                return cmdScreenshot(rest[0]);
+            default:
+                console.error(
+                    `Unknown command: ${cmd}\n` +
+                        'Available: tail | eval | text | dom | screenshot',
+                );
+                process.exit(1);
+        }
+    } catch (err) {
+        console.error(err.stack || String(err));
+        process.exit(1);
+    }
+}
+
+main();

--- a/ClassNoteAI/src-tauri/Cargo.lock
+++ b/ClassNoteAI/src-tauri/Cargo.lock
@@ -2559,6 +2559,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "http-range"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21dec9db110f5f872ed9699c3ecf50cf16f423502706ba5c72462e28d3157573"
+
+[[package]]
 name = "httparse"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5823,6 +5829,7 @@ dependencies = [
  "gtk",
  "heck 0.5.0",
  "http",
+ "http-range",
  "jni",
  "libc",
  "log",

--- a/ClassNoteAI/src-tauri/Cargo.toml
+++ b/ClassNoteAI/src-tauri/Cargo.toml
@@ -23,7 +23,7 @@ default = ["candle-embed"]
 candle-embed = ["candle-core", "candle-nn", "candle-transformers", "hf-hub"]
 
 [dependencies]
-tauri = { version = "2", features = ["devtools"] }
+tauri = { version = "2", features = ["protocol-asset", "devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"

--- a/ClassNoteAI/src-tauri/capabilities/default.json
+++ b/ClassNoteAI/src-tauri/capabilities/default.json
@@ -10,7 +10,6 @@
     "core:default",
     "core:path:default",
     "core:webview:allow-create-webview-window",
-    "core:webview:allow-create-webview-window",
     "core:webview:allow-webview-close",
     "core:window:allow-set-focus",
     "core:window:allow-set-size",

--- a/ClassNoteAI/src-tauri/capabilities/default.json
+++ b/ClassNoteAI/src-tauri/capabilities/default.json
@@ -8,6 +8,8 @@
   ],
   "permissions": [
     "core:default",
+    "core:path:default",
+    "core:webview:allow-create-webview-window",
     "core:webview:allow-create-webview-window",
     "core:webview:allow-webview-close",
     "core:window:allow-set-focus",

--- a/ClassNoteAI/src-tauri/scripts/win-cargo-check.bat
+++ b/ClassNoteAI/src-tauri/scripts/win-cargo-check.bat
@@ -1,0 +1,38 @@
+@echo off
+setlocal EnableExtensions
+REM One-shot: runs `cargo check --features candle-embed` with the same
+REM MSVC + LLVM + CMake env win-tauri-build.bat uses, so local compile
+REM errors surface without having to spin up the full dev server.
+
+set "_VS_TAG="
+if not defined VS_VCVARS (
+    if exist "C:\Program Files\Microsoft Visual Studio\18\Community\VC\Auxiliary\Build\vcvars64.bat" (
+        set "VS_VCVARS=C:\Program Files\Microsoft Visual Studio\18\Community\VC\Auxiliary\Build\vcvars64.bat"
+        set "_VS_TAG=18"
+    )
+    if not defined VS_VCVARS if exist "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat" (
+        set "VS_VCVARS=C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
+        set "_VS_TAG=17"
+    )
+)
+if not defined VS_VCVARS (
+    echo ERROR: vcvars64.bat not found.
+    exit /b 1
+)
+call "%VS_VCVARS%" >nul
+
+if exist "%USERPROFILE%\llvm18\bin\libclang.dll" (
+    set "LIBCLANG_PATH=%USERPROFILE%\llvm18\bin"
+)
+
+if "%_VS_TAG%"=="18" (
+    set "CMAKE_GENERATOR=Visual Studio 18 2026"
+) else (
+    set "CMAKE_GENERATOR=Visual Studio 17 2022"
+)
+set "CMAKE_TOOLCHAIN_FILE=%~dp0win-toolchain.cmake"
+set "PATH=%USERPROFILE%\.cargo\bin;%LIBCLANG_PATH%;%PATH%"
+
+cd /d "%~dp0.."
+cargo check --features candle-embed %*
+endlocal

--- a/ClassNoteAI/src-tauri/src/lib.rs
+++ b/ClassNoteAI/src-tauri/src/lib.rs
@@ -1873,6 +1873,9 @@ pub fn run() {
             recording::video_import::import_video_for_lecture,
             recording::video_import::extract_pcm_from_video,
             recording::video_import::transcribe_video_file,
+            recording::video_import::extract_video_pcm_to_temp,
+            recording::video_import::transcribe_pcm_file_slice,
+            recording::video_import::delete_temp_pcm,
             list_orphaned_recording_lectures,
         ])
         .run(tauri::generate_context!())

--- a/ClassNoteAI/src-tauri/src/lib.rs
+++ b/ClassNoteAI/src-tauri/src/lib.rs
@@ -1876,6 +1876,8 @@ pub fn run() {
             recording::video_import::extract_video_pcm_to_temp,
             recording::video_import::transcribe_pcm_file_slice,
             recording::video_import::delete_temp_pcm,
+            recording::video_import::release_import_whisper,
+            recording::video_import::resolve_whisper_model_path,
             list_orphaned_recording_lectures,
         ])
         .run(tauri::generate_context!())

--- a/ClassNoteAI/src-tauri/src/lib.rs
+++ b/ClassNoteAI/src-tauri/src/lib.rs
@@ -28,8 +28,11 @@ use tauri::Emitter;
 use tokio::sync::Mutex;
 use whisper::WhisperService; // For window.emit()
 
-// 全局 Whisper 服務實例
-static WHISPER_SERVICE: Mutex<Option<WhisperService>> = Mutex::const_new(None);
+// 全局 Whisper 服務實例. `pub(crate)` so sibling modules (e.g.
+// recording::video_import's combined extract+transcribe path) can
+// reuse the loaded model without routing through Tauri command IPC
+// and without serialising 100+ MB of PCM back and forth.
+pub(crate) static WHISPER_SERVICE: Mutex<Option<WhisperService>> = Mutex::const_new(None);
 // 全局 Embedding 服務實例
 static EMBEDDING_SERVICE: Mutex<Option<EmbeddingService>> = Mutex::const_new(None);
 
@@ -1869,6 +1872,7 @@ pub fn run() {
             recording::discard_orphaned_recording,
             recording::video_import::import_video_for_lecture,
             recording::video_import::extract_pcm_from_video,
+            recording::video_import::transcribe_video_file,
             list_orphaned_recording_lectures,
         ])
         .run(tauri::generate_context!())

--- a/ClassNoteAI/src-tauri/src/lib.rs
+++ b/ClassNoteAI/src-tauri/src/lib.rs
@@ -1867,6 +1867,8 @@ pub fn run() {
             recording::finalize_recording,
             recording::find_orphaned_recordings,
             recording::discard_orphaned_recording,
+            recording::video_import::import_video_for_lecture,
+            recording::video_import::extract_pcm_from_video,
             list_orphaned_recording_lectures,
         ])
         .run(tauri::generate_context!())

--- a/ClassNoteAI/src-tauri/src/paths/app_dirs.rs
+++ b/ClassNoteAI/src-tauri/src/paths/app_dirs.rs
@@ -111,6 +111,18 @@ pub fn get_in_progress_audio_dir() -> Result<PathBuf, String> {
     Ok(get_audio_dir()?.join("in-progress"))
 }
 
+/// Get the imported-video directory.
+///
+/// Returns: {app_data_dir}/videos/
+///
+/// Where v0.6.0 lecture video imports are staged. We copy the
+/// user-selected source file in so playback has a stable path owned
+/// by the app (user moving/deleting the original doesn't kill the
+/// lecture).
+pub fn get_video_dir() -> Result<PathBuf, String> {
+    Ok(get_app_data_dir()?.join("videos"))
+}
+
 /// Get the database file path
 ///
 /// Returns: {app_data_dir}/classnoteai.db

--- a/ClassNoteAI/src-tauri/src/recording/mod.rs
+++ b/ClassNoteAI/src-tauri/src/recording/mod.rs
@@ -1,5 +1,10 @@
 //! Crash-safe recording: incremental raw-PCM persistence + orphan recovery.
 //!
+//! Also hosts `video_import` — extracting 16kHz mono i16 PCM out of a
+//! pre-recorded video file (ffmpeg shell-out) so imported lectures
+//! feed the same Whisper transcription pipeline as live recordings.
+pub mod video_import;
+//!
 //! Before v0.5.2, audio only lived in the frontend `recordedChunks: Int16Array[]`
 //! buffer until the user hit Stop — a crash, power loss, or accidental window
 //! close in the middle of an 80-minute lecture wiped the whole session. The

--- a/ClassNoteAI/src-tauri/src/recording/mod.rs
+++ b/ClassNoteAI/src-tauri/src/recording/mod.rs
@@ -3,7 +3,6 @@
 //! Also hosts `video_import` — extracting 16kHz mono i16 PCM out of a
 //! pre-recorded video file (ffmpeg shell-out) so imported lectures
 //! feed the same Whisper transcription pipeline as live recordings.
-pub mod video_import;
 //!
 //! Before v0.5.2, audio only lived in the frontend `recordedChunks: Int16Array[]`
 //! buffer until the user hit Stop — a crash, power loss, or accidental window
@@ -32,6 +31,8 @@ pub mod video_import;
 //!   operates on a `&Path` instead of reading the global paths module. This
 //!   is what makes the recovery / stitching logic actually testable from
 //!   `cargo test --lib`, which is the whole point of PR #38.
+
+pub mod video_import;
 
 use serde::{Deserialize, Serialize};
 use std::fs::{self, File, OpenOptions};

--- a/ClassNoteAI/src-tauri/src/recording/video_import.rs
+++ b/ClassNoteAI/src-tauri/src/recording/video_import.rs
@@ -19,6 +19,22 @@ use std::fs::File;
 use std::io::{BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
+use tokio::sync::Mutex as TokioMutex;
+
+use crate::whisper::WhisperService;
+
+/// Dedicated Whisper service slot for bulk video import. We keep this
+/// separate from the main WHISPER_SERVICE so:
+///   - The user's live-recording model (often large-v3-turbo) stays
+///     loaded and ready — video import doesn't evict it.
+///   - Import can use a faster model (base / small) without touching
+///     the live path. A 1-hour video on large-v3-turbo CPU is ~40 min;
+///     on base it's ~5 min. For bulk transcription the accuracy trade
+///     is almost always worth it.
+/// The tuple carries the loaded model's path so successive slice calls
+/// in the same import reuse the model instead of reloading per chunk.
+static IMPORT_WHISPER_SERVICE: TokioMutex<Option<(String, WhisperService)>> =
+    TokioMutex::const_new(None);
 
 /// Run ffmpeg to decode a video file into raw 16 kHz mono i16 PCM.
 /// Returns the full PCM samples in memory; for typical lecture lengths
@@ -340,6 +356,13 @@ pub async fn extract_video_pcm_to_temp(video_path: String) -> Result<PcmExtractR
 /// Transcribe a [start_sec, end_sec) range of an on-disk PCM file.
 /// The returned segment timestamps are shifted by `start_sec * 1000`
 /// so the frontend can concatenate slices without further adjustment.
+///
+/// When `model_override_path` is `Some`, use a separate Whisper
+/// instance loaded from that file instead of the main WHISPER_SERVICE.
+/// This drives the "fast import" path where bulk video transcription
+/// runs on a smaller model (base) while live recording keeps the
+/// user's larger model loaded in WHISPER_SERVICE. When `None`, falls
+/// back to WHISPER_SERVICE (same as before).
 #[tauri::command]
 pub async fn transcribe_pcm_file_slice(
     pcm_path: String,
@@ -348,11 +371,12 @@ pub async fn transcribe_pcm_file_slice(
     initial_prompt: Option<String>,
     language: Option<String>,
     options: Option<crate::whisper::transcribe::TranscriptionOptions>,
+    model_override_path: Option<String>,
 ) -> Result<crate::whisper::transcribe::TranscriptionResult, String> {
     let t0 = std::time::Instant::now();
     println!(
-        "[video_import] slice start: {:.1}..{:.1}s, lang={:?}, pcm={}",
-        start_sec, end_sec, language, pcm_path
+        "[video_import] slice start: {:.1}..{:.1}s, lang={:?}, override={:?}, pcm={}",
+        start_sec, end_sec, language, model_override_path, pcm_path
     );
     if end_sec <= start_sec {
         return Err("end_sec must be > start_sec".to_string());
@@ -393,40 +417,144 @@ pub async fn transcribe_pcm_file_slice(
     }
 
     let t_lock = std::time::Instant::now();
-    let service_guard = crate::WHISPER_SERVICE.lock().await;
-    let service = service_guard
-        .as_ref()
-        .ok_or_else(|| "Whisper 模型未加載".to_string())?;
-    println!(
-        "[video_import] slice acquired WHISPER_SERVICE lock in {:.2}s",
-        t_lock.elapsed().as_secs_f64()
-    );
+    let result = if let Some(ref override_path) = model_override_path {
+        // Fast-import path: dedicated IMPORT_WHISPER_SERVICE with the
+        // caller-specified model. First slice in an import pays the
+        // model-load cost (~0.5-2s); subsequent slices reuse the
+        // cached model since we key on path.
+        let mut guard = IMPORT_WHISPER_SERVICE.lock().await;
+        let needs_load = match guard.as_ref() {
+            Some((loaded_path, _)) => loaded_path != override_path,
+            None => true,
+        };
+        if needs_load {
+            if !Path::new(override_path).exists() {
+                return Err(format!(
+                    "指定的 Whisper 模型檔案不存在: {}",
+                    override_path
+                ));
+            }
+            println!(
+                "[video_import] loading import-side Whisper model: {}",
+                override_path
+            );
+            let t_load = std::time::Instant::now();
+            let mut svc = WhisperService::new();
+            svc.load_model(override_path)
+                .await
+                .map_err(|e| format!("模型加載失敗: {}", e))?;
+            println!(
+                "[video_import] import model loaded in {:.2}s",
+                t_load.elapsed().as_secs_f64()
+            );
+            *guard = Some((override_path.to_string(), svc));
+        }
+        let (_, service) = guard.as_ref().unwrap();
+        println!(
+            "[video_import] slice acquired IMPORT_WHISPER lock in {:.2}s",
+            t_lock.elapsed().as_secs_f64()
+        );
 
-    let t_whisper = std::time::Instant::now();
-    let mut result = service
-        .transcribe(
-            &samples,
-            PCM_SAMPLE_RATE,
-            initial_prompt.as_deref(),
-            language.as_deref(),
-            options,
-        )
-        .await
-        .map_err(|e| format!("轉錄失敗: {}", e))?;
-    println!(
-        "[video_import] slice whisper done in {:.2}s — segments={} lang={:?}, total slice {:.2}s",
-        t_whisper.elapsed().as_secs_f64(),
-        result.segments.len(),
-        result.language,
-        t0.elapsed().as_secs_f64()
-    );
+        let t_whisper = std::time::Instant::now();
+        let r = service
+            .transcribe(
+                &samples,
+                PCM_SAMPLE_RATE,
+                initial_prompt.as_deref(),
+                language.as_deref(),
+                options,
+            )
+            .await
+            .map_err(|e| format!("轉錄失敗: {}", e))?;
+        println!(
+            "[video_import] slice whisper (import) done in {:.2}s — segments={} lang={:?}, total slice {:.2}s",
+            t_whisper.elapsed().as_secs_f64(),
+            r.segments.len(),
+            r.language,
+            t0.elapsed().as_secs_f64()
+        );
+        r
+    } else {
+        // Default path: share the main WHISPER_SERVICE with live
+        // recording. May contend if the user imports while a mic
+        // capture is running, but that's a rare race.
+        let service_guard = crate::WHISPER_SERVICE.lock().await;
+        let service = service_guard
+            .as_ref()
+            .ok_or_else(|| "Whisper 模型未加載".to_string())?;
+        println!(
+            "[video_import] slice acquired WHISPER_SERVICE lock in {:.2}s",
+            t_lock.elapsed().as_secs_f64()
+        );
 
+        let t_whisper = std::time::Instant::now();
+        let r = service
+            .transcribe(
+                &samples,
+                PCM_SAMPLE_RATE,
+                initial_prompt.as_deref(),
+                language.as_deref(),
+                options,
+            )
+            .await
+            .map_err(|e| format!("轉錄失敗: {}", e))?;
+        println!(
+            "[video_import] slice whisper done in {:.2}s — segments={} lang={:?}, total slice {:.2}s",
+            t_whisper.elapsed().as_secs_f64(),
+            r.segments.len(),
+            r.language,
+            t0.elapsed().as_secs_f64()
+        );
+        r
+    };
+    let mut result = result;
     let offset_ms = (start_sec * 1000.0) as u64;
     for seg in result.segments.iter_mut() {
         seg.start_ms = seg.start_ms.saturating_add(offset_ms);
         seg.end_ms = seg.end_ms.saturating_add(offset_ms);
     }
     Ok(result)
+}
+
+/// Release the import-side Whisper service — called by the frontend
+/// orchestrator when a video import pipeline finishes (or errors). We
+/// don't auto-unload because the user may run several imports back-to
+/// -back with the same model, and each load costs 0.5–2 s. Once idle,
+/// frees ~150 MB for base / ~200 MB for small.
+#[tauri::command]
+pub async fn release_import_whisper() -> Result<(), String> {
+    let mut guard = IMPORT_WHISPER_SERVICE.lock().await;
+    *guard = None;
+    println!("[video_import] IMPORT_WHISPER_SERVICE released");
+    Ok(())
+}
+
+/// Return the absolute path to a preset Whisper model file under the
+/// app's `models/whisper/` dir. Used by the import pipeline so the
+/// frontend can ask for "fast" without hardcoding platform-specific
+/// paths in TS.
+#[tauri::command]
+pub async fn resolve_whisper_model_path(preset: String) -> Result<String, String> {
+    let filename = match preset.as_str() {
+        "base" => "ggml-base.bin",
+        "small" => "ggml-small.bin",
+        "small-q5" => "ggml-small-q5.bin",
+        "medium" => "ggml-medium.bin",
+        "large" => "ggml-large.bin",
+        "turbo" => "ggml-large-v3-turbo-q5_0.bin",
+        _ => return Err(format!("unknown preset: {}", preset)),
+    };
+    let dir = crate::paths::get_whisper_models_dir()
+        .map_err(|e| format!("whisper models dir unavailable: {}", e))?;
+    let full = dir.join(filename);
+    if !full.exists() {
+        return Err(format!(
+            "preset {} ({}) not downloaded",
+            preset,
+            full.display()
+        ));
+    }
+    Ok(full.to_string_lossy().into_owned())
 }
 
 /// Remove the temp `.transcribe.pcm` file once the orchestrator is done

--- a/ClassNoteAI/src-tauri/src/recording/video_import.rs
+++ b/ClassNoteAI/src-tauri/src/recording/video_import.rs
@@ -14,7 +14,9 @@
  * the downstream transcription path needs zero changes.
  */
 
-use std::io::Read;
+use serde::{Deserialize, Serialize};
+use std::fs::File;
+use std::io::{BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
 use std::process::{Command, Stdio};
 
@@ -204,6 +206,218 @@ pub async fn import_video_for_lecture(
 #[tauri::command]
 pub async fn extract_pcm_from_video(video_path: String) -> Result<Vec<i16>, String> {
     extract_pcm_16k_mono(Path::new(&video_path))
+}
+
+// ----- Chunked-transcribe pipeline (v0.6.0) ----------------------------
+//
+// The original `transcribe_video_file` was a single opaque call: ffmpeg
+// → full PCM buffer → one Whisper pass → return all segments. For a
+// 1 hour 20 minute lecture that's ~80 min of CPU work with zero
+// progress feedback, indistinguishable from a hang. We now split the
+// work into 5-minute slices so the frontend can:
+//   1. show granular progress ("轉錄 3/14, 翻譯 2/14"),
+//   2. pipeline translation against transcription instead of sequencing
+//      them, and
+//   3. avoid rebuffering the whole PCM when retrying a single chunk.
+//
+// The PCM is materialised to a temp file on disk once (fast — ffmpeg
+// does ~70 min of video in ~3 s) and then each slice reads the exact
+// byte range it needs. Whisper is called per-slice with the offset
+// baked into the returned segment timestamps.
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PcmExtractResult {
+    pub pcm_path: String,
+    pub duration_sec: f64,
+    pub sample_count: u64,
+}
+
+const PCM_SAMPLE_RATE: u32 = 16_000;
+const PCM_BYTES_PER_SAMPLE: u64 = 2;
+
+/// Stream ffmpeg's PCM output directly to a temp file instead of the
+/// in-memory Vec<i16> that `extract_pcm_16k_mono` uses. A 70-minute
+/// video is ~130 MB; writing to disk is cheaper than holding it in RAM
+/// across the chunked transcription loop (which can take tens of
+/// minutes) and the frontend can then retry individual slices without
+/// re-running ffmpeg.
+fn extract_pcm_to_file(video_path: &Path, pcm_path: &Path) -> Result<u64, String> {
+    if !video_path.exists() {
+        return Err(format!("video file not found: {}", video_path.display()));
+    }
+    if let Some(parent) = pcm_path.parent() {
+        std::fs::create_dir_all(parent)
+            .map_err(|e| format!("failed to create pcm dir: {}", e))?;
+    }
+
+    let ffmpeg = locate_ffmpeg()?;
+    let output = File::create(pcm_path)
+        .map_err(|e| format!("failed to create pcm file: {}", e))?;
+    let mut writer = BufWriter::with_capacity(1024 * 1024, output);
+
+    let mut child = Command::new(&ffmpeg)
+        .args(["-hide_banner", "-loglevel", "error", "-i"])
+        .arg(video_path)
+        .args(["-ac", "1", "-ar", "16000", "-f", "s16le", "-y", "-"])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("failed to spawn ffmpeg: {}", e))?;
+
+    let mut stdout = child.stdout.take().expect("stdout piped");
+    let mut stderr = child.stderr.take().expect("stderr piped");
+
+    let stderr_handle = std::thread::spawn(move || {
+        let mut s = String::new();
+        let _ = stderr.read_to_string(&mut s);
+        s
+    });
+
+    // Stream in 1 MB blocks so we never hold more than that in memory.
+    let mut buf = vec![0u8; 1024 * 1024];
+    let mut total: u64 = 0;
+    loop {
+        let n = stdout
+            .read(&mut buf)
+            .map_err(|e| format!("ffmpeg read failed: {}", e))?;
+        if n == 0 {
+            break;
+        }
+        writer
+            .write_all(&buf[..n])
+            .map_err(|e| format!("pcm write failed: {}", e))?;
+        total += n as u64;
+    }
+    writer
+        .flush()
+        .map_err(|e| format!("pcm flush failed: {}", e))?;
+
+    let status = child
+        .wait()
+        .map_err(|e| format!("ffmpeg wait failed: {}", e))?;
+    let stderr_out = stderr_handle.join().unwrap_or_default();
+    if !status.success() {
+        return Err(format!(
+            "ffmpeg exited with {}: {}",
+            status,
+            stderr_out.trim()
+        ));
+    }
+    if total % 2 != 0 {
+        return Err(format!(
+            "ffmpeg produced {} bytes, not a whole number of i16 samples",
+            total
+        ));
+    }
+    Ok(total / PCM_BYTES_PER_SAMPLE)
+}
+
+#[tauri::command]
+pub async fn extract_video_pcm_to_temp(video_path: String) -> Result<PcmExtractResult, String> {
+    let source = Path::new(&video_path);
+    // Drop the temp PCM next to the staged video so it lives and dies
+    // with the lecture — same directory already has the app's write
+    // permission and our cleanup routines.
+    let stem = source
+        .file_stem()
+        .and_then(|s| s.to_str())
+        .unwrap_or("pcm");
+    let parent = source
+        .parent()
+        .map(|p| p.to_path_buf())
+        .ok_or_else(|| "invalid video path".to_string())?;
+    let pcm_path = parent.join(format!("{}.transcribe.pcm", stem));
+
+    let sample_count = extract_pcm_to_file(source, &pcm_path)?;
+    let duration_sec = sample_count as f64 / PCM_SAMPLE_RATE as f64;
+    Ok(PcmExtractResult {
+        pcm_path: pcm_path.to_string_lossy().into_owned(),
+        duration_sec,
+        sample_count,
+    })
+}
+
+/// Transcribe a [start_sec, end_sec) range of an on-disk PCM file.
+/// The returned segment timestamps are shifted by `start_sec * 1000`
+/// so the frontend can concatenate slices without further adjustment.
+#[tauri::command]
+pub async fn transcribe_pcm_file_slice(
+    pcm_path: String,
+    start_sec: f64,
+    end_sec: f64,
+    initial_prompt: Option<String>,
+    language: Option<String>,
+    options: Option<crate::whisper::transcribe::TranscriptionOptions>,
+) -> Result<crate::whisper::transcribe::TranscriptionResult, String> {
+    if end_sec <= start_sec {
+        return Err("end_sec must be > start_sec".to_string());
+    }
+    let path = Path::new(&pcm_path);
+    let mut file = File::open(path).map_err(|e| format!("open pcm failed: {}", e))?;
+    let start_byte = (start_sec * PCM_SAMPLE_RATE as f64 * PCM_BYTES_PER_SAMPLE as f64) as u64;
+    // Align to sample boundary.
+    let start_byte = start_byte - (start_byte % PCM_BYTES_PER_SAMPLE);
+    let sample_span = ((end_sec - start_sec) * PCM_SAMPLE_RATE as f64) as usize;
+    let byte_span = sample_span * PCM_BYTES_PER_SAMPLE as usize;
+
+    file.seek(SeekFrom::Start(start_byte))
+        .map_err(|e| format!("seek failed: {}", e))?;
+    let mut bytes = vec![0u8; byte_span];
+    let read = file
+        .read(&mut bytes)
+        .map_err(|e| format!("read pcm failed: {}", e))?;
+    bytes.truncate(read - (read % PCM_BYTES_PER_SAMPLE as usize));
+
+    let samples: Vec<i16> = bytes
+        .chunks_exact(2)
+        .map(|b| i16::from_le_bytes([b[0], b[1]]))
+        .collect();
+
+    if samples.is_empty() {
+        return Ok(crate::whisper::transcribe::TranscriptionResult {
+            text: String::new(),
+            segments: vec![],
+            language: None,
+            duration_ms: 0,
+        });
+    }
+
+    let service_guard = crate::WHISPER_SERVICE.lock().await;
+    let service = service_guard
+        .as_ref()
+        .ok_or_else(|| "Whisper 模型未加載".to_string())?;
+    let mut result = service
+        .transcribe(
+            &samples,
+            PCM_SAMPLE_RATE,
+            initial_prompt.as_deref(),
+            language.as_deref(),
+            options,
+        )
+        .await
+        .map_err(|e| format!("轉錄失敗: {}", e))?;
+
+    let offset_ms = (start_sec * 1000.0) as u64;
+    for seg in result.segments.iter_mut() {
+        seg.start_ms = seg.start_ms.saturating_add(offset_ms);
+        seg.end_ms = seg.end_ms.saturating_add(offset_ms);
+    }
+    Ok(result)
+}
+
+/// Remove the temp `.transcribe.pcm` file once the orchestrator is done
+/// with it. Best-effort — a leftover PCM is harmless (just disk).
+#[tauri::command]
+pub async fn delete_temp_pcm(pcm_path: String) -> Result<(), String> {
+    let path = Path::new(&pcm_path);
+    if !path.exists() {
+        return Ok(());
+    }
+    // Guard against accidental deletion outside a pcm file.
+    if !pcm_path.ends_with(".pcm") {
+        return Err("refusing to delete non-.pcm file".to_string());
+    }
+    std::fs::remove_file(path).map_err(|e| format!("delete failed: {}", e))
 }
 
 /// Combined "extract + transcribe" entry point. The original shape --

--- a/ClassNoteAI/src-tauri/src/recording/video_import.rs
+++ b/ClassNoteAI/src-tauri/src/recording/video_import.rs
@@ -1,0 +1,207 @@
+/*!
+ * Video → PCM extraction for the v0.6.0 "import recorded lecture" flow.
+ *
+ * We shell out to `ffmpeg` rather than linking against libavcodec — the
+ * app already ships with other native deps (whisper-rs, ct2rs, candle)
+ * and adding libav would blow up the Windows build matrix. `ffmpeg` is
+ * near-universally installed on developer machines and we probe PATH
+ * at call time with a clear error when missing; bundling a static
+ * binary can come later if real-user installs hit "ffmpeg not found"
+ * often enough.
+ *
+ * Output format is fixed at 16 kHz mono i16 PCM (the exact shape
+ * whisper-rs's `transcribe` wants — same as live-recording input), so
+ * the downstream transcription path needs zero changes.
+ */
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+
+/// Run ffmpeg to decode a video file into raw 16 kHz mono i16 PCM.
+/// Returns the full PCM samples in memory; for typical lecture lengths
+/// (1-2 hours) that's ~100-200 MB of i16 which is fine to hold on
+/// desktop. If we ever care about streaming very long lectures we can
+/// emit a temp .wav and hand the path back instead.
+pub fn extract_pcm_16k_mono(video_path: &Path) -> Result<Vec<i16>, String> {
+    if !video_path.exists() {
+        return Err(format!("video file not found: {}", video_path.display()));
+    }
+
+    let ffmpeg = locate_ffmpeg()?;
+
+    let mut child = Command::new(&ffmpeg)
+        // Suppress the extremely verbose default banner; keep warnings/errors.
+        .args([
+            "-hide_banner",
+            "-loglevel",
+            "error",
+            "-i",
+        ])
+        .arg(video_path)
+        .args([
+            // Mono, 16 kHz, signed 16-bit little-endian (whisper input).
+            "-ac", "1",
+            "-ar", "16000",
+            "-f", "s16le",
+            "-y",
+            "-",
+        ])
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .map_err(|e| format!("failed to spawn ffmpeg: {}", e))?;
+
+    // Drain stdout (PCM bytes) and stderr (diagnostics) concurrently
+    // to avoid pipe-buffer deadlock on long videos.
+    let mut stdout = child.stdout.take().expect("stdout piped");
+    let stdout_handle = std::thread::spawn(move || {
+        let mut buf = Vec::with_capacity(16 * 1024 * 1024);
+        stdout
+            .read_to_end(&mut buf)
+            .map(|_| buf)
+            .map_err(|e| format!("ffmpeg stdout read failed: {}", e))
+    });
+
+    let mut stderr = child.stderr.take().expect("stderr piped");
+    let stderr_handle = std::thread::spawn(move || {
+        let mut s = String::new();
+        let _ = stderr.read_to_string(&mut s);
+        s
+    });
+
+    let status = child
+        .wait()
+        .map_err(|e| format!("ffmpeg wait failed: {}", e))?;
+    let stderr_out = stderr_handle.join().unwrap_or_default();
+
+    if !status.success() {
+        return Err(format!(
+            "ffmpeg exited with {}: {}",
+            status,
+            stderr_out.trim()
+        ));
+    }
+
+    let pcm_bytes = stdout_handle
+        .join()
+        .map_err(|_| "ffmpeg stdout thread panicked".to_string())??;
+
+    // Reinterpret the byte buffer as i16 samples. Little-endian on both
+    // Windows and macOS arm64/x64 so this is a direct cast for us.
+    if pcm_bytes.len() % 2 != 0 {
+        return Err(format!(
+            "ffmpeg produced {} bytes, not a whole number of i16 samples",
+            pcm_bytes.len()
+        ));
+    }
+    let samples: Vec<i16> = pcm_bytes
+        .chunks_exact(2)
+        .map(|b| i16::from_le_bytes([b[0], b[1]]))
+        .collect();
+    Ok(samples)
+}
+
+/// Find `ffmpeg` on the current machine. Returns a descriptive error
+/// the frontend can show to the user when absent.
+fn locate_ffmpeg() -> Result<String, String> {
+    // Fast path: PATH lookup via `which`-equivalent. `ffmpeg` alone
+    // works on every shell that has it resolvable, so we just try to
+    // spawn it with `-version` to see if it's there.
+    let probe = Command::new("ffmpeg")
+        .arg("-version")
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .status();
+    if probe.is_ok() && probe.unwrap().success() {
+        return Ok("ffmpeg".to_string());
+    }
+
+    // Windows: common WinGet install location. If a user has installed
+    // Gyan.FFmpeg but their PATH wasn't updated for the current app
+    // session, we still find it.
+    #[cfg(target_os = "windows")]
+    {
+        if let Some(home) = dirs::home_dir() {
+            let winget_path = home.join(
+                "AppData/Local/Microsoft/WinGet/Packages/\
+                 Gyan.FFmpeg_Microsoft.Winget.Source_8wekyb3d8bbwe/\
+                 ffmpeg-8.0.1-full_build/bin/ffmpeg.exe",
+            );
+            if winget_path.exists() {
+                return Ok(winget_path.to_string_lossy().into_owned());
+            }
+        }
+    }
+
+    Err(
+        "ffmpeg 未安裝或不在 PATH 中。\
+         請從 https://ffmpeg.org/download.html 下載後重新啟動應用程式。"
+            .to_string(),
+    )
+}
+
+// ----- Tauri command wrappers ------------------------------------------
+
+/// Copy / link a video source file into the lecture's data directory so
+/// we own it and the user can't accidentally move/delete the playback
+/// target. Returns the destination path (string) for the frontend to
+/// persist in `lectures.video_path`.
+///
+/// Uses a rename-then-fallback-copy strategy: same-volume moves are
+/// free; cross-volume gets a full copy. Either way, the original is
+/// left intact if the user picked a file outside the app's data dir.
+pub fn stage_video_inner(
+    videos_dir: &Path,
+    lecture_id: &str,
+    source: &Path,
+) -> std::io::Result<PathBuf> {
+    if lecture_id.is_empty() || lecture_id.len() > 128 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "lecture_id must be 1-128 chars",
+        ));
+    }
+    for c in lecture_id.chars() {
+        if !(c.is_ascii_alphanumeric() || c == '-' || c == '_') {
+            return Err(std::io::Error::new(
+                std::io::ErrorKind::InvalidInput,
+                format!("lecture_id contains disallowed char: {:?}", c),
+            ));
+        }
+    }
+    if !source.exists() {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::NotFound,
+            format!("source video not found: {}", source.display()),
+        ));
+    }
+    std::fs::create_dir_all(videos_dir)?;
+    let ext = source
+        .extension()
+        .and_then(|e| e.to_str())
+        .unwrap_or("mp4");
+    let dest = videos_dir.join(format!("{}.{}", lecture_id, ext));
+    // We copy rather than move: the user may want to keep their
+    // original file, and moving from arbitrary user dirs gets brittle
+    // (OneDrive-mirrored paths, network shares, etc).
+    std::fs::copy(source, &dest)?;
+    Ok(dest)
+}
+
+#[tauri::command]
+pub async fn import_video_for_lecture(
+    lecture_id: String,
+    source_path: String,
+) -> Result<String, String> {
+    let videos_dir = crate::paths::get_video_dir()
+        .map_err(|e| format!("video dir unavailable: {}", e))?;
+    let dest = stage_video_inner(&videos_dir, &lecture_id, Path::new(&source_path))
+        .map_err(|e| format!("failed to stage video: {}", e))?;
+    Ok(dest.to_string_lossy().into_owned())
+}
+
+#[tauri::command]
+pub async fn extract_pcm_from_video(video_path: String) -> Result<Vec<i16>, String> {
+    extract_pcm_16k_mono(Path::new(&video_path))
+}

--- a/ClassNoteAI/src-tauri/src/recording/video_import.rs
+++ b/ClassNoteAI/src-tauri/src/recording/video_import.rs
@@ -349,6 +349,11 @@ pub async fn transcribe_pcm_file_slice(
     language: Option<String>,
     options: Option<crate::whisper::transcribe::TranscriptionOptions>,
 ) -> Result<crate::whisper::transcribe::TranscriptionResult, String> {
+    let t0 = std::time::Instant::now();
+    println!(
+        "[video_import] slice start: {:.1}..{:.1}s, lang={:?}, pcm={}",
+        start_sec, end_sec, language, pcm_path
+    );
     if end_sec <= start_sec {
         return Err("end_sec must be > start_sec".to_string());
     }
@@ -372,6 +377,11 @@ pub async fn transcribe_pcm_file_slice(
         .chunks_exact(2)
         .map(|b| i16::from_le_bytes([b[0], b[1]]))
         .collect();
+    println!(
+        "[video_import] slice read {} samples in {:.2}s — calling whisper…",
+        samples.len(),
+        t0.elapsed().as_secs_f64()
+    );
 
     if samples.is_empty() {
         return Ok(crate::whisper::transcribe::TranscriptionResult {
@@ -382,10 +392,17 @@ pub async fn transcribe_pcm_file_slice(
         });
     }
 
+    let t_lock = std::time::Instant::now();
     let service_guard = crate::WHISPER_SERVICE.lock().await;
     let service = service_guard
         .as_ref()
         .ok_or_else(|| "Whisper 模型未加載".to_string())?;
+    println!(
+        "[video_import] slice acquired WHISPER_SERVICE lock in {:.2}s",
+        t_lock.elapsed().as_secs_f64()
+    );
+
+    let t_whisper = std::time::Instant::now();
     let mut result = service
         .transcribe(
             &samples,
@@ -396,6 +413,13 @@ pub async fn transcribe_pcm_file_slice(
         )
         .await
         .map_err(|e| format!("轉錄失敗: {}", e))?;
+    println!(
+        "[video_import] slice whisper done in {:.2}s — segments={} lang={:?}, total slice {:.2}s",
+        t_whisper.elapsed().as_secs_f64(),
+        result.segments.len(),
+        result.language,
+        t0.elapsed().as_secs_f64()
+    );
 
     let offset_ms = (start_sec * 1000.0) as u64;
     for seg in result.segments.iter_mut() {

--- a/ClassNoteAI/src-tauri/src/recording/video_import.rs
+++ b/ClassNoteAI/src-tauri/src/recording/video_import.rs
@@ -205,3 +205,37 @@ pub async fn import_video_for_lecture(
 pub async fn extract_pcm_from_video(video_path: String) -> Result<Vec<i16>, String> {
     extract_pcm_16k_mono(Path::new(&video_path))
 }
+
+/// Combined "extract + transcribe" entry point. The original shape --
+/// one command for extract (returns Vec<i16>), one for transcribe --
+/// would have round-tripped up to ~115 MB of PCM over Tauri's JSON IPC
+/// for a 1-hour 16 kHz video. Serialising 57M i16 as JSON text blows
+/// out to ~300 MB and OOMs the webview.
+///
+/// Keeping the PCM inside the Rust process and handing only the
+/// finished transcription segments back (usually a few KB) avoids
+/// the whole issue. The actual Whisper call uses the same WHISPER_SERVICE
+/// singleton as the live-recording path.
+#[tauri::command]
+pub async fn transcribe_video_file(
+    video_path: String,
+    initial_prompt: Option<String>,
+    language: Option<String>,
+    options: Option<crate::whisper::transcribe::TranscriptionOptions>,
+) -> Result<crate::whisper::transcribe::TranscriptionResult, String> {
+    let pcm = extract_pcm_16k_mono(Path::new(&video_path))?;
+    let service_guard = crate::WHISPER_SERVICE.lock().await;
+    let service = service_guard
+        .as_ref()
+        .ok_or_else(|| "Whisper 模型未加載".to_string())?;
+    service
+        .transcribe(
+            &pcm,
+            16_000,
+            initial_prompt.as_deref(),
+            language.as_deref(),
+            options,
+        )
+        .await
+        .map_err(|e| format!("轉錄失敗: {}", e))
+}

--- a/ClassNoteAI/src-tauri/src/storage/database.rs
+++ b/ClassNoteAI/src-tauri/src/storage/database.rs
@@ -239,6 +239,7 @@ impl Database {
                     duration INTEGER NOT NULL,
                     pdf_path TEXT,
                     audio_path TEXT,
+                    video_path TEXT,
                     status TEXT NOT NULL,
                     created_at TEXT NOT NULL,
                     updated_at TEXT NOT NULL,
@@ -378,6 +379,19 @@ impl Database {
             self.conn
                 .execute("ALTER TABLE lectures ADD COLUMN is_deleted INTEGER NOT NULL DEFAULT 0", [])?;
             self.conn.execute("CREATE INDEX IF NOT EXISTS idx_lectures_is_deleted ON lectures(is_deleted)", [])?;
+        }
+
+        // 2.3 v0.6.0 video_path migration. Idempotent — only adds the
+        // column if it's missing on the existing table.
+        let mut stmt = self.conn.prepare("PRAGMA table_info(lectures)")?;
+        let has_video_path = stmt
+            .query_map([], |row| row.get::<_, String>(1))?
+            .any(|name| name.unwrap_or_default() == "video_path");
+        drop(stmt);
+        if !has_video_path {
+            println!("Migrating lectures table: adding video_path column (v0.6.0)");
+            self.conn
+                .execute("ALTER TABLE lectures ADD COLUMN video_path TEXT", [])?;
         }
 
 
@@ -683,8 +697,8 @@ impl Database {
         // — would wipe all subtitles, notes, and the RAG index, and
         // orphan the AI chat history for this lecture.
         self.conn.execute(
-            "INSERT INTO lectures (id, course_id, title, date, duration, pdf_path, audio_path, status, created_at, updated_at, is_deleted)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11)
+            "INSERT INTO lectures (id, course_id, title, date, duration, pdf_path, audio_path, video_path, status, created_at, updated_at, is_deleted)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10, ?11, ?12)
              ON CONFLICT(id) DO UPDATE SET
                 course_id = excluded.course_id,
                 title = excluded.title,
@@ -692,6 +706,7 @@ impl Database {
                 duration = excluded.duration,
                 pdf_path = excluded.pdf_path,
                 audio_path = excluded.audio_path,
+                video_path = excluded.video_path,
                 status = excluded.status,
                 updated_at = excluded.updated_at,
                 is_deleted = excluded.is_deleted",
@@ -703,6 +718,7 @@ impl Database {
                 lecture.duration,
                 lecture.pdf_path,
                 lecture.audio_path,
+                lecture.video_path,
                 lecture.status,
                 lecture.created_at,
                 lecture.updated_at,
@@ -714,8 +730,13 @@ impl Database {
 
     /// 獲取課程
     pub fn get_lecture(&self, id: &str) -> SqlResult<Option<Lecture>> {
+        // v0.6.0: `video_path` appended at column index 11 (was last
+        // `is_deleted` at 10; we now return is_deleted at 10 still
+        // because `Lecture::try_from` reads is_deleted at index 10 and
+        // video_path at index 11 — make sure the SELECT column order
+        // matches that read order exactly).
         let mut stmt = self.conn.prepare(
-            "SELECT id, course_id, title, date, duration, pdf_path, audio_path, status, created_at, updated_at, is_deleted
+            "SELECT id, course_id, title, date, duration, pdf_path, audio_path, status, created_at, updated_at, is_deleted, video_path
              FROM lectures WHERE id = ?1",
         )?;
 
@@ -729,7 +750,7 @@ impl Database {
     /// 列出指定用戶的所有課程 (不包含已刪除)
     pub fn list_lectures(&self, user_id: &str) -> SqlResult<Vec<Lecture>> {
         let mut stmt = self.conn.prepare(
-            "SELECT l.id, l.course_id, l.title, l.date, l.duration, l.pdf_path, l.audio_path, l.status, l.created_at, l.updated_at, l.is_deleted
+            "SELECT l.id, l.course_id, l.title, l.date, l.duration, l.pdf_path, l.audio_path, l.status, l.created_at, l.updated_at, l.is_deleted, l.video_path
              FROM lectures l
              JOIN courses c ON l.course_id = c.id
              WHERE c.user_id = ?1 AND l.is_deleted = 0 AND c.is_deleted = 0
@@ -745,7 +766,7 @@ impl Database {
     /// 列出指定用戶的所有課程 (包含已刪除，用於同步)
     pub fn list_lectures_sync(&self, user_id: &str) -> SqlResult<Vec<Lecture>> {
         let mut stmt = self.conn.prepare(
-            "SELECT l.id, l.course_id, l.title, l.date, l.duration, l.pdf_path, l.audio_path, l.status, l.created_at, l.updated_at, l.is_deleted
+            "SELECT l.id, l.course_id, l.title, l.date, l.duration, l.pdf_path, l.audio_path, l.status, l.created_at, l.updated_at, l.is_deleted, l.video_path
              FROM lectures l
              JOIN courses c ON l.course_id = c.id
              WHERE c.user_id = ?1
@@ -761,7 +782,7 @@ impl Database {
     /// 列出特定科目的所有課堂 (需驗證科目所屬權)
     pub fn list_lectures_by_course(&self, course_id: &str, user_id: &str) -> SqlResult<Vec<Lecture>> {
         let mut stmt = self.conn.prepare(
-            "SELECT l.id, l.course_id, l.title, l.date, l.duration, l.pdf_path, l.audio_path, l.status, l.created_at, l.updated_at, l.is_deleted
+            "SELECT l.id, l.course_id, l.title, l.date, l.duration, l.pdf_path, l.audio_path, l.status, l.created_at, l.updated_at, l.is_deleted, l.video_path
              FROM lectures l
              JOIN courses c ON l.course_id = c.id
              WHERE l.course_id = ?1 AND c.user_id = ?2 AND l.is_deleted = 0
@@ -824,6 +845,10 @@ impl Database {
                     is_deleted: row.get(8)?,
                     created_at: row.get(9)?,
                     updated_at: row.get(10)?,
+                    // This query is used only for orphan-recovery on
+                    // startup, and orphans by definition have no video
+                    // — always None is fine here.
+                    video_path: None,
                 })
             })?
             .collect::<SqlResult<Vec<_>>>()?;
@@ -1101,7 +1126,7 @@ impl Database {
     /// 列出已刪除的課堂
     pub fn list_deleted_lectures(&self, user_id: &str) -> SqlResult<Vec<Lecture>> {
         let mut stmt = self.conn.prepare(
-            "SELECT l.id, l.course_id, l.title, l.date, l.duration, l.pdf_path, l.audio_path, l.status, l.created_at, l.updated_at, l.is_deleted
+            "SELECT l.id, l.course_id, l.title, l.date, l.duration, l.pdf_path, l.audio_path, l.status, l.created_at, l.updated_at, l.is_deleted, l.video_path
              FROM lectures l
              INNER JOIN courses c ON l.course_id = c.id
              WHERE c.user_id = ?1 AND l.is_deleted = 1 ORDER BY l.updated_at DESC",

--- a/ClassNoteAI/src-tauri/src/storage/models.rs
+++ b/ClassNoteAI/src-tauri/src/storage/models.rs
@@ -80,6 +80,14 @@ pub struct Lecture {
     pub duration: i64,
     pub pdf_path: Option<String>,
     pub audio_path: Option<String>,
+    /// v0.6.0+: imported video file path. Staged under
+    /// `{app_data}/videos/{lecture_id}.{ext}` by
+    /// `import_video_for_lecture`. When populated, Notes Review mode
+    /// renders a `<video>` player in place of the audio scrubber and
+    /// the subtitles/RAG index are derived from the video's audio
+    /// track.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub video_path: Option<String>,
     pub status: String,
     pub is_deleted: bool, // Soft Delete
     pub created_at: String,
@@ -97,6 +105,7 @@ impl Lecture {
             duration: 0,
             pdf_path,
             audio_path: None,
+            video_path: None,
             status: "recording".to_string(),
             is_deleted: false,
             created_at: now.clone(),
@@ -121,6 +130,11 @@ impl TryFrom<&Row<'_>> for Lecture {
             created_at: row.get(8)?,
             updated_at: row.get(9)?,
             is_deleted: row.get(10).unwrap_or(false), // Append is_deleted at the end (index 10)
+            // video_path was added in v0.6.0. Existing SELECTs may not
+            // include it yet (column index 11 on updated queries;
+            // absent on old ones). Default to None so pre-migration
+            // rows don't error.
+            video_path: row.get::<_, Option<String>>(11).unwrap_or(None),
         })
     }
 }

--- a/ClassNoteAI/src-tauri/src/translation/ctranslate2.rs
+++ b/ClassNoteAI/src-tauri/src/translation/ctranslate2.rs
@@ -179,12 +179,20 @@ impl CT2Translator {
             .map_err(|e| format!("Translation failed: {}", e))?;
 
         // Extract translations from results, re-interleaving empty
-        // strings at the positions whose inputs we skipped above.
+        // strings at the positions whose inputs we skipped above. Each
+        // output is run through `clean_translation` — M2M100 with the
+        // src-side `__xx__` prefix we prepend occasionally leaks that
+        // token back into the decoded string and, worse, sometimes
+        // echoes the full English source before emitting the Chinese
+        // translation (observed e.g. `"__en__ And we will have to save
+        // it to the next class. 我们将不得不将其保存到下一类。"`).
+        // We strip both unconditionally rather than try to fix the
+        // prompting — post-processing is deterministic and cheap.
         let mut output = vec![String::new(); texts.len()];
         for ((orig_idx, _), (translation, _score)) in
             non_empty.iter().zip(results.into_iter())
         {
-            output[*orig_idx] = translation;
+            output[*orig_idx] = clean_translation(&translation, target_lang);
         }
 
         Ok(output)
@@ -198,6 +206,54 @@ impl CT2Translator {
             .next()
             .ok_or_else(|| "No translation result".to_string())
     }
+}
+
+/// Post-process a raw M2M100 translation output:
+///   1. Strip any `__xx__` / `__xxx__` language tokens — these are
+///      meant to be internal and shouldn't appear in user-visible
+///      text, but M2M100 occasionally echoes them.
+///   2. If the target language is Chinese and the output still starts
+///      with non-CJK characters (observed: the model echoing the
+///      English source before switching languages), drop everything
+///      up to the first CJK character.
+///
+/// Kept conservative — this only touches known failure modes; normal
+/// translations (which are pure target-language text) pass through
+/// unchanged after step 1.
+fn clean_translation(raw: &str, target_lang: &str) -> String {
+    // Step 1: strip `__xx__` / `__xxx__` / `__xxxx__` tokens.
+    let mut s = raw.trim().to_string();
+    loop {
+        let Some(start) = s.find("__") else { break };
+        let remaining = &s[start + 2..];
+        let Some(end_offset) = remaining.find("__") else { break };
+        if end_offset == 0 || end_offset > 4 {
+            // Not a plausible lang token — bail to avoid eating user text.
+            break;
+        }
+        let token_end = start + 2 + end_offset + 2;
+        s.replace_range(start..token_end, " ");
+    }
+    s = s.split_whitespace().collect::<Vec<_>>().join(" ");
+
+    // Step 2: if target is zh, strip any leading non-CJK text. We
+    // consider CJK blocks, CJK extension A, halfwidth/fullwidth punct,
+    // and CJK punct — i.e. anything that could legitimately START a
+    // Chinese sentence.
+    if target_lang.starts_with("zh") {
+        let is_cjk = |c: char| {
+            let u = c as u32;
+            (0x3000..=0x303F).contains(&u) // CJK punctuation
+                || (0x3400..=0x4DBF).contains(&u) // CJK Ext A
+                || (0x4E00..=0x9FFF).contains(&u) // CJK Unified
+                || (0xFF00..=0xFFEF).contains(&u) // Halfwidth/Fullwidth
+                || (0xF900..=0xFAFF).contains(&u) // Compatibility
+        };
+        if let Some((i, _)) = s.char_indices().find(|(_, c)| is_cjk(*c)) {
+            s = s[i..].trim().to_string();
+        }
+    }
+    s
 }
 
 /// Map ISO-ish language codes to the M2M100 language token used by

--- a/ClassNoteAI/src-tauri/src/whisper/transcribe.rs
+++ b/ClassNoteAI/src-tauri/src/whisper/transcribe.rs
@@ -210,9 +210,20 @@ pub async fn transcribe_audio(
             .full_get_segment_t1(i)
             .map_err(|e| anyhow::anyhow!("獲取片段結束時間失敗: {:?}", e))?;
 
-        // 轉換時間戳（從樣本數轉換為毫秒）
-        let start_ms = (start_timestamp * 1000) / sample_rate as i64;
-        let end_ms = (end_timestamp * 1000) / sample_rate as i64;
+        // whisper.cpp's `full_get_segment_t{0,1}` return values in
+        // **centiseconds** (10 ms units) — not sample indices. The
+        // old code `(t * 1000) / sample_rate` treated them as samples
+        // at 16 kHz, which compressed every segment's timestamp to
+        // ~1/16 of its true value and clumped all subtitles at the
+        // start of each chunk (the user-visible "字幕只有分鐘級別
+        // 精度" symptom).
+        //
+        // `sample_rate` is intentionally dropped from the math here —
+        // the unit conversion is purely t_cs * 10 = t_ms, independent
+        // of the input audio's sample rate.
+        let _ = sample_rate;
+        let start_ms = (start_timestamp * 10) as i64;
+        let end_ms = (end_timestamp * 10) as i64;
 
         segments.push(TranscriptionSegment {
             text: segment_text.trim().to_string(),

--- a/ClassNoteAI/src-tauri/tauri.conf.json
+++ b/ClassNoteAI/src-tauri/tauri.conf.json
@@ -23,7 +23,22 @@
       }
     ],
     "security": {
-      "csp": null
+      "csp": null,
+      "assetProtocol": {
+        "enable": true,
+        "scope": {
+          "allow": [
+            "$APPDATA/videos/*",
+            "$APPDATA/videos/**",
+            "$APPDATA/audio/*",
+            "$APPDATA/audio/**",
+            "$HOME/Library/Application Support/com.classnoteai/videos/*",
+            "$HOME/Library/Application Support/com.classnoteai/videos/**",
+            "$HOME/Library/Application Support/com.classnoteai/audio/*",
+            "$HOME/Library/Application Support/com.classnoteai/audio/**"
+          ]
+        }
+      }
     }
   },
   "bundle": {

--- a/ClassNoteAI/src-tauri/tauri.conf.json
+++ b/ClassNoteAI/src-tauri/tauri.conf.json
@@ -19,7 +19,7 @@
         "minHeight": 700,
         "resizable": true,
         "center": true,
-        "dragDropEnabled": false
+        "dragDropEnabled": true
       }
     ],
     "security": {

--- a/ClassNoteAI/src/components/DragDropTest.tsx
+++ b/ClassNoteAI/src/components/DragDropTest.tsx
@@ -6,11 +6,11 @@ import { useState } from "react";
 import DragDropZone from "./DragDropZone";
 
 export default function DragDropTest() {
-  const [droppedFiles, setDroppedFiles] = useState<File[]>([]);
+  const [droppedPaths, setDroppedPaths] = useState<string[]>([]);
 
-  const handleFileDrop = (file: File) => {
-    console.log("測試組件收到文件:", file.name);
-    setDroppedFiles(prev => [...prev, file]);
+  const handleFileDrop = (paths: string[]) => {
+    console.log("測試組件收到檔案:", paths);
+    setDroppedPaths(prev => [...prev, ...paths]);
   };
 
   return (
@@ -22,14 +22,12 @@ export default function DragDropTest() {
       >
         <div className="text-center">
           <p className="text-lg mb-4">拖放文件到此處測試</p>
-          {droppedFiles.length > 0 && (
+          {droppedPaths.length > 0 && (
             <div className="mt-4">
-              <p className="font-semibold mb-2">已接收的文件:</p>
+              <p className="font-semibold mb-2">已接收的檔案:</p>
               <ul className="list-disc list-inside">
-                {droppedFiles.map((file, i) => (
-                  <li key={i}>
-                    {file.name} ({file.size} bytes, {file.type})
-                  </li>
+                {droppedPaths.map((p, i) => (
+                  <li key={i}>{p}</li>
                 ))}
               </ul>
             </div>

--- a/ClassNoteAI/src/components/DragDropZone.tsx
+++ b/ClassNoteAI/src/components/DragDropZone.tsx
@@ -1,291 +1,78 @@
-import { useState, useRef, useCallback, useEffect } from "react";
-import { FolderOpen } from "lucide-react";
-import { logDragEvent, testDragDropSupport } from "../utils/dragDropDebug";
+import { useRef } from 'react';
+import { FolderOpen } from 'lucide-react';
+import { useTauriFileDrop } from '../hooks/useTauriFileDrop';
 
 interface DragDropZoneProps {
-  onFileDrop: (file: File) => void;
-  children: React.ReactNode;
-  className?: string;
+    /** Called once per drop with the absolute filesystem paths Tauri reported. */
+    onFileDrop: (paths: string[]) => void;
+    children: React.ReactNode;
+    className?: string;
+    /** Toggle the subscription without unmounting (e.g. disable
+     *  lecture-level drops while an import modal is open). */
+    enabled?: boolean;
+    /** Hint shown in the drop overlay. */
+    overlayLabel?: string;
+    /** Secondary line below the overlay label. */
+    overlayHint?: string;
 }
 
 /**
- * 拖放區域組件
- * 提供統一的拖放處理邏輯
+ * v0.6.0 refactor: drag-drop now rides on Tauri's native window event
+ * (see useTauriFileDrop). We deleted the HTML5 listeners that the
+ * original implementation used because `dragDropEnabled` in
+ * tauri.conf.json is now `true` — the webview's own drag events no
+ * longer fire. The props shape changed from `File` to `paths: string[]`
+ * since the native event carries filesystem paths, not File handles.
  */
-export default function DragDropZone({ onFileDrop, children, className = "" }: DragDropZoneProps) {
-  const [isDragging, setIsDragging] = useState(false);
-  const dragCounter = useRef(0);
-  const zoneRef = useRef<HTMLDivElement>(null);
+export default function DragDropZone({
+    onFileDrop,
+    children,
+    className = '',
+    enabled = true,
+    overlayLabel = '放開以匯入檔案',
+    overlayHint = '支援影片、PDF、PPT、Word',
+}: DragDropZoneProps) {
+    const zoneRef = useRef<HTMLDivElement>(null);
+    const { isDragging } = useTauriFileDrop({
+        zoneRef,
+        onDrop: onFileDrop,
+        enabled,
+    });
 
-  // 檢查瀏覽器支持並添加全局事件監聽器
-  useEffect(() => {
-    testDragDropSupport();
-    // 拖放診斷已禁用
-    
-    const zoneElement = zoneRef.current;
-    if (!zoneElement) {
-      return;
-    }
-    
-    // 全局拖放事件處理器 - 在 document 層級捕獲所有事件
-    const handleGlobalDragEnter = (e: DragEvent) => {
-      const target = e.target as HTMLElement;
-      const isInZone = target.closest('[data-testid="drag-drop-zone"]');
-      
-      if (isInZone) {
-        e.preventDefault();
-        e.stopPropagation();
-        // 拖放診斷已禁用
-        
-        dragCounter.current++;
-        
-        const types = Array.from(e.dataTransfer?.types || []);
-        
-        if (types.length > 0 || (e.dataTransfer?.files && e.dataTransfer.files.length > 0)) {
-          setIsDragging(true);
-          if (e.dataTransfer) {
-            e.dataTransfer.dropEffect = 'copy';
-          }
-        } else {
-          // 即使沒有類型，也嘗試設置（可能是某些瀏覽器的特殊情況）
-          setIsDragging(true);
-          if (e.dataTransfer) {
-            e.dataTransfer.dropEffect = 'copy';
-          }
-        }
-      }
-    };
-    
-    const handleGlobalDragOver = (e: DragEvent) => {
-      const target = e.target as HTMLElement;
-      const isInZone = target.closest('[data-testid="drag-drop-zone"]');
-      
-      if (isInZone) {
-        e.preventDefault();
-        e.stopPropagation();
-        if (e.dataTransfer) {
-          e.dataTransfer.dropEffect = 'copy';
-        }
-        // 確保拖放狀態已設置
-        setIsDragging(prev => {
-          if (!prev && dragCounter.current > 0) {
-            return true;
-          }
-          return prev;
-        });
-      }
-    };
-    
-    const handleGlobalDragLeave = (e: DragEvent) => {
-      const target = e.target as HTMLElement;
-      const isInZone = target.closest('[data-testid="drag-drop-zone"]');
-      const relatedTarget = e.relatedTarget as HTMLElement;
-      const isLeavingZone = !relatedTarget || !relatedTarget.closest('[data-testid="drag-drop-zone"]');
-      
-      if (isInZone && isLeavingZone) {
-        e.preventDefault();
-        e.stopPropagation();
-        // 拖放診斷已禁用
-        dragCounter.current--;
-        if (dragCounter.current <= 0) {
-          dragCounter.current = 0;
-          setIsDragging(false);
-        }
-      }
-    };
-    
-    const handleGlobalDrop = (e: DragEvent) => {
-      const target = e.target as HTMLElement;
-      const isInZone = target.closest('[data-testid="drag-drop-zone"]');
-      
-      if (isInZone) {
-        e.preventDefault();
-        e.stopPropagation();
-        // 拖放診斷已禁用
-        setIsDragging(false);
-        dragCounter.current = 0;
-        
-        if (e.dataTransfer && e.dataTransfer.files && e.dataTransfer.files.length > 0) {
-          const file = e.dataTransfer.files[0];
-          onFileDrop(file);
-        }
-      }
-    };
-    
-    // 在 document 上添加全局事件監聽器（捕獲階段）
-    document.addEventListener('dragenter', handleGlobalDragEnter, true);
-    document.addEventListener('dragover', handleGlobalDragOver, true);
-    document.addEventListener('dragleave', handleGlobalDragLeave, true);
-    document.addEventListener('drop', handleGlobalDrop, true);
-    
-    // 同時在 window 上添加（確保捕獲所有事件）
-    window.addEventListener('dragenter', handleGlobalDragEnter, true);
-    window.addEventListener('dragover', handleGlobalDragOver, true);
-    window.addEventListener('dragleave', handleGlobalDragLeave, true);
-    window.addEventListener('drop', handleGlobalDrop, true);
-    
-    return () => {
-      document.removeEventListener('dragenter', handleGlobalDragEnter, true);
-      document.removeEventListener('dragover', handleGlobalDragOver, true);
-      document.removeEventListener('dragleave', handleGlobalDragLeave, true);
-      document.removeEventListener('drop', handleGlobalDrop, true);
-      window.removeEventListener('dragenter', handleGlobalDragEnter, true);
-      window.removeEventListener('dragover', handleGlobalDragOver, true);
-      window.removeEventListener('dragleave', handleGlobalDragLeave, true);
-      window.removeEventListener('drop', handleGlobalDrop, true);
-    };
-  }, [onFileDrop]);
-
-  const handleDragEnter = useCallback((e: React.DragEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    
-    // 拖放診斷已禁用
-    logDragEvent('dragEnter', e);
-    
-    dragCounter.current++;
-    
-    // 檢查是否包含文件 - 更寬鬆的檢查
-    const types = Array.from(e.dataTransfer.types);
-    
-    // 對於從文件系統拖放的文件，通常會有 'Files' 類型
-    // 但某些瀏覽器可能使用其他類型，所以我們更寬鬆地檢查
-    const hasFiles = types.includes('Files') || 
-                     types.includes('application/x-moz-file') ||
-                     types.some(t => t.toLowerCase().includes('file')) ||
-                     types.length > 0; // 如果有任何類型，也嘗試處理（可能是文件）
-    
-    // 只要有類型，就設置為拖放狀態（更寬鬆的策略）
-    if (types.length > 0) {
-      setIsDragging(true);
-      e.dataTransfer.dropEffect = 'copy';
-    } else if (hasFiles) {
-      setIsDragging(true);
-      e.dataTransfer.dropEffect = 'copy';
-    }
-  }, []);
-
-  const handleDragLeave = useCallback((e: React.DragEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    
-    // 拖放診斷已禁用
-    logDragEvent('dragLeave', e);
-    
-    dragCounter.current--;
-    
-    // 只有當完全離開拖放區域時才取消拖放狀態
-    if (dragCounter.current === 0) {
-      setIsDragging(false);
-    }
-  }, []);
-
-  const handleDragOver = useCallback((e: React.DragEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    
-    // 設置拖放效果 - 在 dragOver 中必須設置 dropEffect
-    const types = Array.from(e.dataTransfer.types);
-    const hasFiles = types.includes('Files') || 
-                     types.includes('application/x-moz-file') ||
-                     types.some(t => t.toLowerCase().includes('file')) ||
-                     types.length > 0;
-    
-    if (hasFiles || types.length > 0) {
-      e.dataTransfer.dropEffect = 'copy';
-      // 確保拖放狀態已設置（使用函數式更新避免依賴）
-      setIsDragging(prev => {
-        if (!prev && dragCounter.current > 0) {
-          return true;
-        }
-        return prev;
-      });
-    }
-  }, []);
-
-  const handleDrop = useCallback((e: React.DragEvent) => {
-    e.preventDefault();
-    e.stopPropagation();
-    
-    // 拖放診斷已禁用
-    logDragEvent('drop', e);
-    
-    setIsDragging(false);
-    dragCounter.current = 0;
-
-    // 方法1: 直接從 files 獲取
-    const files = e.dataTransfer.files;
-    if (files.length > 0) {
-      const file = files[0];
-      onFileDrop(file);
-      return;
-    }
-
-    // 方法2: 從 items 獲取文件
-    const items = e.dataTransfer.items;
-    if (items && items.length > 0) {
-      for (let i = 0; i < items.length; i++) {
-        const item = items[i];
-
-        if (item.kind === 'file') {
-          // 嘗試直接獲取文件
-          const file = item.getAsFile();
-          if (file) {
-            onFileDrop(file);
-            return;
-          }
-
-          // 嘗試使用 webkitGetAsEntry (Chrome/Safari)
-          const entry = (item as any).webkitGetAsEntry?.();
-          if (entry) {
-            if (entry.isFile) {
-              entry.file((file: File) => {
-                onFileDrop(file);
-              });
-              return;
-            }
-          }
-        }
-      }
-    }
-  }, [onFileDrop]);
-
-  return (
-    <div
-      ref={zoneRef}
-      className={`relative ${className}`}
-      style={{ minHeight: '100%', width: '100%', position: 'relative' }}
-      onDragEnter={handleDragEnter}
-      onDragOver={handleDragOver}
-      onDragLeave={handleDragLeave}
-      onDrop={handleDrop}
-      data-testid="drag-drop-zone"
-    >
-      {isDragging && (
-        <div 
-          className="absolute inset-0 flex items-center justify-center bg-blue-50/90 dark:bg-blue-900/50 border-4 border-blue-500 border-dashed z-[60] pointer-events-none"
-          style={{ 
-            position: 'absolute',
-            top: 0,
-            left: 0,
-            right: 0,
-            bottom: 0,
-            zIndex: 60
-          }}
+    return (
+        <div
+            ref={zoneRef}
+            className={`relative ${className}`}
+            style={{ minHeight: '100%', width: '100%' }}
+            data-testid="drag-drop-zone"
         >
-          <div className="text-center">
-            <FolderOpen size={64} className="mx-auto mb-4 text-blue-500 animate-bounce" />
-            <p className="text-lg text-blue-600 dark:text-blue-400 font-semibold">
-              放開以打開 PDF 文件
-            </p>
-            <p className="text-sm text-blue-500 dark:text-blue-400 mt-2">
-              拖放 PDF 文件到此處
-            </p>
-          </div>
+            {isDragging && (
+                <div
+                    className="absolute inset-0 flex items-center justify-center bg-blue-50/90 dark:bg-blue-900/50 border-4 border-blue-500 border-dashed z-[60] pointer-events-none"
+                    style={{
+                        position: 'absolute',
+                        top: 0,
+                        left: 0,
+                        right: 0,
+                        bottom: 0,
+                        zIndex: 60,
+                    }}
+                >
+                    <div className="text-center">
+                        <FolderOpen
+                            size={64}
+                            className="mx-auto mb-4 text-blue-500 animate-bounce"
+                        />
+                        <p className="text-lg text-blue-600 dark:text-blue-400 font-semibold">
+                            {overlayLabel}
+                        </p>
+                        <p className="text-sm text-blue-500 dark:text-blue-400 mt-2">
+                            {overlayHint}
+                        </p>
+                    </div>
+                </div>
+            )}
+            {children}
         </div>
-      )}
-      {children}
-    </div>
-  );
+    );
 }
-

--- a/ClassNoteAI/src/components/ImportModal.tsx
+++ b/ClassNoteAI/src/components/ImportModal.tsx
@@ -26,6 +26,7 @@ export interface PasteSubmission {
 }
 
 export type VideoLanguage = 'auto' | 'en' | 'zh';
+export type VideoQuality = 'fast' | 'standard';
 
 interface Props {
     open: boolean;
@@ -35,9 +36,9 @@ interface Props {
     progressMessage?: string;
     onClose: () => void;
     /** User clicked "匯入影片檔" → run the native file picker. */
-    onPickVideo: (language: VideoLanguage) => void;
+    onPickVideo: (language: VideoLanguage, quality: VideoQuality) => void;
     /** User dropped a video file directly onto the modal. */
-    onDropVideo: (path: string, language: VideoLanguage) => void;
+    onDropVideo: (path: string, language: VideoLanguage, quality: VideoQuality) => void;
     /** User filled in the paste form and hit confirm. */
     onSubmitPaste: (submission: PasteSubmission) => void;
 }
@@ -58,6 +59,7 @@ export default function ImportModal({
     const [pasteLang, setPasteLang] = useState<SubtitleLanguage>('en');
     const [translate, setTranslate] = useState(true);
     const [videoLang, setVideoLang] = useState<VideoLanguage>('auto');
+    const [videoQuality, setVideoQuality] = useState<VideoQuality>('fast');
     const modalRef = useRef<HTMLDivElement>(null);
 
     // Modal is its own drop zone — takes priority over the NotesView
@@ -69,7 +71,7 @@ export default function ImportModal({
         onDrop: (paths) => {
             const video = paths.find((p) => VIDEO_EXT.test(p));
             if (video) {
-                onDropVideo(video, videoLang);
+                onDropVideo(video, videoLang, videoQuality);
             }
         },
     });
@@ -127,7 +129,7 @@ export default function ImportModal({
                     <div className="p-6 space-y-4">
                         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                             <button
-                                onClick={() => onPickVideo(videoLang)}
+                                onClick={() => onPickVideo(videoLang, videoQuality)}
                                 disabled={isBusy}
                                 className="flex flex-col items-center text-center p-6 rounded-lg border-2 border-dashed border-gray-200 dark:border-gray-700 hover:border-purple-400 hover:bg-purple-50 dark:hover:bg-purple-900/20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                             >
@@ -156,29 +158,47 @@ export default function ImportModal({
                                 </div>
                             </button>
                         </div>
-                        {/* Language row applies to the video import path.
-                            Whisper's auto-detector runs on the first 30 s of
-                            audio and has been observed to land on garbage
-                            (e.g. 'af' with p=0.01) when lectures open with
-                            silence or noise — letting the user pin it
-                            avoids that failure mode. */}
-                        <div className="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-400">
-                            <span>影片語言：</span>
-                            <select
-                                value={videoLang}
-                                onChange={(e) =>
-                                    setVideoLang(e.target.value as VideoLanguage)
-                                }
-                                disabled={isBusy}
-                                className="text-sm px-2 py-1 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-gray-100 disabled:opacity-50"
-                            >
-                                <option value="auto">自動偵測</option>
-                                <option value="en">英文</option>
-                                <option value="zh">中文</option>
-                            </select>
-                            <span className="text-gray-400">
-                                自動偵測偶爾會失準 — 若已知語言建議直接指定
-                            </span>
+                        {/* Video-import options. Applies to both the
+                            click-pick path and the drop path. Quality
+                            defaults to 'fast' because bulk transcription
+                            on CPU with the standard (large/turbo) model
+                            runs at ~1x realtime — a 70-min video is
+                            ~70 min of CPU. Base is ~5x faster and
+                            accurate enough for English lectures; users
+                            who need maximum accuracy can flip back. */}
+                        <div className="space-y-2 pt-1">
+                            <div className="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-400">
+                                <span className="min-w-[4rem]">轉錄速度：</span>
+                                <select
+                                    value={videoQuality}
+                                    onChange={(e) =>
+                                        setVideoQuality(e.target.value as VideoQuality)
+                                    }
+                                    disabled={isBusy}
+                                    className="text-sm px-2 py-1 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-gray-100 disabled:opacity-50"
+                                >
+                                    <option value="fast">快速（base 模型，約 5–10 分鐘/小時）</option>
+                                    <option value="standard">標準（依設定，約 30–60 分鐘/小時）</option>
+                                </select>
+                            </div>
+                            <div className="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-400">
+                                <span className="min-w-[4rem]">影片語言：</span>
+                                <select
+                                    value={videoLang}
+                                    onChange={(e) =>
+                                        setVideoLang(e.target.value as VideoLanguage)
+                                    }
+                                    disabled={isBusy}
+                                    className="text-sm px-2 py-1 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-gray-100 disabled:opacity-50"
+                                >
+                                    <option value="auto">自動偵測</option>
+                                    <option value="en">英文</option>
+                                    <option value="zh">中文</option>
+                                </select>
+                                <span className="text-gray-400">
+                                    自動偵測偶爾會失準 — 若已知語言建議直接指定
+                                </span>
+                            </div>
                         </div>
                     </div>
                 )}

--- a/ClassNoteAI/src/components/ImportModal.tsx
+++ b/ClassNoteAI/src/components/ImportModal.tsx
@@ -28,6 +28,17 @@ export interface PasteSubmission {
 export type VideoLanguage = 'auto' | 'en' | 'zh';
 export type VideoQuality = 'fast' | 'standard';
 
+export interface VideoImportOptions {
+    language: VideoLanguage;
+    quality: VideoQuality;
+    /** Run the LLM-backed fine refinement pass after rough transcribe
+     *  + CT2 translate. Default OFF because a 70-min lecture spends
+     *  ~130k tokens on this pass, and cloud providers charge per token
+     *  (GitHub Models free tier rate-limits). Users who have a local
+     *  LLM or are OK burning tokens can toggle it on. */
+    refineWithAI: boolean;
+}
+
 interface Props {
     open: boolean;
     /** Busy state (video import running) — disables interaction + closes. */
@@ -36,9 +47,9 @@ interface Props {
     progressMessage?: string;
     onClose: () => void;
     /** User clicked "匯入影片檔" → run the native file picker. */
-    onPickVideo: (language: VideoLanguage, quality: VideoQuality) => void;
+    onPickVideo: (options: VideoImportOptions) => void;
     /** User dropped a video file directly onto the modal. */
-    onDropVideo: (path: string, language: VideoLanguage, quality: VideoQuality) => void;
+    onDropVideo: (path: string, options: VideoImportOptions) => void;
     /** User filled in the paste form and hit confirm. */
     onSubmitPaste: (submission: PasteSubmission) => void;
 }
@@ -60,6 +71,7 @@ export default function ImportModal({
     const [translate, setTranslate] = useState(true);
     const [videoLang, setVideoLang] = useState<VideoLanguage>('auto');
     const [videoQuality, setVideoQuality] = useState<VideoQuality>('fast');
+    const [refineWithAI, setRefineWithAI] = useState(false);
     const modalRef = useRef<HTMLDivElement>(null);
 
     // Modal is its own drop zone — takes priority over the NotesView
@@ -71,7 +83,11 @@ export default function ImportModal({
         onDrop: (paths) => {
             const video = paths.find((p) => VIDEO_EXT.test(p));
             if (video) {
-                onDropVideo(video, videoLang, videoQuality);
+                onDropVideo(video, {
+                    language: videoLang,
+                    quality: videoQuality,
+                    refineWithAI,
+                });
             }
         },
     });
@@ -129,7 +145,13 @@ export default function ImportModal({
                     <div className="p-6 space-y-4">
                         <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                             <button
-                                onClick={() => onPickVideo(videoLang, videoQuality)}
+                                onClick={() =>
+                                    onPickVideo({
+                                        language: videoLang,
+                                        quality: videoQuality,
+                                        refineWithAI,
+                                    })
+                                }
                                 disabled={isBusy}
                                 className="flex flex-col items-center text-center p-6 rounded-lg border-2 border-dashed border-gray-200 dark:border-gray-700 hover:border-purple-400 hover:bg-purple-50 dark:hover:bg-purple-900/20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                             >
@@ -199,6 +221,34 @@ export default function ImportModal({
                                     自動偵測偶爾會失準 — 若已知語言建議直接指定
                                 </span>
                             </div>
+                            {/* AI 精修 toggle. Default OFF because a
+                                70-min lecture consumes ~130k tokens through
+                                the user's configured LLM provider, which
+                                is real money on OpenAI/Claude and hits
+                                rate limits on GitHub Models free tier.
+                                Users who want it can opt in; warning copy
+                                below makes the cost visible up-front. */}
+                            <label className="flex items-start gap-2 text-xs text-gray-600 dark:text-gray-400 pt-1">
+                                <input
+                                    type="checkbox"
+                                    checked={refineWithAI}
+                                    onChange={(e) => setRefineWithAI(e.target.checked)}
+                                    disabled={isBusy}
+                                    className="mt-0.5 accent-indigo-500"
+                                />
+                                <span>
+                                    <span className="font-medium text-gray-700 dark:text-gray-300">
+                                        使用 AI 精修字幕
+                                    </span>
+                                    <span className="block text-gray-400 dark:text-gray-500 mt-0.5">
+                                        粗翻譯完成後再請 LLM 修正 ASR 錯誤 + 產生自然中文。
+                                        <span className="text-amber-600 dark:text-amber-500">
+                                            預估 1 小時影片約 130k tokens（GPT-4o ≈ $1、Claude Sonnet ≈ $1.5、GitHub Models 免費但可能撞 rate limit）
+                                        </span>
+                                        。預設關閉。
+                                    </span>
+                                </span>
+                            </label>
                         </div>
                     </div>
                 )}

--- a/ClassNoteAI/src/components/ImportModal.tsx
+++ b/ClassNoteAI/src/components/ImportModal.tsx
@@ -1,0 +1,235 @@
+import { useRef, useState } from 'react';
+import { Film, ClipboardPaste, X, Loader2, ArrowLeft } from 'lucide-react';
+import { useTauriFileDrop } from '../hooks/useTauriFileDrop';
+
+/**
+ * v0.6.0 — unified "匯入" entry point for the Notes view.
+ *
+ * Replaces the standalone "匯入影片" button with a modal that offers
+ * two matched paths:
+ *   1. Import a local video file (ffmpeg → Whisper → CT2 → RAG).
+ *   2. Paste subtitle text for courses that block video download but
+ *      expose captions (SRT/VTT/plain text supported).
+ *
+ * The modal is also a drop zone: dragging a video file anywhere over
+ * it jumps straight into the import flow.
+ */
+
+type Mode = 'menu' | 'paste';
+
+export type SubtitleLanguage = 'en' | 'zh';
+
+export interface PasteSubmission {
+    rawText: string;
+    language: SubtitleLanguage;
+    translateToChinese: boolean;
+}
+
+interface Props {
+    open: boolean;
+    /** Busy state (video import running) — disables interaction + closes. */
+    isBusy: boolean;
+    /** Progress message shown at the bottom while busy. */
+    progressMessage?: string;
+    onClose: () => void;
+    /** User clicked "匯入影片檔" → run the native file picker. */
+    onPickVideo: () => void;
+    /** User dropped a video file directly onto the modal. */
+    onDropVideo: (path: string) => void;
+    /** User filled in the paste form and hit confirm. */
+    onSubmitPaste: (submission: PasteSubmission) => void;
+}
+
+const VIDEO_EXT = /\.(mp4|m4v|mkv|webm|mov|avi)$/i;
+
+export default function ImportModal({
+    open,
+    isBusy,
+    progressMessage,
+    onClose,
+    onPickVideo,
+    onDropVideo,
+    onSubmitPaste,
+}: Props) {
+    const [mode, setMode] = useState<Mode>('menu');
+    const [pasteText, setPasteText] = useState('');
+    const [pasteLang, setPasteLang] = useState<SubtitleLanguage>('en');
+    const [translate, setTranslate] = useState(true);
+    const modalRef = useRef<HTMLDivElement>(null);
+
+    // Modal is its own drop zone — takes priority over the NotesView
+    // drop zone below it because elementFromPoint returns the topmost
+    // element, which is the modal while it's mounted.
+    useTauriFileDrop({
+        zoneRef: modalRef,
+        enabled: open && !isBusy,
+        onDrop: (paths) => {
+            const video = paths.find((p) => VIDEO_EXT.test(p));
+            if (video) {
+                onDropVideo(video);
+            }
+        },
+    });
+
+    if (!open) return null;
+
+    const handleClose = () => {
+        if (isBusy) return;
+        setMode('menu');
+        setPasteText('');
+        onClose();
+    };
+
+    const handlePasteSubmit = () => {
+        if (!pasteText.trim()) return;
+        onSubmitPaste({
+            rawText: pasteText,
+            language: pasteLang,
+            translateToChinese: pasteLang === 'en' && translate,
+        });
+    };
+
+    return (
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+            <div
+                ref={modalRef}
+                className="w-full max-w-2xl mx-4 bg-white dark:bg-slate-900 rounded-xl shadow-2xl border border-gray-200 dark:border-gray-700 overflow-hidden"
+            >
+                <div className="px-6 py-4 border-b border-gray-200 dark:border-gray-700 flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                        {mode === 'paste' && !isBusy && (
+                            <button
+                                onClick={() => setMode('menu')}
+                                className="p-1 rounded hover:bg-gray-100 dark:hover:bg-slate-800 text-gray-500"
+                                title="返回"
+                            >
+                                <ArrowLeft size={18} />
+                            </button>
+                        )}
+                        <h2 className="text-base font-semibold text-gray-900 dark:text-gray-100">
+                            {mode === 'menu' ? '匯入已錄製的課程' : '貼上字幕'}
+                        </h2>
+                    </div>
+                    <button
+                        onClick={handleClose}
+                        disabled={isBusy}
+                        className="p-1 rounded hover:bg-gray-100 dark:hover:bg-slate-800 text-gray-500 disabled:opacity-40 disabled:cursor-not-allowed"
+                        title="關閉"
+                    >
+                        <X size={18} />
+                    </button>
+                </div>
+
+                {mode === 'menu' && (
+                    <div className="p-6 grid grid-cols-1 sm:grid-cols-2 gap-4">
+                        <button
+                            onClick={onPickVideo}
+                            disabled={isBusy}
+                            className="flex flex-col items-center text-center p-6 rounded-lg border-2 border-dashed border-gray-200 dark:border-gray-700 hover:border-purple-400 hover:bg-purple-50 dark:hover:bg-purple-900/20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                            <Film size={36} className="text-purple-500 mb-2" />
+                            <div className="font-medium text-gray-900 dark:text-gray-100">
+                                匯入影片檔
+                            </div>
+                            <div className="text-xs text-gray-500 dark:text-gray-400 mt-2 leading-relaxed">
+                                選擇或拖入 .mp4 / .mkv / .webm
+                                等檔案<br />
+                                自動抽音、轉錄、翻譯、建立 AI 助教索引
+                            </div>
+                        </button>
+                        <button
+                            onClick={() => setMode('paste')}
+                            disabled={isBusy}
+                            className="flex flex-col items-center text-center p-6 rounded-lg border-2 border-dashed border-gray-200 dark:border-gray-700 hover:border-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        >
+                            <ClipboardPaste size={36} className="text-blue-500 mb-2" />
+                            <div className="font-medium text-gray-900 dark:text-gray-100">
+                                貼上字幕
+                            </div>
+                            <div className="text-xs text-gray-500 dark:text-gray-400 mt-2 leading-relaxed">
+                                課程不給下載但可複製字幕時<br />
+                                支援 SRT / VTT / 純文字
+                            </div>
+                        </button>
+                    </div>
+                )}
+
+                {mode === 'paste' && (
+                    <div className="p-6 space-y-4">
+                        <div>
+                            <label className="block text-xs font-medium text-gray-700 dark:text-gray-300 mb-1.5">
+                                字幕內容
+                            </label>
+                            <textarea
+                                value={pasteText}
+                                onChange={(e) => setPasteText(e.target.value)}
+                                disabled={isBusy}
+                                placeholder={
+                                    '支援 SRT：\n1\n00:00:01,000 --> 00:00:04,000\nHello, welcome.\n\n' +
+                                    '或 VTT、或純文字段落（無時間戳會平均分配）'
+                                }
+                                className="w-full h-56 px-3 py-2 text-sm font-mono rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-gray-100 focus:outline-none focus:ring-2 focus:ring-blue-500 disabled:opacity-50"
+                            />
+                        </div>
+                        <div className="flex items-center gap-6 flex-wrap">
+                            <div className="flex items-center gap-2">
+                                <label className="text-xs text-gray-700 dark:text-gray-300">
+                                    字幕語言：
+                                </label>
+                                <select
+                                    value={pasteLang}
+                                    onChange={(e) => setPasteLang(e.target.value as SubtitleLanguage)}
+                                    disabled={isBusy}
+                                    className="text-sm px-2 py-1 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-gray-100 disabled:opacity-50"
+                                >
+                                    <option value="en">英文</option>
+                                    <option value="zh">中文</option>
+                                </select>
+                            </div>
+                            {pasteLang === 'en' && (
+                                <label className="flex items-center gap-2 text-xs text-gray-700 dark:text-gray-300">
+                                    <input
+                                        type="checkbox"
+                                        checked={translate}
+                                        onChange={(e) => setTranslate(e.target.checked)}
+                                        disabled={isBusy}
+                                    />
+                                    翻譯成中文（本機 CT2 模型）
+                                </label>
+                            )}
+                        </div>
+                        <div className="flex justify-end gap-2">
+                            <button
+                                onClick={() => setMode('menu')}
+                                disabled={isBusy}
+                                className="px-4 py-2 text-sm rounded-md border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-100 dark:hover:bg-slate-800 disabled:opacity-50"
+                            >
+                                取消
+                            </button>
+                            <button
+                                onClick={handlePasteSubmit}
+                                disabled={isBusy || !pasteText.trim()}
+                                className="inline-flex items-center gap-1.5 px-4 py-2 text-sm rounded-md bg-blue-600 text-white hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed"
+                            >
+                                {isBusy && <Loader2 size={14} className="animate-spin" />}
+                                確認匯入
+                            </button>
+                        </div>
+                    </div>
+                )}
+
+                {isBusy && (
+                    <div className="px-6 py-3 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-slate-800/30 flex items-center gap-2 text-sm text-gray-600 dark:text-gray-300">
+                        <Loader2 size={14} className="animate-spin text-blue-500" />
+                        {progressMessage || '處理中…'}
+                    </div>
+                )}
+                {!isBusy && mode === 'menu' && (
+                    <div className="px-6 py-3 border-t border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-slate-800/30 text-[11px] text-gray-500 dark:text-gray-400">
+                        提示：影片檔可以直接拖入此視窗
+                    </div>
+                )}
+            </div>
+        </div>
+    );
+}

--- a/ClassNoteAI/src/components/ImportModal.tsx
+++ b/ClassNoteAI/src/components/ImportModal.tsx
@@ -25,6 +25,8 @@ export interface PasteSubmission {
     translateToChinese: boolean;
 }
 
+export type VideoLanguage = 'auto' | 'en' | 'zh';
+
 interface Props {
     open: boolean;
     /** Busy state (video import running) — disables interaction + closes. */
@@ -33,9 +35,9 @@ interface Props {
     progressMessage?: string;
     onClose: () => void;
     /** User clicked "匯入影片檔" → run the native file picker. */
-    onPickVideo: () => void;
+    onPickVideo: (language: VideoLanguage) => void;
     /** User dropped a video file directly onto the modal. */
-    onDropVideo: (path: string) => void;
+    onDropVideo: (path: string, language: VideoLanguage) => void;
     /** User filled in the paste form and hit confirm. */
     onSubmitPaste: (submission: PasteSubmission) => void;
 }
@@ -55,6 +57,7 @@ export default function ImportModal({
     const [pasteText, setPasteText] = useState('');
     const [pasteLang, setPasteLang] = useState<SubtitleLanguage>('en');
     const [translate, setTranslate] = useState(true);
+    const [videoLang, setVideoLang] = useState<VideoLanguage>('auto');
     const modalRef = useRef<HTMLDivElement>(null);
 
     // Modal is its own drop zone — takes priority over the NotesView
@@ -66,7 +69,7 @@ export default function ImportModal({
         onDrop: (paths) => {
             const video = paths.find((p) => VIDEO_EXT.test(p));
             if (video) {
-                onDropVideo(video);
+                onDropVideo(video, videoLang);
             }
         },
     });
@@ -121,36 +124,62 @@ export default function ImportModal({
                 </div>
 
                 {mode === 'menu' && (
-                    <div className="p-6 grid grid-cols-1 sm:grid-cols-2 gap-4">
-                        <button
-                            onClick={onPickVideo}
-                            disabled={isBusy}
-                            className="flex flex-col items-center text-center p-6 rounded-lg border-2 border-dashed border-gray-200 dark:border-gray-700 hover:border-purple-400 hover:bg-purple-50 dark:hover:bg-purple-900/20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                        >
-                            <Film size={36} className="text-purple-500 mb-2" />
-                            <div className="font-medium text-gray-900 dark:text-gray-100">
-                                匯入影片檔
-                            </div>
-                            <div className="text-xs text-gray-500 dark:text-gray-400 mt-2 leading-relaxed">
-                                選擇或拖入 .mp4 / .mkv / .webm
-                                等檔案<br />
-                                自動抽音、轉錄、翻譯、建立 AI 助教索引
-                            </div>
-                        </button>
-                        <button
-                            onClick={() => setMode('paste')}
-                            disabled={isBusy}
-                            className="flex flex-col items-center text-center p-6 rounded-lg border-2 border-dashed border-gray-200 dark:border-gray-700 hover:border-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
-                        >
-                            <ClipboardPaste size={36} className="text-blue-500 mb-2" />
-                            <div className="font-medium text-gray-900 dark:text-gray-100">
-                                貼上字幕
-                            </div>
-                            <div className="text-xs text-gray-500 dark:text-gray-400 mt-2 leading-relaxed">
-                                課程不給下載但可複製字幕時<br />
-                                支援 SRT / VTT / 純文字
-                            </div>
-                        </button>
+                    <div className="p-6 space-y-4">
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+                            <button
+                                onClick={() => onPickVideo(videoLang)}
+                                disabled={isBusy}
+                                className="flex flex-col items-center text-center p-6 rounded-lg border-2 border-dashed border-gray-200 dark:border-gray-700 hover:border-purple-400 hover:bg-purple-50 dark:hover:bg-purple-900/20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                            >
+                                <Film size={36} className="text-purple-500 mb-2" />
+                                <div className="font-medium text-gray-900 dark:text-gray-100">
+                                    匯入影片檔
+                                </div>
+                                <div className="text-xs text-gray-500 dark:text-gray-400 mt-2 leading-relaxed">
+                                    選擇或拖入 .mp4 / .mkv / .webm
+                                    等檔案<br />
+                                    自動抽音、轉錄、翻譯、建立 AI 助教索引
+                                </div>
+                            </button>
+                            <button
+                                onClick={() => setMode('paste')}
+                                disabled={isBusy}
+                                className="flex flex-col items-center text-center p-6 rounded-lg border-2 border-dashed border-gray-200 dark:border-gray-700 hover:border-blue-400 hover:bg-blue-50 dark:hover:bg-blue-900/20 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                            >
+                                <ClipboardPaste size={36} className="text-blue-500 mb-2" />
+                                <div className="font-medium text-gray-900 dark:text-gray-100">
+                                    貼上字幕
+                                </div>
+                                <div className="text-xs text-gray-500 dark:text-gray-400 mt-2 leading-relaxed">
+                                    課程不給下載但可複製字幕時<br />
+                                    支援 SRT / VTT / 純文字
+                                </div>
+                            </button>
+                        </div>
+                        {/* Language row applies to the video import path.
+                            Whisper's auto-detector runs on the first 30 s of
+                            audio and has been observed to land on garbage
+                            (e.g. 'af' with p=0.01) when lectures open with
+                            silence or noise — letting the user pin it
+                            avoids that failure mode. */}
+                        <div className="flex items-center gap-2 text-xs text-gray-600 dark:text-gray-400">
+                            <span>影片語言：</span>
+                            <select
+                                value={videoLang}
+                                onChange={(e) =>
+                                    setVideoLang(e.target.value as VideoLanguage)
+                                }
+                                disabled={isBusy}
+                                className="text-sm px-2 py-1 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-gray-100 disabled:opacity-50"
+                            >
+                                <option value="auto">自動偵測</option>
+                                <option value="en">英文</option>
+                                <option value="zh">中文</option>
+                            </select>
+                            <span className="text-gray-400">
+                                自動偵測偶爾會失準 — 若已知語言建議直接指定
+                            </span>
+                        </div>
                     </div>
                 )}
 

--- a/ClassNoteAI/src/components/LectureView.tsx
+++ b/ClassNoteAI/src/components/LectureView.tsx
@@ -128,55 +128,16 @@ export default function LectureView() {
     checkAndLoadModels();
   }, []); // 空依賴數組，只在組件掛載時執行一次
 
-  const handleFileDrop = async (file: File) => {
-    // 拖放診斷已禁用
-
-    // 驗證文件類型
-    const fileName = file.name.toLowerCase();
-    const isValidPDF = fileName.endsWith('.pdf') || file.type === 'application/pdf' || file.type === '';
-
-    if (!isValidPDF) {
-      console.warn("不是 PDF 文件:", file.name, file.type);
-      alert('請拖放 PDF 文件');
+  const handleFileDrop = async (paths: string[]) => {
+    if (paths.length === 0) return;
+    const path = paths[0];
+    const lower = path.toLowerCase();
+    if (!lower.endsWith('.pdf')) {
+      alert('請拖放 PDF 檔案');
       return;
     }
-
-    console.log("文件驗證通過，開始處理");
-
-    // 在 Tauri 中，嘗試獲取文件路徑
-    // 檢查是否有 path 屬性（Tauri 可能會提供）
-    const filePath = (file as any).path;
-
-    if (filePath && typeof filePath === 'string') {
-      console.log("使用文件路徑:", filePath);
-      // 如果 Tauri 提供了文件路徑，直接使用
-      setPdfPath(filePath);
-    } else {
-      console.log("使用 FileReader 讀取文件");
-      // 使用 FileReader 讀取文件並直接傳遞 ArrayBuffer
-      const reader = new FileReader();
-      reader.onload = async (event) => {
-        if (event.target?.result) {
-          const arrayBuffer = event.target.result as ArrayBuffer;
-          console.log("文件讀取成功，文件大小:", arrayBuffer.byteLength, "bytes");
-
-          // 直接使用 ArrayBuffer，避免 blob URL 的問題
-          setPdfData(arrayBuffer);
-          setPdfPath(null); // 清除 filePath，使用 pdfData
-        }
-      };
-      reader.onerror = (error) => {
-        console.error("文件讀取失敗:", error);
-        alert('文件讀取失敗，請重試');
-      };
-      reader.onprogress = (e) => {
-        if (e.lengthComputable) {
-          const percentLoaded = Math.round((e.loaded / e.total) * 100);
-          console.log(`文件讀取進度: ${percentLoaded}%`);
-        }
-      };
-      reader.readAsArrayBuffer(file);
-    }
+    setPdfPath(path);
+    setPdfData(null);
   };
 
   // 使用 ref 來追蹤模型加載狀態，避免閉包問題

--- a/ClassNoteAI/src/components/NotesView.tsx
+++ b/ClassNoteAI/src/components/NotesView.tsx
@@ -1076,6 +1076,38 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
   // translate, save subtitles, index for RAG. User can leave the
   // window; when they come back, Notes Review mode shows the video
   // with subtitles + AI 助教 fully indexed.
+  /** Reload subtitles from DB into subtitleService so the Review
+   *  mode subtitle panel reflects progressive video-import progress.
+   *  Called from the import progress callback whenever a chunk has
+   *  just been saved — cheap enough (single SQLite query) to rerun
+   *  per chunk for a 70-min lecture (70 chunks). */
+  const reloadSubtitlesFromDb = async (lid: string) => {
+    try {
+      const subs = await storageService.getSubtitles(lid);
+      subtitleService.clear();
+      subtitleService.setLectureId(lid);
+      for (const sub of subs) {
+        subtitleService.addSegment({
+          id: sub.id,
+          roughText: sub.text_en,
+          roughTranslation: sub.text_zh,
+          displayText: sub.text_en,
+          displayTranslation: sub.text_zh,
+          startTime: sub.timestamp * 1000,
+          endTime: (sub.timestamp + 5) * 1000,
+          source: sub.type === 'fine' ? 'fine' : 'rough',
+          translationSource: sub.text_zh
+            ? (sub.type === 'fine' ? 'fine' : 'rough')
+            : undefined,
+          text: sub.text_en,
+          translatedText: sub.text_zh,
+        });
+      }
+    } catch (err) {
+      console.warn('[NotesView] reloadSubtitlesFromDb failed:', err);
+    }
+  };
+
   const runVideoImport = async (
     sourcePath: string,
     language: VideoLanguage = 'auto',
@@ -1088,15 +1120,40 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
       const result = await videoImportService.importVideo(lectureId, sourcePath, {
         language,
         quality,
-        onProgress: (p) => setImportProgressMessage(p.message),
+        onProgress: async (p) => {
+          setImportProgressMessage(p.message);
+          // Step 1 just completed — the video is playable from its
+          // final path. Refresh the lecture row into state so the
+          // Notes Review mode picks up video_path, then close the
+          // import modal. User can now watch while transcription
+          // continues in the background (see progressive caption
+          // pattern above). Also flip to Review mode if they're
+          // still on Recording so the video is actually visible.
+          if (p.stage === 'video_ready') {
+            const fresh = await storageService.getLecture(lectureId);
+            if (fresh) setCurrentLectureData(fresh);
+            setIsImportModalOpen(false);
+            setViewMode('review');
+            toastService.success(
+              '影片已就緒',
+              '可以開始觀看，字幕會隨轉錄逐步填入。',
+            );
+          }
+          // A chunk just persisted new subtitles (or translations).
+          // Reload the in-memory subtitle set so the display updates
+          // without waiting for the whole pipeline to finish.
+          if (p.subtitlesChanged) {
+            await reloadSubtitlesFromDb(lectureId);
+          }
+        },
       });
       const fresh = await storageService.getLecture(lectureId);
       if (fresh) setCurrentLectureData(fresh);
+      await reloadSubtitlesFromDb(lectureId);
       toastService.success(
         '影片匯入完成',
-        `共 ${result.segmentCount} 段字幕，可到 Notes Review 看播放。`,
+        `共 ${result.segmentCount} 段字幕，AI 助教已索引完畢。`,
       );
-      setIsImportModalOpen(false);
     } catch (err) {
       toastService.error('影片匯入失敗', err instanceof Error ? err.message : String(err));
     } finally {

--- a/ClassNoteAI/src/components/NotesView.tsx
+++ b/ClassNoteAI/src/components/NotesView.tsx
@@ -38,7 +38,9 @@ import { generateLocalEmbedding } from "../services/embeddingService";
 import { embeddingStorageService } from "../services/embeddingStorageService";
 import { openDetachedAiTutor } from "../services/aiTutorWindow";
 import { videoImportService } from "../services/videoImportService";
+import { subtitleImportService } from "../services/subtitleImportService";
 import { selectVideoFile } from "../services/fileService";
+import ImportModal, { PasteSubmission } from "./ImportModal";
 import { Lecture, Note, RecordingStatus } from "../types";
 import CourseCreationDialog from "./CourseCreationDialog";
 import { AudioRecorder } from "../services/audioRecorder";
@@ -92,6 +94,7 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
   // v0.6.0 video import state
   const [isImportingVideo, setIsImportingVideo] = useState(false);
   const [importProgressMessage, setImportProgressMessage] = useState<string>('');
+  const [isImportModalOpen, setIsImportModalOpen] = useState(false);
   const [isAIChatOpen, setIsAIChatOpen] = useState(false);
   const [pdfTextContent, setPdfTextContent] = useState<string>('');
   const [transcriptContent, setTranscriptContent] = useState<string>('');
@@ -1068,10 +1071,8 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
   // translate, save subtitles, index for RAG. User can leave the
   // window; when they come back, Notes Review mode shows the video
   // with subtitles + AI 助教 fully indexed.
-  const handleImportVideo = async () => {
+  const runVideoImport = async (sourcePath: string) => {
     if (!lectureId || isImportingVideo) return;
-    const sourcePath = await selectVideoFile();
-    if (!sourcePath) return;
     setIsImportingVideo(true);
     setImportProgressMessage('開始匯入…');
     try {
@@ -1079,16 +1080,50 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
         language: 'auto',
         onProgress: (p) => setImportProgressMessage(p.message),
       });
-      // Refresh lecture state so the Notes Review mode picks up
-      // video_path + new subtitles immediately.
       const fresh = await storageService.getLecture(lectureId);
       if (fresh) setCurrentLectureData(fresh);
       toastService.success(
         '影片匯入完成',
         `共 ${result.segmentCount} 段字幕，可到 Notes Review 看播放。`,
       );
+      setIsImportModalOpen(false);
     } catch (err) {
       toastService.error('影片匯入失敗', err instanceof Error ? err.message : String(err));
+    } finally {
+      setIsImportingVideo(false);
+      setImportProgressMessage('');
+    }
+  };
+
+  const handlePickAndImportVideo = async () => {
+    const sourcePath = await selectVideoFile();
+    if (!sourcePath) return;
+    await runVideoImport(sourcePath);
+  };
+
+  const handleImportPastedSubtitles = async (submission: PasteSubmission) => {
+    if (!lectureId || isImportingVideo) return;
+    setIsImportingVideo(true);
+    setImportProgressMessage('解析字幕…');
+    try {
+      const result = await subtitleImportService.importPasted(
+        lectureId,
+        submission.rawText,
+        {
+          language: submission.language,
+          translateToChinese: submission.translateToChinese,
+          onProgress: (p) => setImportProgressMessage(p.message),
+        },
+      );
+      const fresh = await storageService.getLecture(lectureId);
+      if (fresh) setCurrentLectureData(fresh);
+      toastService.success(
+        '字幕匯入完成',
+        `共 ${result.segmentCount} 段字幕，AI 助教可立即查閱。`,
+      );
+      setIsImportModalOpen(false);
+    } catch (err) {
+      toastService.error('字幕匯入失敗', err instanceof Error ? err.message : String(err));
     } finally {
       setIsImportingVideo(false);
       setImportProgressMessage('');
@@ -1294,98 +1329,58 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
     }
   };
 
-  const handleFileDrop = async (file: File) => {
-    const fileName = file.name.toLowerCase();
-    const isPdf = fileName.endsWith('.pdf') || file.type === 'application/pdf';
-    const isSupported = isPdf || fileName.endsWith('.ppt') || fileName.endsWith('.pptx') ||
-      fileName.endsWith('.doc') || fileName.endsWith('.docx');
+  // v0.6.0 drag-drop now rides on Tauri's native `onDragDropEvent`,
+  // which hands us real filesystem paths instead of HTML5 `File`
+  // objects. That means we can route by extension and avoid the old
+  // `File.arrayBuffer()` + `write_temp_file` round-trip — critical for
+  // video files where that path would JSON-encode hundreds of MB.
+  const handleFileDrop = async (paths: string[]) => {
+    if (paths.length === 0) return;
+    const path = paths[0];
+    const lower = path.toLowerCase();
 
-    if (!isSupported) {
-      toastService.warning('請拖入 PDF、PPT、或 Word 檔案');
+    const isVideo = /\.(mp4|m4v|mkv|webm|mov|avi)$/.test(lower);
+    const isPdf = lower.endsWith('.pdf');
+    const isConvertible =
+      lower.endsWith('.ppt') ||
+      lower.endsWith('.pptx') ||
+      lower.endsWith('.doc') ||
+      lower.endsWith('.docx');
+
+    if (isVideo) {
+      await runVideoImport(path);
+      return;
+    }
+
+    if (isConvertible) {
+      await convertAndLoadDocument(path);
       return;
     }
 
     if (!isPdf) {
-      // Need to convert - save to temp location first
-      const reader = new FileReader();
-      reader.onload = async (event) => {
-        if (event.target?.result) {
-          // Save dropped file to temp location
-          const tempDir = await invoke<string>('get_temp_dir').catch(() => '/tmp');
-          const tempPath = `${tempDir}/${file.name}`;
+      toastService.warning('請拖入影片、PDF、PPT 或 Word 檔案');
+      return;
+    }
 
-          // Write file (we'll need a Tauri command for this)
-          const arrayBuffer = event.target.result as ArrayBuffer;
-          const uint8Array = new Uint8Array(arrayBuffer);
-
-          try {
-            await invoke('write_temp_file', {
-              path: tempPath,
-              data: Array.from(uint8Array)
-            });
-            await convertAndLoadDocument(tempPath);
-          } catch (error) {
-            console.error('Failed to save temp file:', error);
-            toastService.error('檔案處理失敗', '請試試用「選擇檔案」按鈕');
-          }
-        }
-      };
-      reader.readAsArrayBuffer(file);
-    } else {
-      // Direct PDF load — persist the bytes to app data so the PDF
-      // survives a page reload or re-entry to the lecture. Prior to
-      // v0.5.2 the dropped ArrayBuffer lived only in React state and
-      // evaporated on reload, so users lost their slide deck every
-      // time HMR (or an explicit reload) kicked in.
-      const reader = new FileReader();
-      reader.onload = async (event) => {
-        if (!event.target?.result) return;
-        const arrayBuffer = event.target.result as ArrayBuffer;
-        setPdfData(arrayBuffer);
-        try {
-          const appData = await invoke<string>('get_app_data_dir');
-          const sep = navigator.userAgent.includes('Windows') ? '\\' : '/';
-          const safeName = file.name.replace(/[^A-Za-z0-9._-]/g, '_');
-          // v0.5.2 audit follow-up: prefix the filename with the
-          // lecture id. The prior scheme was `{ts}-{name}.pdf` which
-          // had no link back to the lecture, so a `write_temp_file`
-          // success followed by an `updateLecturePDF` DB failure left
-          // an orphan file we couldn't auto-recover. The new pattern
-          // `lecture_{id}_{ts}_{name}.pdf` mirrors the audio convention
-          // and is what `try_recover_pdf_path` (next commit) scans for.
-          const target = `${appData}${sep}lecture-pdfs${sep}lecture_${currentLectureData?.id ?? 'unknown'}_${Date.now()}_${safeName}`;
-          await invoke('write_temp_file', {
-            path: target,
-            data: Array.from(new Uint8Array(arrayBuffer)),
-          });
-          setPdfPath(target);
-          try {
-            await updateLecturePDF(target);
-          } catch (dbErr) {
-            // The FILE is already on disk at `target`. Surface the DB
-            // failure to the user so they know to retry — previously
-            // this was only `console.error`, so the UI showed the PDF
-            // loaded (from in-memory buffer) but the DB didn't know
-            // about it, and the PDF vanished on next reload. With the
-            // new filename pattern, `try_recover_pdf_path` will recover
-            // on next load anyway, but a loud toast prevents confusion.
-            console.error('[NotesView] PDF file written but DB save failed:', dbErr);
-            toastService.error(
-              'PDF 已儲存但資料庫更新失敗',
-              '下次開啟此課堂時系統會自動重新連結。' +
-                (dbErr instanceof Error ? ` (${dbErr.message})` : ''),
-            );
-          }
-        } catch (err) {
-          console.error('[NotesView] Failed to persist dropped PDF:', err);
-          toastService.error(
-            'PDF 儲存失敗',
-            err instanceof Error ? err.message : String(err),
-          );
-          setPdfPath(null);
-        }
-      };
-      reader.readAsArrayBuffer(file);
+    // Load PDF directly from its on-disk path — no temp copy needed.
+    try {
+      const pdfBytes = await invoke<number[]>('read_binary_file', { path });
+      const arrayBuffer = new Uint8Array(pdfBytes).buffer;
+      setPdfData(arrayBuffer);
+      setPdfPath(path);
+      try {
+        await updateLecturePDF(path);
+      } catch (dbErr) {
+        console.error('[NotesView] PDF path loaded but DB save failed:', dbErr);
+        toastService.error(
+          'PDF 資料庫更新失敗',
+          '下次開啟此課堂時系統會自動重新連結。' +
+            (dbErr instanceof Error ? ` (${dbErr.message})` : ''),
+        );
+      }
+    } catch (err) {
+      console.error('[NotesView] Failed to read dropped PDF:', err);
+      toastService.error('PDF 讀取失敗', err instanceof Error ? err.message : String(err));
     }
   };
 
@@ -1773,14 +1768,14 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
               Save. */}
           {viewMode === 'recording' && lectureId && (
             <button
-              onClick={handleImportVideo}
+              onClick={() => setIsImportModalOpen(true)}
               disabled={isImportingVideo}
               className="flex items-center gap-2 px-3 py-2 bg-purple-50 dark:bg-purple-900/20 text-purple-600 dark:text-purple-400 rounded-lg hover:bg-purple-100 dark:hover:bg-purple-900/30 transition-colors disabled:opacity-50"
-              title="匯入已錄製的影片，自動轉錄 + 翻譯 + 建立 AI 助教索引"
+              title="匯入已錄製的影片或課程字幕"
             >
               {isImportingVideo ? <Loader2 size={18} className="animate-spin" /> : <Film size={18} />}
               <span className="hidden sm:inline">
-                {isImportingVideo ? (importProgressMessage || '處理中…') : '匯入影片'}
+                {isImportingVideo ? (importProgressMessage || '處理中…') : '匯入'}
               </span>
             </button>
           )}
@@ -1869,7 +1864,7 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
                       </button>
                     </div>
                   )}
-                  <DragDropZone onFileDrop={handleFileDrop} className="flex-1 overflow-hidden">
+                  <DragDropZone onFileDrop={handleFileDrop} enabled={!isImportModalOpen} className="flex-1 overflow-hidden">
                     {pdfPath || pdfData ? (
                       <PDFViewer
                         ref={pdfViewerRef}
@@ -2308,6 +2303,16 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
           displayMode="floating"
         />
       )}
+
+      <ImportModal
+        open={isImportModalOpen}
+        isBusy={isImportingVideo}
+        progressMessage={importProgressMessage}
+        onClose={() => setIsImportModalOpen(false)}
+        onPickVideo={handlePickAndImportVideo}
+        onDropVideo={(path) => runVideoImport(path)}
+        onSubmitPaste={handleImportPastedSubtitles}
+      />
     </div >
   );
 }

--- a/ClassNoteAI/src/components/NotesView.tsx
+++ b/ClassNoteAI/src/components/NotesView.tsx
@@ -40,7 +40,7 @@ import { openDetachedAiTutor } from "../services/aiTutorWindow";
 import { videoImportService } from "../services/videoImportService";
 import { subtitleImportService } from "../services/subtitleImportService";
 import { selectVideoFile } from "../services/fileService";
-import ImportModal, { PasteSubmission, VideoLanguage } from "./ImportModal";
+import ImportModal, { PasteSubmission, VideoLanguage, VideoQuality } from "./ImportModal";
 import { Lecture, Note, RecordingStatus } from "../types";
 import CourseCreationDialog from "./CourseCreationDialog";
 import { AudioRecorder } from "../services/audioRecorder";
@@ -1076,13 +1076,18 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
   // translate, save subtitles, index for RAG. User can leave the
   // window; when they come back, Notes Review mode shows the video
   // with subtitles + AI 助教 fully indexed.
-  const runVideoImport = async (sourcePath: string, language: VideoLanguage = 'auto') => {
+  const runVideoImport = async (
+    sourcePath: string,
+    language: VideoLanguage = 'auto',
+    quality: VideoQuality = 'fast',
+  ) => {
     if (!lectureId || isImportingVideo) return;
     setIsImportingVideo(true);
     setImportProgressMessage('開始匯入…');
     try {
       const result = await videoImportService.importVideo(lectureId, sourcePath, {
         language,
+        quality,
         onProgress: (p) => setImportProgressMessage(p.message),
       });
       const fresh = await storageService.getLecture(lectureId);
@@ -1100,10 +1105,10 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
     }
   };
 
-  const handlePickAndImportVideo = async (language: VideoLanguage) => {
+  const handlePickAndImportVideo = async (language: VideoLanguage, quality: VideoQuality) => {
     const sourcePath = await selectVideoFile();
     if (!sourcePath) return;
-    await runVideoImport(sourcePath, language);
+    await runVideoImport(sourcePath, language, quality);
   };
 
   const handleImportPastedSubtitles = async (submission: PasteSubmission) => {
@@ -2357,7 +2362,7 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
         progressMessage={importProgressMessage}
         onClose={() => setIsImportModalOpen(false)}
         onPickVideo={handlePickAndImportVideo}
-        onDropVideo={(path, language) => runVideoImport(path, language)}
+        onDropVideo={(path, language, quality) => runVideoImport(path, language, quality)}
         onSubmitPaste={handleImportPastedSubtitles}
       />
     </div >

--- a/ClassNoteAI/src/components/NotesView.tsx
+++ b/ClassNoteAI/src/components/NotesView.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useRef } from "react";
-import { invoke } from "@tauri-apps/api/core";
+import { invoke, convertFileSrc } from "@tauri-apps/api/core";
 import { readFile } from "@tauri-apps/plugin-fs";
-import { Download, ArrowLeft, Pencil, Cpu, Loader2, FileText, Mic, MicOff, Pause, Square, Save, BookOpen, FolderOpen, Wand2, Bot } from "lucide-react";
+import { Download, ArrowLeft, Pencil, Cpu, Loader2, FileText, Mic, MicOff, Pause, Square, Save, BookOpen, FolderOpen, Wand2, Bot, Film } from "lucide-react";
 import { Panel, PanelGroup, PanelResizeHandle } from "react-resizable-panels";
 import { useNavigate, useParams } from "react-router-dom";
 import ReactMarkdown from 'react-markdown';
@@ -37,6 +37,8 @@ import { toastService } from "../services/toastService";
 import { generateLocalEmbedding } from "../services/embeddingService";
 import { embeddingStorageService } from "../services/embeddingStorageService";
 import { openDetachedAiTutor } from "../services/aiTutorWindow";
+import { videoImportService } from "../services/videoImportService";
+import { selectVideoFile } from "../services/fileService";
 import { Lecture, Note, RecordingStatus } from "../types";
 import CourseCreationDialog from "./CourseCreationDialog";
 import { AudioRecorder } from "../services/audioRecorder";
@@ -87,6 +89,9 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
   const [autoScrollEnabled, setAutoScrollEnabled] = useState(true);
   const [alignmentSuggestion, setAlignmentSuggestion] = useState<AlignmentSuggestion | null>(null);
   const [isConverting, setIsConverting] = useState(false);
+  // v0.6.0 video import state
+  const [isImportingVideo, setIsImportingVideo] = useState(false);
+  const [importProgressMessage, setImportProgressMessage] = useState<string>('');
   const [isAIChatOpen, setIsAIChatOpen] = useState(false);
   const [pdfTextContent, setPdfTextContent] = useState<string>('');
   const [transcriptContent, setTranscriptContent] = useState<string>('');
@@ -228,7 +233,12 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
   const [audioCurrentTime, setAudioCurrentTime] = useState(0);
   const [audioDuration, setAudioDuration] = useState(0);
   const [isPlaying, setIsPlaying] = useState(false);
-  const audioRef = useRef<HTMLAudioElement>(null);
+  // v0.6.0: `audioRef` is now HTMLMediaElement so the same ref can
+  // point at either the hidden <audio> (live-recorded lecture) or the
+  // visible <video> (imported video lecture). All existing playback
+  // helpers (togglePlay, handleSeek, handleTimeUpdate) work off
+  // HTMLMediaElement members so the branch is purely render-side.
+  const audioRef = useRef<HTMLMediaElement>(null);
   const [playbackVolume, setPlaybackVolume] = useState(100); // Output volume for playback
 
   // Initialize audio when review mode starts or lecture loads
@@ -1054,6 +1064,37 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
     }
   };
 
+  // v0.6.0: pick a video, copy it into app data, transcribe it,
+  // translate, save subtitles, index for RAG. User can leave the
+  // window; when they come back, Notes Review mode shows the video
+  // with subtitles + AI 助教 fully indexed.
+  const handleImportVideo = async () => {
+    if (!lectureId || isImportingVideo) return;
+    const sourcePath = await selectVideoFile();
+    if (!sourcePath) return;
+    setIsImportingVideo(true);
+    setImportProgressMessage('開始匯入…');
+    try {
+      const result = await videoImportService.importVideo(lectureId, sourcePath, {
+        language: 'auto',
+        onProgress: (p) => setImportProgressMessage(p.message),
+      });
+      // Refresh lecture state so the Notes Review mode picks up
+      // video_path + new subtitles immediately.
+      const fresh = await storageService.getLecture(lectureId);
+      if (fresh) setCurrentLectureData(fresh);
+      toastService.success(
+        '影片匯入完成',
+        `共 ${result.segmentCount} 段字幕，可到 Notes Review 看播放。`,
+      );
+    } catch (err) {
+      toastService.error('影片匯入失敗', err instanceof Error ? err.message : String(err));
+    } finally {
+      setIsImportingVideo(false);
+      setImportProgressMessage('');
+    }
+  };
+
   const handleSaveLecture = async (lectureOverride?: any) => {
     // Determine which lecture data to use (current state or override)
     // React Event objects might be passed as first arg if used in onClick
@@ -1725,6 +1766,25 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
             </button>
           )}
 
+          {/* v0.6.0: Import Video button — runs the imported-video
+              pipeline (ffmpeg → Whisper → subtitles → RAG index)
+              and ends with the lecture ready to review in Notes
+              Review mode. Shown only in recording mode, alongside
+              Save. */}
+          {viewMode === 'recording' && lectureId && (
+            <button
+              onClick={handleImportVideo}
+              disabled={isImportingVideo}
+              className="flex items-center gap-2 px-3 py-2 bg-purple-50 dark:bg-purple-900/20 text-purple-600 dark:text-purple-400 rounded-lg hover:bg-purple-100 dark:hover:bg-purple-900/30 transition-colors disabled:opacity-50"
+              title="匯入已錄製的影片，自動轉錄 + 翻譯 + 建立 AI 助教索引"
+            >
+              {isImportingVideo ? <Loader2 size={18} className="animate-spin" /> : <Film size={18} />}
+              <span className="hidden sm:inline">
+                {isImportingVideo ? (importProgressMessage || '處理中…') : '匯入影片'}
+              </span>
+            </button>
+          )}
+
           {/* Summary & Export Buttons (Visible in Review Mode) */}
           {viewMode === 'review' && selectedNote && (
             <>
@@ -2141,13 +2201,34 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
               </div>
             )}
 
-            {/* Hidden Audio Element */}
-            <audio
-              ref={audioRef}
-              onTimeUpdate={handleTimeUpdate}
-              onLoadedMetadata={handleLoadedMetadata}
-              onEnded={() => setIsPlaying(false)}
-            />
+            {/* Media element — <video> when a video was imported for
+                this lecture (v0.6.0), otherwise the original hidden
+                <audio>. We swap ref targets only; the existing
+                playback control wiring (togglePlay / handleSeek /
+                subtitle sync) is media-type agnostic. Video path uses
+                Tauri's asset:// protocol via convertFileSrc so we
+                stream the file off disk instead of pulling the whole
+                thing into a blob URL -- a 1 GB lecture recording
+                wouldn't survive that. */}
+            {currentLectureData?.video_path ? (
+              <video
+                ref={audioRef as React.RefObject<HTMLVideoElement>}
+                src={convertFileSrc(currentLectureData.video_path)}
+                onTimeUpdate={handleTimeUpdate}
+                onLoadedMetadata={handleLoadedMetadata}
+                onEnded={() => setIsPlaying(false)}
+                controls
+                className="w-full rounded-lg bg-black"
+                style={{ maxHeight: '50vh' }}
+              />
+            ) : (
+              <audio
+                ref={audioRef as React.RefObject<HTMLAudioElement>}
+                onTimeUpdate={handleTimeUpdate}
+                onLoadedMetadata={handleLoadedMetadata}
+                onEnded={() => setIsPlaying(false)}
+              />
+            )}
           </div>
         )}
             </div>

--- a/ClassNoteAI/src/components/NotesView.tsx
+++ b/ClassNoteAI/src/components/NotesView.tsx
@@ -1147,9 +1147,12 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
           }
         },
       });
-      const fresh = await storageService.getLecture(lectureId);
-      if (fresh) setCurrentLectureData(fresh);
-      await reloadSubtitlesFromDb(lectureId);
+      // Re-run the full lecture load once import completes so the
+      // auto-note-generation path fires (same code that runs on first
+      // open of a lecture that already has subtitles). Without this the
+      // Notes tab stays empty and the "總結 / 匯出" header buttons —
+      // which gate on `selectedNote` — don't appear.
+      await loadLectureData(lectureId);
       toastService.success(
         '影片匯入完成',
         `共 ${result.segmentCount} 段字幕，AI 助教已索引完畢。`,
@@ -1837,7 +1840,14 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
               and ends with the lecture ready to review in Notes
               Review mode. Shown only in recording mode, alongside
               Save. */}
-          {viewMode === 'recording' && lectureId && (
+          {/* 匯入 button visibility:
+                - Always in Recording mode (so user can start an import
+                  from a fresh lecture).
+                - Also in Review mode WHILE an import is running, so
+                  the progress message stays with the user after we
+                  auto-switch them to Review in the `video_ready`
+                  handler — otherwise they lose sight of "轉錄 N/70". */}
+          {lectureId && (viewMode === 'recording' || isImportingVideo) && (
             <button
               onClick={() => setIsImportModalOpen(true)}
               disabled={isImportingVideo}
@@ -1918,8 +1928,19 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
             className="overflow-hidden"
           >
             <div className="h-full overflow-hidden">
-        {viewMode === 'recording' ? (
-          // Recording Mode Layout (Split View with Resizable Panels)
+        {/* v0.6.0 keep-alive: both mode layouts render simultaneously
+            with one hidden via the `hidden` attribute. Prior to this
+            the ternary unmounted Review's <video> whenever the user
+            tabbed to Live, so flipping back triggered a full reload
+            from disk (slow buffering, media state reset to t=0). The
+            dual-mount keeps the <video> element — and its `currentTime`,
+            buffered ranges, pause state — stable across toggles. The
+            cost is trivial: both PanelGroups are lightweight layout
+            containers; the only heavy child is PDFViewer, and the
+            Live-mode one shares pdfPath/pdfData state so renders
+            cheaply when hidden. Drop zones in each mode are guarded
+            with `enabled` so only the visible one accepts files. */}
+        <div hidden={viewMode !== 'recording'} className="h-full">
           <div className="flex flex-col h-full">
             <PanelGroup direction="horizontal" className="flex-1">
               {/* Left Panel: PDF Viewer */}
@@ -2035,15 +2056,15 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
               </Panel>
             </PanelGroup>
 
-            {/* Bottom Audio Player Bar (Optional position, currently integrating roughly where controls were but lets keep it separate if needed) 
-                 Actually, the requirement was to put Audio Player broadly. 
+            {/* Bottom Audio Player Bar (Optional position, currently integrating roughly where controls were but lets keep it separate if needed)
+                 Actually, the requirement was to put Audio Player broadly.
                  For 'Recording Mode', we use the live controls above.
                  AudioPlayer is mostly for 'Review Mode' to play back recorded audio.
                  Let's stick to the plan: AudioPlayer helps in playback.
              */}
           </div>
-        ) : (
-          // Review Mode Layout (Split View with Audio Player)
+        </div>
+        <div hidden={viewMode !== 'review'} className="h-full">
           <div className="flex flex-col h-full overflow-hidden relative">
             <PanelGroup direction="horizontal" className="flex-1 overflow-hidden">
               {/* Left Panel: Reference Area. v0.6.0 — content depends
@@ -2334,7 +2355,7 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
               />
             )}
           </div>
-        )}
+        </div>
             </div>
           </Panel>
           {/* Sidebar Panel — only rendered in sidebar mode + open.

--- a/ClassNoteAI/src/components/NotesView.tsx
+++ b/ClassNoteAI/src/components/NotesView.tsx
@@ -40,7 +40,7 @@ import { openDetachedAiTutor } from "../services/aiTutorWindow";
 import { videoImportService } from "../services/videoImportService";
 import { subtitleImportService } from "../services/subtitleImportService";
 import { selectVideoFile } from "../services/fileService";
-import ImportModal, { PasteSubmission } from "./ImportModal";
+import ImportModal, { PasteSubmission, VideoLanguage } from "./ImportModal";
 import { Lecture, Note, RecordingStatus } from "../types";
 import CourseCreationDialog from "./CourseCreationDialog";
 import { AudioRecorder } from "../services/audioRecorder";
@@ -52,6 +52,7 @@ import * as translationModelService from "../services/translationModelService";
 import { subtitleService } from "../services/subtitleService";
 import PDFViewer, { PDFViewerHandle } from "./PDFViewer";
 import DragDropZone from "./DragDropZone";
+import VideoPiP from "./VideoPiP";
 import { selectPDFFile } from "../services/fileService";
 import { autoAlignmentService, AlignmentSuggestion } from "../services/autoAlignmentService";
 import { pdfService } from "../services/pdfService";
@@ -112,6 +113,8 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
   const [alignmentRefreshTick, setAlignmentRefreshTick] = useState(0);
   // User-configurable AI 助教 chrome mode (Settings → 雲端 AI 助理).
   const [aiTutorMode, setAiTutorMode] = useState<'floating' | 'sidebar' | 'detached'>('floating');
+  // v0.6.0 video+PDF layout. Loaded from settings (lectureLayout.videoPdfMode).
+  const [videoPdfMode, setVideoPdfMode] = useState<'split' | 'pip'>('split');
   const [currentPage, setCurrentPage] = useState(1);
   // Pieces of the Whisper initial_prompt. Stored separately so
   // `handleTextExtract` (PDF side) and `loadLecture` (course side)
@@ -402,6 +405,8 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
         const settings = await storageService.getAppSettings();
         const mode = settings?.aiTutor?.displayMode ?? 'floating';
         setAiTutorMode(mode);
+        const layout = settings?.lectureLayout?.videoPdfMode ?? 'split';
+        setVideoPdfMode(layout);
       } catch { /* ignore */ }
     })();
   }, []);
@@ -1071,13 +1076,13 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
   // translate, save subtitles, index for RAG. User can leave the
   // window; when they come back, Notes Review mode shows the video
   // with subtitles + AI 助教 fully indexed.
-  const runVideoImport = async (sourcePath: string) => {
+  const runVideoImport = async (sourcePath: string, language: VideoLanguage = 'auto') => {
     if (!lectureId || isImportingVideo) return;
     setIsImportingVideo(true);
     setImportProgressMessage('開始匯入…');
     try {
       const result = await videoImportService.importVideo(lectureId, sourcePath, {
-        language: 'auto',
+        language,
         onProgress: (p) => setImportProgressMessage(p.message),
       });
       const fresh = await storageService.getLecture(lectureId);
@@ -1095,10 +1100,10 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
     }
   };
 
-  const handlePickAndImportVideo = async () => {
+  const handlePickAndImportVideo = async (language: VideoLanguage) => {
     const sourcePath = await selectVideoFile();
     if (!sourcePath) return;
-    await runVideoImport(sourcePath);
+    await runVideoImport(sourcePath, language);
   };
 
   const handleImportPastedSubtitles = async (submission: PasteSubmission) => {
@@ -1348,7 +1353,11 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
       lower.endsWith('.docx');
 
     if (isVideo) {
-      await runVideoImport(path);
+      // Dragging a video onto the lecture area uses auto-detect by
+      // default — the user hasn't been through the modal where they
+      // could pick a language. If detection fails they can retry via
+      // the 匯入 button and pick explicitly.
+      await runVideoImport(path, 'auto');
       return;
     }
 
@@ -1975,26 +1984,78 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
           // Review Mode Layout (Split View with Audio Player)
           <div className="flex flex-col h-full overflow-hidden relative">
             <PanelGroup direction="horizontal" className="flex-1 overflow-hidden">
-              {/* Left Panel: PDF Viewer (Ref Area) */}
+              {/* Left Panel: Reference Area. v0.6.0 — content depends
+                  on which artifacts this lecture has:
+                    - video only: full-panel <video>
+                    - PDF only: full-panel PDFViewer (historical default)
+                    - both + split: vertical resizable split (video top / PDF bottom)
+                    - both + pip:   PDF fills, video floats as an overlay
+                  Layout choice comes from settings.lectureLayout.videoPdfMode. */}
               <Panel defaultSize={50} minSize={20} className="flex flex-col border-r border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-gray-900">
-                {/* PDF Header? Maybe keep it simple */}
-                <DragDropZone onFileDrop={handleFileDrop} className="flex-1 overflow-hidden">
-                  {pdfPath || pdfData ? (
-                    <PDFViewer
-                      ref={pdfViewerRef}
-                      filePath={pdfPath || undefined}
-                      pdfData={pdfData || undefined}
-                      onTextExtract={handleTextExtract}
-                      onPageChange={setCurrentPage}
-                    />
-                  ) : (
-                    <div className="flex items-center justify-center h-full text-gray-500">
-                      <div className="text-center">
-                        <BookOpen size={48} className="mx-auto mb-4 opacity-20" />
-                        <p>No PDF Reference</p>
+                <DragDropZone onFileDrop={handleFileDrop} enabled={!isImportModalOpen} className="flex-1 overflow-hidden">
+                  {(() => {
+                    const hasVideo = !!currentLectureData?.video_path;
+                    const hasPdf = !!(pdfPath || pdfData);
+                    const pdfPane = hasPdf ? (
+                      <PDFViewer
+                        ref={pdfViewerRef}
+                        filePath={pdfPath || undefined}
+                        pdfData={pdfData || undefined}
+                        onTextExtract={handleTextExtract}
+                        onPageChange={setCurrentPage}
+                      />
+                    ) : (
+                      <div className="flex items-center justify-center h-full text-gray-500">
+                        <div className="text-center">
+                          <BookOpen size={48} className="mx-auto mb-4 opacity-20" />
+                          <p>No PDF Reference</p>
+                        </div>
                       </div>
-                    </div>
-                  )}
+                    );
+                    const videoEl = hasVideo ? (
+                      <video
+                        ref={audioRef as React.RefObject<HTMLVideoElement>}
+                        src={convertFileSrc(currentLectureData!.video_path!)}
+                        onTimeUpdate={handleTimeUpdate}
+                        onLoadedMetadata={handleLoadedMetadata}
+                        onEnded={() => setIsPlaying(false)}
+                        controls
+                        className="w-full h-full bg-black object-contain"
+                      />
+                    ) : null;
+
+                    if (hasVideo && hasPdf && videoPdfMode === 'split') {
+                      return (
+                        <PanelGroup direction="vertical" autoSaveId="notesview-left-split">
+                          <Panel defaultSize={40} minSize={20}>
+                            <div className="w-full h-full bg-black">{videoEl}</div>
+                          </Panel>
+                          <PanelResizeHandle className="h-1.5 bg-gray-200 dark:bg-gray-700 hover:bg-blue-400 dark:hover:bg-blue-600 transition-colors cursor-row-resize" />
+                          <Panel defaultSize={60} minSize={20}>
+                            {pdfPane}
+                          </Panel>
+                        </PanelGroup>
+                      );
+                    }
+                    if (hasVideo && hasPdf && videoPdfMode === 'pip') {
+                      return (
+                        <div className="relative w-full h-full">
+                          {pdfPane}
+                          <VideoPiP
+                            ref={audioRef as React.RefObject<HTMLVideoElement>}
+                            src={convertFileSrc(currentLectureData!.video_path!)}
+                            onTimeUpdate={handleTimeUpdate}
+                            onLoadedMetadata={handleLoadedMetadata}
+                            onEnded={() => setIsPlaying(false)}
+                          />
+                        </div>
+                      );
+                    }
+                    if (hasVideo) {
+                      return <div className="w-full h-full bg-black">{videoEl}</div>;
+                    }
+                    return pdfPane;
+                  })()}
                 </DragDropZone>
               </Panel>
 
@@ -2196,27 +2257,13 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
               </div>
             )}
 
-            {/* Media element — <video> when a video was imported for
-                this lecture (v0.6.0), otherwise the original hidden
-                <audio>. We swap ref targets only; the existing
-                playback control wiring (togglePlay / handleSeek /
-                subtitle sync) is media-type agnostic. Video path uses
-                Tauri's asset:// protocol via convertFileSrc so we
-                stream the file off disk instead of pulling the whole
-                thing into a blob URL -- a 1 GB lecture recording
-                wouldn't survive that. */}
-            {currentLectureData?.video_path ? (
-              <video
-                ref={audioRef as React.RefObject<HTMLVideoElement>}
-                src={convertFileSrc(currentLectureData.video_path)}
-                onTimeUpdate={handleTimeUpdate}
-                onLoadedMetadata={handleLoadedMetadata}
-                onEnded={() => setIsPlaying(false)}
-                controls
-                className="w-full rounded-lg bg-black"
-                style={{ maxHeight: '50vh' }}
-              />
-            ) : (
+            {/* Audio-only lectures keep the hidden <audio> ref here;
+                video lectures render the <video> on the left panel
+                (see the Review Mode left panel block above). The ref
+                target switches based on `currentLectureData.video_path`
+                — all playback wiring (togglePlay / handleSeek /
+                subtitle sync) is media-type agnostic. */}
+            {!currentLectureData?.video_path && (
               <audio
                 ref={audioRef as React.RefObject<HTMLAudioElement>}
                 onTimeUpdate={handleTimeUpdate}
@@ -2310,7 +2357,7 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
         progressMessage={importProgressMessage}
         onClose={() => setIsImportModalOpen(false)}
         onPickVideo={handlePickAndImportVideo}
-        onDropVideo={(path) => runVideoImport(path)}
+        onDropVideo={(path, language) => runVideoImport(path, language)}
         onSubmitPaste={handleImportPastedSubtitles}
       />
     </div >

--- a/ClassNoteAI/src/components/NotesView.tsx
+++ b/ClassNoteAI/src/components/NotesView.tsx
@@ -40,7 +40,7 @@ import { openDetachedAiTutor } from "../services/aiTutorWindow";
 import { videoImportService } from "../services/videoImportService";
 import { subtitleImportService } from "../services/subtitleImportService";
 import { selectVideoFile } from "../services/fileService";
-import ImportModal, { PasteSubmission, VideoLanguage, VideoQuality } from "./ImportModal";
+import ImportModal, { PasteSubmission, VideoImportOptions } from "./ImportModal";
 import { Lecture, Note, RecordingStatus } from "../types";
 import CourseCreationDialog from "./CourseCreationDialog";
 import { AudioRecorder } from "../services/audioRecorder";
@@ -313,29 +313,12 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
     }
   };
 
-  const handleSubtitleSeek = (timestamp: number) => {
-    // timestamp is absolute Date time (ms). We need relative seconds.
-    // Assuming recording started at lecture.created_at? 
-    // Or first segment start time? 
-    // Ideally we store 'recording_start_time' in lecture.
-    // Fallback: Use 1st segment start time as rough base 
-    // OR assume 0 if we can't determine.
-    // In "Live Recording", usually the first segment starts at ~0-5s.
-    // Let's rely on segment data if available.
-    // Actually, simpler approach:
-    // If we use `created_at` of the lecture as start time.
-    if (!currentLectureData) return;
-
-    const lectureStart = new Date(currentLectureData.created_at).getTime();
-    const seekTime = (timestamp - lectureStart) / 1000;
-
-    // Sanity check: seek time should be positive.
-    // If user started recording later than creation? 
-    // This is tricky without explicit 'recording_start_timestamp'.
-    // But usually acceptable to assume created_at ~= start.
-    // Better: check first segment.
-    // If seekTime < 0, maybe use 0.
-    handleSeek(Math.max(0, seekTime));
+  /** SubtitleDisplay hands us RELATIVE seconds from media start
+   *  (it already did the epoch subtraction internally using the
+   *  baseTime prop). So this is just a pass-through to handleSeek,
+   *  clamped non-negative. */
+  const handleSubtitleSeek = (relativeTimeSec: number) => {
+    handleSeek(Math.max(0, relativeTimeSec));
   };
 
   // Update transcript content when note changes
@@ -1110,16 +1093,16 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
 
   const runVideoImport = async (
     sourcePath: string,
-    language: VideoLanguage = 'auto',
-    quality: VideoQuality = 'fast',
+    options: VideoImportOptions = { language: 'auto', quality: 'fast', refineWithAI: false },
   ) => {
     if (!lectureId || isImportingVideo) return;
     setIsImportingVideo(true);
     setImportProgressMessage('開始匯入…');
     try {
       const result = await videoImportService.importVideo(lectureId, sourcePath, {
-        language,
-        quality,
+        language: options.language,
+        quality: options.quality,
+        refineWithAI: options.refineWithAI,
         onProgress: async (p) => {
           setImportProgressMessage(p.message);
           // Step 1 just completed — the video is playable from its
@@ -1165,10 +1148,10 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
     }
   };
 
-  const handlePickAndImportVideo = async (language: VideoLanguage, quality: VideoQuality) => {
+  const handlePickAndImportVideo = async (options: VideoImportOptions) => {
     const sourcePath = await selectVideoFile();
     if (!sourcePath) return;
-    await runVideoImport(sourcePath, language, quality);
+    await runVideoImport(sourcePath, options);
   };
 
   const handleImportPastedSubtitles = async (submission: PasteSubmission) => {
@@ -1418,11 +1401,11 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
       lower.endsWith('.docx');
 
     if (isVideo) {
-      // Dragging a video onto the lecture area uses auto-detect by
-      // default — the user hasn't been through the modal where they
-      // could pick a language. If detection fails they can retry via
-      // the 匯入 button and pick explicitly.
-      await runVideoImport(path, 'auto');
+      // Dragging a video onto the lecture area uses auto-detect and
+      // fast mode by default — the user hasn't been through the modal
+      // where they could tweak. If detection fails or they want AI
+      // refinement, re-import via the 匯入 button.
+      await runVideoImport(path, { language: 'auto', quality: 'fast', refineWithAI: false });
       return;
     }
 
@@ -2440,7 +2423,7 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
         progressMessage={importProgressMessage}
         onClose={() => setIsImportModalOpen(false)}
         onPickVideo={handlePickAndImportVideo}
-        onDropVideo={(path, language, quality) => runVideoImport(path, language, quality)}
+        onDropVideo={(path, options) => runVideoImport(path, options)}
         onSubmitPaste={handleImportPastedSubtitles}
       />
     </div >

--- a/ClassNoteAI/src/components/SubtitleDisplay.tsx
+++ b/ClassNoteAI/src/components/SubtitleDisplay.tsx
@@ -3,7 +3,7 @@
  * 顯示實時轉錄的字幕
  */
 
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect, useMemo, useRef } from 'react';
 import { Trash2 } from 'lucide-react';
 import { subtitleService } from '../services/subtitleService';
 import type { SubtitleState } from '../types/subtitle';
@@ -13,13 +13,22 @@ interface SubtitleDisplayProps {
   fontSize?: number;
   position?: 'top' | 'bottom' | 'center';
   onSeek?: (timestamp: number) => void;
+  /** Current media playhead in seconds (video.currentTime). When
+   *  present, the component highlights + auto-scrolls to the
+   *  segment currently under playback. */
   currentTime?: number;
+  /** Absolute epoch ms of lecture start. We subtract it from each
+   *  segment's startTime (also epoch ms) to get the relative
+   *  playback offset. Without this, segments from live recording
+   *  (which store Date.now() at capture) would display as absolute
+   *  2026-ish timestamps instead of "02:13". */
   baseTime?: number;
 }
 
 export default function SubtitleDisplay({ onSeek, currentTime, baseTime }: SubtitleDisplayProps) {
   const [subtitleState, setSubtitleState] = useState<SubtitleState>(subtitleService.getState());
   const scrollRef = useRef<HTMLDivElement>(null);
+  const segmentRefs = useRef<Map<string, HTMLDivElement>>(new Map());
 
   useEffect(() => {
     // 訂閱字幕服務
@@ -30,29 +39,59 @@ export default function SubtitleDisplay({ onSeek, currentTime, baseTime }: Subti
     return unsubscribe;
   }, []);
 
-  // 自動滾動到底部
+  /** Active segment index — the LATEST segment whose relative start
+   *  time is ≤ currentTime. Binary-searchable but linear is fine for
+   *  the ~1000 segments a lecture has. Recomputed only when currentTime
+   *  or segment list changes. */
+  const activeIdx = useMemo(() => {
+    if (currentTime === undefined || currentTime === null) return -1;
+    const segs = subtitleState.segments;
+    if (segs.length === 0) return -1;
+    // Lecture-relative seconds for each segment.
+    const refEpochMs =
+      baseTime !== undefined
+        ? baseTime
+        : segs[0]
+          ? segs[0].startTime
+          : 0;
+    let last = -1;
+    for (let i = 0; i < segs.length; i++) {
+      const relSec = Math.max(0, (segs[i].startTime - refEpochMs) / 1000);
+      if (relSec <= currentTime) last = i;
+      else break; // segments are monotonic-increasing in time
+    }
+    return last;
+  }, [currentTime, subtitleState.segments, baseTime]);
+
+  // While recording (no currentTime), pin view to the latest segment.
   useEffect(() => {
-    if (scrollRef.current && !currentTime) { // Only auto-scroll if not reviewing (currentTime implies review/playback) or if strict follow mode (TODO)
-      // For now, let's keep auto-scroll behavior basic or maybe disable it if reviewing history?
-      // Actually, if we are in review mode, we might want auto-scroll TO the highlighted segment.
+    if (scrollRef.current && currentTime === undefined) {
       scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
     }
-  }, [subtitleState.segments, currentTime]); // Re-run when segments change. CurrentTime might be too frequent?
+  }, [subtitleState.segments.length, currentTime]);
 
-  // Auto-scroll to current time segment
+  // During playback, keep the active segment in view. Scrolls the
+  // active row into the middle of the container so the user always
+  // sees ~3 segments of context. We avoid smooth scroll during rapid
+  // seek (the browser naturally coalesces instant-scroll updates).
   useEffect(() => {
-    if (currentTime && scrollRef.current) {
-      /* TODO: Implement auto-scroll logic
-      const activeSegment = subtitleState.segments.find((s, i) => {
-        const next = subtitleState.segments[i + 1];
-        const start = new Date(s.startTime).getTime();
-        // ... implementation needed
-        return false;
-      });
-      */
-      // Implementing scroll to active element inside render might be easier by ref
+    if (activeIdx < 0) return;
+    const seg = subtitleState.segments[activeIdx];
+    if (!seg) return;
+    const el = segmentRefs.current.get(seg.id);
+    const container = scrollRef.current;
+    if (!el || !container) return;
+    const elTop = el.offsetTop;
+    const elHeight = el.offsetHeight;
+    const containerHeight = container.clientHeight;
+    // Only scroll if the active row is outside the visible window,
+    // and aim for "roughly centred" rather than pinned to the top.
+    const desiredTop = elTop - containerHeight / 2 + elHeight / 2;
+    const currentScroll = container.scrollTop;
+    if (Math.abs(desiredTop - currentScroll) > containerHeight / 3) {
+      container.scrollTo({ top: Math.max(0, desiredTop), behavior: 'smooth' });
     }
-  }, [currentTime]);
+  }, [activeIdx, subtitleState.segments]);
 
   return (
     <div className="relative h-full flex flex-col overflow-hidden" style={{ zIndex: 10 }}>
@@ -68,38 +107,39 @@ export default function SubtitleDisplay({ onSeek, currentTime, baseTime }: Subti
             <p className="text-sm mt-2">開始錄音後，轉錄結果會實時顯示</p>
           </div>
         ) : (
-          subtitleState.segments.map((segment, _index) => {
-            // Calculate relative time
-            // If baseTime is provided, use it. Otherwise fallback to first segment's time or created_at logic
-            const segmentTime = new Date(segment.startTime).getTime();
-            const referenceTime = baseTime || (subtitleState.segments[0] ? new Date(subtitleState.segments[0].startTime).getTime() : segmentTime);
-            const relativeMs = Math.max(0, segmentTime - referenceTime);
+          subtitleState.segments.map((segment, index) => {
+            // Relative playback offset. `baseTime` is the epoch ms of
+            // the lecture start; `segment.startTime` is the epoch ms
+            // recorded/saved at capture time. Subtracting gives the
+            // offset inside the media file. Fallback: when no baseTime
+            // is provided (e.g. live recording without a stored
+            // created_at), anchor to the first segment.
+            const refEpochMs =
+              baseTime !== undefined
+                ? baseTime
+                : subtitleState.segments[0]
+                  ? subtitleState.segments[0].startTime
+                  : segment.startTime;
+            const relativeMs = Math.max(0, segment.startTime - refEpochMs);
 
             const minutes = Math.floor(relativeMs / 60000);
             const seconds = Math.floor((relativeMs % 60000) / 1000);
             const timeString = `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
 
-            // Calculate if active
-            // Note: We need relative time for audio sync. 
-            // segment.startTime is usually absolute timestamp of recording start.
-            // We need to know the lecture start time to calculate offset?
-            // OR, if audio file is pure recording, its 0:00 matches lecture start?
-            // Usually yes.
-            // But segment.startTime is "2023-..."
-            // We need to store 'relativeStartTime' or invoke a helper.
-            // For now, let's assume strict timestamp matching if we had absolute time, 
-            // but for AudioPlayer 'currentTime' is seconds from 0.
-            // We need to map Audio 'currentTime' (sec) to Segment 'startTime' (Date).
-            // This requires knowing the base timestamp of the recording.
-            // Let's defer exact highlighting logic and just add the onClick for now.
+            const isActive = index === activeIdx;
 
             return (
               <div
                 key={segment.id}
+                ref={(el) => {
+                  if (el) segmentRefs.current.set(segment.id, el);
+                  else segmentRefs.current.delete(segment.id);
+                }}
                 onClick={() => onSeek?.(relativeMs / 1000)}
                 className={`p-3 rounded-lg shadow-sm border relative z-10 cursor-pointer transition-colors
-                    ${currentTime ? 'hover:bg-blue-50 dark:hover:bg-blue-900/20' : ''}
-                    bg-white dark:bg-slate-800 border-gray-200 dark:border-gray-700
+                    ${isActive
+                      ? 'bg-blue-100 dark:bg-blue-900/40 border-blue-300 dark:border-blue-700 ring-2 ring-blue-400 dark:ring-blue-600'
+                      : 'bg-white dark:bg-slate-800 border-gray-200 dark:border-gray-700 hover:bg-blue-50 dark:hover:bg-blue-900/20'}
                 `}
                 style={{ zIndex: 10 }}
               >

--- a/ClassNoteAI/src/components/VideoPiP.tsx
+++ b/ClassNoteAI/src/components/VideoPiP.tsx
@@ -1,0 +1,105 @@
+import { forwardRef, useEffect, useRef, useState } from 'react';
+import { GripVertical } from 'lucide-react';
+
+/**
+ * v0.6.0 — "picture-in-picture" floating video for lectures that have
+ * both an imported video and an attached PDF. The slides are the main
+ * thing (big centred PDF); the video is a draggable overlay users can
+ * park wherever it doesn't cover what they're reading.
+ *
+ * Deliberately simple: no resize handle in the initial cut (fixed
+ * 360×203 16:9), no boundary clamping (users can drag it fully off
+ * screen if they really want to — unlikely in practice). Position is
+ * not persisted across reloads; it resets to the top-right corner of
+ * the container each mount, which is the most common "not in the way"
+ * spot for a centered PDF.
+ *
+ * The media ref is forwarded to the parent so the existing playback
+ * wiring (timeupdate, seek, subtitle sync) keeps working unchanged —
+ * this component only owns the positioning, not the playback model.
+ */
+
+interface Props {
+    src: string;
+    onTimeUpdate: React.ReactEventHandler<HTMLVideoElement>;
+    onLoadedMetadata: React.ReactEventHandler<HTMLVideoElement>;
+    onEnded: () => void;
+}
+
+const VideoPiP = forwardRef<HTMLVideoElement, Props>(
+    ({ src, onTimeUpdate, onLoadedMetadata, onEnded }, ref) => {
+        const [pos, setPos] = useState({ x: 16, y: 16 });
+        const dragState = useRef<{ startX: number; startY: number; origX: number; origY: number } | null>(null);
+        const containerRef = useRef<HTMLDivElement>(null);
+
+        useEffect(() => {
+            const onMove = (e: MouseEvent) => {
+                if (!dragState.current) return;
+                const dx = e.clientX - dragState.current.startX;
+                const dy = e.clientY - dragState.current.startY;
+                setPos({
+                    x: dragState.current.origX + dx,
+                    y: dragState.current.origY + dy,
+                });
+            };
+            const onUp = () => {
+                dragState.current = null;
+            };
+            window.addEventListener('mousemove', onMove);
+            window.addEventListener('mouseup', onUp);
+            return () => {
+                window.removeEventListener('mousemove', onMove);
+                window.removeEventListener('mouseup', onUp);
+            };
+        }, []);
+
+        const beginDrag = (e: React.MouseEvent) => {
+            dragState.current = {
+                startX: e.clientX,
+                startY: e.clientY,
+                origX: pos.x,
+                origY: pos.y,
+            };
+            e.preventDefault();
+        };
+
+        return (
+            <div
+                ref={containerRef}
+                className="absolute z-30 rounded-lg shadow-2xl bg-black overflow-hidden border border-gray-700"
+                style={{
+                    top: pos.y,
+                    right: pos.x < 0 ? undefined : pos.x,
+                    left: pos.x < 0 ? Math.abs(pos.x) : undefined,
+                    width: 360,
+                }}
+            >
+                {/* Drag handle — a slim bar across the top. Using a
+                    dedicated handle instead of "drag anywhere on the
+                    video" keeps the native <video> controls usable
+                    (click to pause doesn't start a drag). */}
+                <div
+                    onMouseDown={beginDrag}
+                    className="flex items-center justify-center gap-1 bg-gray-900/90 text-gray-400 text-[10px] py-1 cursor-grab active:cursor-grabbing select-none"
+                    title="拖動"
+                >
+                    <GripVertical size={10} />
+                    <span>拖動</span>
+                </div>
+                <video
+                    ref={ref}
+                    src={src}
+                    onTimeUpdate={onTimeUpdate}
+                    onLoadedMetadata={onLoadedMetadata}
+                    onEnded={onEnded}
+                    controls
+                    className="w-full block bg-black"
+                />
+            </div>
+        );
+    },
+);
+
+VideoPiP.displayName = 'VideoPiP';
+
+export default VideoPiP;

--- a/ClassNoteAI/src/components/settings/SettingsCloudAI.tsx
+++ b/ClassNoteAI/src/components/settings/SettingsCloudAI.tsx
@@ -4,6 +4,7 @@ import { Card } from "./shared";
 import UsageSummary from "./UsageSummary";
 import OcrSettings from "./OcrSettings";
 import AiTutorDisplaySettings from "./AiTutorDisplaySettings";
+import VideoLayoutSettings from "./VideoLayoutSettings";
 
 export default function SettingsCloudAI() {
   return (
@@ -17,6 +18,7 @@ export default function SettingsCloudAI() {
           <AIProviderSettings />
           <OcrSettings />
           <AiTutorDisplaySettings />
+          <VideoLayoutSettings />
           <UsageSummary />
         </div>
       </Card>

--- a/ClassNoteAI/src/components/settings/VideoLayoutSettings.tsx
+++ b/ClassNoteAI/src/components/settings/VideoLayoutSettings.tsx
@@ -1,0 +1,127 @@
+import { useEffect, useState } from 'react';
+import { Film, Rows2, PictureInPicture2 } from 'lucide-react';
+import { storageService } from '../../services/storageService';
+
+type LayoutMode = 'split' | 'pip';
+
+/**
+ * v0.6.0 — when a lecture has both an imported video and a PDF/PPT,
+ * the user can choose between:
+ *
+ *   - split — left panel splits vertically into video (top) + PDF
+ *             (bottom); resizable divider.
+ *   - pip   — PDF takes the full left panel; video floats as a small
+ *             draggable overlay (Zoom / Meet-style picture-in-picture).
+ *
+ * No "best" choice — split wins when slides are dense (coding / math
+ * lectures where you need to read line-by-line) because the video is
+ * big enough to see the prof's face/pointer. PiP wins when the video
+ * is the primary content (demos, tours) and the slides are reference.
+ * Rather than auto-guess we let users pick the same way they pick
+ * the AI 助教 display mode.
+ */
+
+const MODES: {
+    value: LayoutMode;
+    title: string;
+    caption: string;
+    icon: React.ReactNode;
+}[] = [
+    {
+        value: 'split',
+        title: '上下分割',
+        caption: '左邊板面垂直分成上下兩塊，影片在上、投影片在下，分隔線可拖動調整比例。',
+        icon: <Rows2 className="w-4 h-4" />,
+    },
+    {
+        value: 'pip',
+        title: '懸浮小窗 (PiP)',
+        caption: '投影片佔滿左邊板面，影片變成可拖移的小視窗，像 Zoom 的分格視窗。適合以投影片為主的課堂。',
+        icon: <PictureInPicture2 className="w-4 h-4" />,
+    },
+];
+
+export default function VideoLayoutSettings() {
+    const [mode, setMode] = useState<LayoutMode>('split');
+    const [loaded, setLoaded] = useState(false);
+    const [savedAt, setSavedAt] = useState<number | null>(null);
+
+    useEffect(() => {
+        (async () => {
+            try {
+                const settings = await storageService.getAppSettings();
+                setMode(
+                    (settings?.lectureLayout?.videoPdfMode as LayoutMode) ?? 'split',
+                );
+            } finally {
+                setLoaded(true);
+            }
+        })();
+    }, []);
+
+    const handleChange = async (next: LayoutMode) => {
+        setMode(next);
+        try {
+            const existing = await storageService.getAppSettings();
+            if (!existing) return;
+            await storageService.saveAppSettings({
+                ...existing,
+                lectureLayout: {
+                    ...(existing.lectureLayout ?? {}),
+                    videoPdfMode: next,
+                },
+            });
+            setSavedAt(Date.now());
+        } catch (err) {
+            console.error('[VideoLayoutSettings] Failed to save:', err);
+        }
+    };
+
+    if (!loaded) return null;
+
+    return (
+        <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-slate-900/50 p-4">
+            <div className="flex items-center gap-2 mb-3">
+                <Film className="w-4 h-4 text-gray-500" />
+                <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                    影片與投影片佈局
+                </span>
+                {savedAt && Date.now() - savedAt < 2000 && (
+                    <span className="text-[10px] text-green-600 dark:text-green-400">已保存</span>
+                )}
+            </div>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mb-3">
+                當課堂同時有匯入的影片與投影片時使用的排版方式。切換會即時生效。
+            </p>
+            <div className="space-y-2">
+                {MODES.map((m) => (
+                    <label
+                        key={m.value}
+                        className={`flex items-start gap-3 p-2.5 rounded-md border cursor-pointer transition-colors ${
+                            mode === m.value
+                                ? 'border-indigo-300 bg-indigo-50 dark:border-indigo-700 dark:bg-indigo-900/20'
+                                : 'border-gray-200 dark:border-gray-700 hover:bg-gray-100 dark:hover:bg-slate-800/50'
+                        }`}
+                    >
+                        <input
+                            type="radio"
+                            name="video-layout-mode"
+                            className="mt-1 accent-indigo-500"
+                            checked={mode === m.value}
+                            onChange={() => handleChange(m.value)}
+                        />
+                        <div className="flex-1 min-w-0">
+                            <div className="flex items-center gap-1.5 text-sm font-medium text-gray-900 dark:text-gray-100">
+                                {m.icon}
+                                {m.title}
+                            </div>
+                            <div className="text-[11px] text-gray-500 dark:text-gray-400 mt-0.5">
+                                {m.caption}
+                            </div>
+                        </div>
+                    </label>
+                ))}
+            </div>
+        </div>
+    );
+}

--- a/ClassNoteAI/src/hooks/useTauriFileDrop.ts
+++ b/ClassNoteAI/src/hooks/useTauriFileDrop.ts
@@ -1,0 +1,117 @@
+import { useEffect, useRef, useState } from 'react';
+import { getCurrentWebview } from '@tauri-apps/api/webview';
+import type { UnlistenFn } from '@tauri-apps/api/event';
+
+/**
+ * v0.6.0 — Tauri-native drag-drop hook.
+ *
+ * We switched `dragDropEnabled` from `false` to `true` in tauri.conf.json
+ * so the backend emits `drop` events with real filesystem paths instead
+ * of letting the webview's HTML5 drag-drop fire with opaque `File`
+ * objects. The motivation is video import: a 500 MB recorded lecture
+ * read as `File.arrayBuffer()` → `write_temp_file(Vec<u8>)` would have
+ * to JSON-encode ~500 MB of bytes across the Tauri IPC, which is both
+ * slow and memory-expensive. Paths avoid it entirely.
+ *
+ * Because Tauri's drop event is window-global (not per-element) we
+ * emulate zone bounds in JS: each registered zone checks whether the
+ * drop's physical coordinates map into its DOMRect before claiming the
+ * event. Only the topmost zone under the cursor fires its callback.
+ *
+ * Multiple instances can coexist (e.g. the NotesView root zone plus an
+ * open ImportModal on top); z-order is decided by `elementFromPoint`
+ * at drop time, which naturally picks the modal when it's mounted.
+ */
+
+type DropHandler = (paths: string[]) => void;
+
+interface Options {
+    /** Ref to the DOM element that represents the drop zone. Drops
+     *  whose cursor position maps outside this element's bounds are
+     *  ignored. */
+    zoneRef: React.RefObject<HTMLElement | null>;
+    /** Called with the list of absolute filesystem paths dropped. */
+    onDrop: DropHandler;
+    /** Disable the subscription without unmounting the component. */
+    enabled?: boolean;
+}
+
+export function useTauriFileDrop({ zoneRef, onDrop, enabled = true }: Options) {
+    const [isDragging, setIsDragging] = useState(false);
+    // Keep latest callbacks in refs so we don't need to re-subscribe on
+    // every render — the Tauri event subscription is async and tearing
+    // it down per render would miss events during the resubscribe gap.
+    const onDropRef = useRef(onDrop);
+    const zoneRefRef = useRef(zoneRef);
+    onDropRef.current = onDrop;
+    zoneRefRef.current = zoneRef;
+
+    useEffect(() => {
+        if (!enabled) {
+            setIsDragging(false);
+            return;
+        }
+
+        let unlisten: UnlistenFn | undefined;
+        let cancelled = false;
+
+        const isPointInsideZone = (physicalX: number, physicalY: number): boolean => {
+            const el = zoneRefRef.current.current;
+            if (!el) return false;
+            // Convert Tauri's physical position → CSS pixels. devicePixelRatio
+            // can change at runtime (user moves window between monitors), so
+            // read it fresh each event.
+            const dpr = window.devicePixelRatio || 1;
+            const cssX = physicalX / dpr;
+            const cssY = physicalY / dpr;
+            const rect = el.getBoundingClientRect();
+            if (cssX < rect.left || cssX > rect.right) return false;
+            if (cssY < rect.top || cssY > rect.bottom) return false;
+            // `elementFromPoint` respects z-order, so a modal mounted
+            // above the lecture view takes precedence — only the
+            // topmost zone under the cursor claims the drop.
+            const hit = document.elementFromPoint(cssX, cssY);
+            return !!hit && (hit === el || el.contains(hit));
+        };
+
+        const subscribe = async () => {
+            const webview = getCurrentWebview();
+            unlisten = await webview.onDragDropEvent((event) => {
+                if (cancelled) return;
+                const payload = event.payload;
+                switch (payload.type) {
+                    case 'enter':
+                    case 'over': {
+                        const inside = isPointInsideZone(payload.position.x, payload.position.y);
+                        setIsDragging(inside);
+                        break;
+                    }
+                    case 'leave': {
+                        setIsDragging(false);
+                        break;
+                    }
+                    case 'drop': {
+                        setIsDragging(false);
+                        if (!isPointInsideZone(payload.position.x, payload.position.y)) {
+                            return;
+                        }
+                        const paths = payload.paths ?? [];
+                        if (paths.length === 0) return;
+                        onDropRef.current(paths);
+                        break;
+                    }
+                }
+            });
+            if (cancelled && unlisten) unlisten();
+        };
+
+        subscribe();
+
+        return () => {
+            cancelled = true;
+            if (unlisten) unlisten();
+        };
+    }, [enabled]);
+
+    return { isDragging };
+}

--- a/ClassNoteAI/src/services/fileService.ts
+++ b/ClassNoteAI/src/services/fileService.ts
@@ -34,6 +34,32 @@ export async function selectPDFFile(): Promise<{ path: string; data: ArrayBuffer
 }
 
 /**
+ * Pick a video file to import into the current lecture. We only need
+ * the path -- import_video_for_lecture on the Rust side copies the
+ * bytes itself. Keeping the large file off the JS heap matters for
+ * 500 MB+ lecture recordings.
+ */
+export async function selectVideoFile(): Promise<string | null> {
+  try {
+    const selected = await open({
+      multiple: false,
+      filters: [
+        {
+          name: 'Video',
+          extensions: ['mp4', 'mkv', 'webm', 'mov', 'm4v', 'avi'],
+        },
+      ],
+      title: '選擇影片檔案',
+    });
+    if (selected && typeof selected === 'string') return selected;
+    return null;
+  } catch (error) {
+    console.error('影片選擇失敗:', error);
+    return null;
+  }
+}
+
+/**
  * 選擇多個 PDF 文件
  * @returns 選中的文件路徑數組
  */

--- a/ClassNoteAI/src/services/ragService.ts
+++ b/ClassNoteAI/src/services/ragService.ts
@@ -123,7 +123,13 @@ class RAGService {
             // enough to amortize the per-call overhead that was eating
             // 70% of wall time before batching (tokenizer lock acquire
             // + Tauri IPC serialize/deserialize × 100 chunks).
-            const BATCH = 16;
+            // v0.6.0: 16 → 32. BGE-small-en-v1.5 is ~33M params; a
+            // batch of 32 at seq_len 512 costs ~120 MB of activation
+            // memory, well within a desktop's headroom. Cuts wall time
+            // for a 70-min lecture's ~200 chunks from ~13 batches to
+            // ~7, and the embedding model's per-call Tauri IPC overhead
+            // halves accordingly.
+            const BATCH = 32;
             const embeddings: number[][] = [];
             for (let i = 0; i < texts.length; i += BATCH) {
                 const slice = texts.slice(i, i + BATCH);
@@ -209,7 +215,13 @@ class RAGService {
             }
 
             onProgress?.({ stage: 'embedding', current: 0, total: allChunks.length, message: '正在生成嵌入向量...' });
-            const BATCH = 16;
+            // v0.6.0: 16 → 32. BGE-small-en-v1.5 is ~33M params; a
+            // batch of 32 at seq_len 512 costs ~120 MB of activation
+            // memory, well within a desktop's headroom. Cuts wall time
+            // for a 70-min lecture's ~200 chunks from ~13 batches to
+            // ~7, and the embedding model's per-call Tauri IPC overhead
+            // halves accordingly.
+            const BATCH = 32;
             const texts = allChunks.map((c) => c.text);
             const embeddings: number[][] = [];
             for (let i = 0; i < texts.length; i += BATCH) {

--- a/ClassNoteAI/src/services/subtitleImportService.ts
+++ b/ClassNoteAI/src/services/subtitleImportService.ts
@@ -1,0 +1,217 @@
+import { invoke } from '@tauri-apps/api/core';
+import { storageService } from './storageService';
+import { ragService } from './ragService';
+import type { Subtitle } from '../types';
+
+/**
+ * v0.6.0 — companion to videoImportService for the case where the
+ * course platform blocks video download but lets users copy the
+ * captions. The user pastes SRT / VTT / plain text and we produce the
+ * same `subtitles` + RAG-index artifacts that videoImport produces,
+ * minus the `video_path`. AI 助教 can then treat the lecture as if
+ * it had a normal recording.
+ *
+ * We deliberately accept three formats in one textarea rather than a
+ * file upload: users copy from a caption side-panel in the course
+ * player, which is usually just text in their clipboard — never a file
+ * on disk. Auto-detect on paste contents: `-->` anywhere means
+ * SRT/VTT, otherwise plain text.
+ */
+
+export type PasteStage =
+    | 'parsing'
+    | 'translating'
+    | 'saving'
+    | 'indexing'
+    | 'done';
+
+export interface PasteProgress {
+    stage: PasteStage;
+    message: string;
+}
+
+export type SubtitleLanguage = 'en' | 'zh';
+
+export interface PasteOptions {
+    /** Language of the pasted text. en → save as text_en, optionally
+     *  translate to Chinese. zh → save as text_zh, skip translation. */
+    language: SubtitleLanguage;
+    /** When language='en', run CT2 batch-translate to populate text_zh. */
+    translateToChinese: boolean;
+    onProgress?: (p: PasteProgress) => void;
+}
+
+export interface ParsedCue {
+    text: string;
+    startMs: number;
+    endMs: number;
+}
+
+/**
+ * Parse one of: SRT, VTT, or plain text into timed cues.
+ *
+ * - SRT: `HH:MM:SS,SSS --> HH:MM:SS,SSS`
+ * - VTT: `HH:MM:SS.SSS --> HH:MM:SS.SSS` (plus optional `WEBVTT` header)
+ * - Plain text: split on blank lines, assign fake timestamps 4s apart
+ *   starting from 0 so each paragraph still has a stable ordering.
+ *   Real timestamps are unavailable so playback-sync won't work, but
+ *   the transcript/RAG/notes flow all still work.
+ */
+export function parseSubtitleInput(raw: string): ParsedCue[] {
+    const trimmed = raw.trim();
+    if (!trimmed) return [];
+
+    if (trimmed.includes('-->')) {
+        return parseTimestamped(trimmed);
+    }
+    return parsePlainText(trimmed);
+}
+
+function parseTimestamped(input: string): ParsedCue[] {
+    // Strip optional WEBVTT header + any NOTE blocks.
+    const stripped = input
+        .replace(/^WEBVTT[^\n]*\n/i, '')
+        .replace(/^NOTE[\s\S]*?(?:\n\s*\n|$)/gim, '');
+
+    const blocks = stripped.split(/\n\s*\n/).map((b) => b.trim()).filter(Boolean);
+    const cues: ParsedCue[] = [];
+
+    // Matches both SRT (,) and VTT (.) fractional-second separators,
+    // and optional hours.
+    const TS = /(?:(\d{1,2}):)?(\d{1,2}):(\d{2})[.,](\d{1,3})\s*-->\s*(?:(\d{1,2}):)?(\d{1,2}):(\d{2})[.,](\d{1,3})/;
+
+    for (const block of blocks) {
+        const lines = block.split(/\r?\n/);
+        // Skip optional numeric sequence line (SRT style).
+        let idx = 0;
+        if (lines[0] && /^\d+$/.test(lines[0].trim())) idx = 1;
+        if (idx >= lines.length) continue;
+
+        const m = lines[idx].match(TS);
+        if (!m) continue;
+
+        const startMs = tsToMs(m[1], m[2], m[3], m[4]);
+        const endMs = tsToMs(m[5], m[6], m[7], m[8]);
+        const text = lines
+            .slice(idx + 1)
+            .join(' ')
+            // Strip VTT inline speaker tags and simple HTML from some
+            // exporters (Coursera / YouTube).
+            .replace(/<[^>]+>/g, '')
+            .trim();
+        if (!text) continue;
+        cues.push({ text, startMs, endMs });
+    }
+    return cues;
+}
+
+function tsToMs(h: string | undefined, m: string, s: string, ms: string): number {
+    const hours = h ? parseInt(h, 10) : 0;
+    const mins = parseInt(m, 10);
+    const secs = parseInt(s, 10);
+    // SRT uses 3-digit ms; VTT allows 1-3. Pad so "5" → 500, not 5.
+    const fracMs = parseInt(ms.padEnd(3, '0').slice(0, 3), 10);
+    return ((hours * 3600 + mins * 60 + secs) * 1000) + fracMs;
+}
+
+/**
+ * Plain text → paragraph-per-cue. Paragraphs are separated by blank
+ * lines; single newlines within a paragraph are joined with a space so
+ * copy-paste from PDFs / web captions that hard-wrap at ~80 chars
+ * doesn't produce garbage. Fake timestamps 4 s apart keep the UI
+ * ordering stable but aren't real.
+ */
+function parsePlainText(input: string): ParsedCue[] {
+    const paragraphs = input
+        .split(/\n\s*\n/)
+        .map((p) => p.replace(/\s*\n\s*/g, ' ').trim())
+        .filter(Boolean);
+    return paragraphs.map((text, i) => ({
+        text,
+        startMs: i * 4000,
+        endMs: i * 4000 + 4000,
+    }));
+}
+
+export const subtitleImportService = {
+    /** Full pipeline: parse → optional translate → save → RAG index → mark lecture completed. */
+    async importPasted(
+        lectureId: string,
+        rawText: string,
+        options: PasteOptions,
+    ): Promise<{ segmentCount: number }> {
+        const emit = (p: PasteProgress) => options.onProgress?.(p);
+
+        emit({ stage: 'parsing', message: '解析字幕…' });
+        const cues = parseSubtitleInput(rawText);
+        if (cues.length === 0) {
+            throw new Error('沒有解析到任何字幕內容。請確認貼上的文字非空。');
+        }
+
+        // Translate only when source is English AND user asked for it.
+        // Chinese source skips translation entirely (the existing
+        // translate_ct2_batch is English→Chinese only).
+        let translations: string[] = new Array(cues.length).fill('');
+        if (options.language === 'en' && options.translateToChinese) {
+            emit({
+                stage: 'translating',
+                message: `翻譯 ${cues.length} 段字幕…`,
+            });
+            const texts = cues.map((c) => c.text);
+            const BATCH = 64;
+            for (let i = 0; i < texts.length; i += BATCH) {
+                const slice = texts.slice(i, i + BATCH);
+                try {
+                    const translated = await invoke<string[]>('translate_ct2_batch', { texts: slice });
+                    for (let j = 0; j < slice.length; j++) {
+                        translations[i + j] = translated[j] ?? '';
+                    }
+                } catch (err) {
+                    // Same graceful degradation as videoImportService.
+                    console.warn('[subtitleImport] batch translate failed:', err);
+                    for (let j = 0; j < slice.length; j++) translations[i + j] = '';
+                }
+            }
+        }
+
+        emit({ stage: 'saving', message: '儲存字幕…' });
+        const nowIso = new Date().toISOString();
+        const subtitles: Subtitle[] = cues.map((cue, idx) => {
+            const isEn = options.language === 'en';
+            return {
+                id: crypto.randomUUID(),
+                lecture_id: lectureId,
+                timestamp: cue.startMs / 1000,
+                text_en: isEn ? cue.text : '',
+                text_zh: isEn ? (translations[idx] || undefined) : cue.text,
+                // Pasted captions came from a human-written source on the
+                // course platform — treat as fine rather than rough.
+                type: 'fine',
+                confidence: undefined,
+                created_at: nowIso,
+            };
+        });
+        await storageService.saveSubtitles(subtitles);
+
+        const lecture = await storageService.getLecture(lectureId);
+        if (lecture) {
+            const lastEndMs = cues[cues.length - 1].endMs;
+            await storageService.saveLecture({
+                ...lecture,
+                duration: Math.max(lecture.duration, Math.round(lastEndMs / 1000)),
+                status: 'completed',
+                updated_at: new Date().toISOString(),
+            });
+        }
+
+        emit({ stage: 'indexing', message: '建立 AI 助教索引…' });
+        const transcriptText = subtitles
+            .map((s) => s.text_zh || s.text_en)
+            .filter(Boolean)
+            .join('\n');
+        await ragService.indexLecture(lectureId, null, transcriptText);
+
+        emit({ stage: 'done', message: '完成' });
+        return { segmentCount: cues.length };
+    },
+};

--- a/ClassNoteAI/src/services/subtitleImportService.ts
+++ b/ClassNoteAI/src/services/subtitleImportService.ts
@@ -97,7 +97,9 @@ function parseTimestamped(input: string): ParsedCue[] {
             .join(' ')
             // Strip VTT inline speaker tags and simple HTML from some
             // exporters (Coursera / YouTube).
-            .replace(/<[^>]+>/g, '')
+            // Remove angle brackets directly to avoid incomplete
+            // multi-character sanitization where tags can re-form.
+            .replace(/[<>]/g, '')
             .trim();
         if (!text) continue;
         cues.push({ text, startMs, endMs });

--- a/ClassNoteAI/src/services/videoImportService.ts
+++ b/ClassNoteAI/src/services/videoImportService.ts
@@ -4,27 +4,39 @@ import { ragService } from './ragService';
 import type { Subtitle } from '../types';
 
 /**
- * v0.6.0 — import a recorded lecture video and produce the same
- * artifacts a live-recorded lecture produces:
+ * v0.6.0 — chunked video import pipeline.
  *
- *   1. Copy the user-selected video file into the app's video dir.
- *   2. Pipe it through ffmpeg to get 16 kHz mono i16 PCM.
- *   3. Run whisper-rs over the PCM to get timed segments.
- *   4. Persist the segments as `subtitles` rows (role = "rough";
- *      the streaming fine-refine pass can upgrade them to "fine"
- *      later if needed).
- *   5. Update the lecture row with `video_path` + durations.
- *   6. Re-index the lecture for RAG so AI 助教 can use the
- *      transcript immediately.
+ * Previously the whole flow lived inside a single `transcribe_video_file`
+ * call that would:
+ *   1. Run ffmpeg to fully buffer the PCM,
+ *   2. Run one monolithic Whisper pass over it,
+ *   3. Return all segments — at which point we batch-translated.
  *
- * Everything after step 1 is background work. The UI surfaces
- * progress via the callback.
+ * For a 70-minute lecture step 2 was 20–60 min of opaque work with
+ * zero UI feedback — indistinguishable from a hang. We now:
+ *
+ *   a. Extract PCM once to a temp `.pcm` file (fast, ~3 s for 70 min),
+ *   b. Slice into 5-min chunks and transcribe each via
+ *      `transcribe_pcm_file_slice`,
+ *   c. As each chunk's segments come back, immediately queue them for
+ *      CT2 translation — transcription of chunk N+1 runs in parallel
+ *      with translation of chunk N on the Rust side,
+ *   d. After all chunks finish (both passes), persist subtitles +
+ *      build the RAG index.
+ *
+ * Language detection is cached from the first chunk and passed to
+ * every subsequent chunk. Whisper's auto-detector runs on the first
+ * 30 s of audio; if the lecture opens with silence or background
+ * noise, detection lands on garbage (we saw "af" with p=0.01 on one
+ * English lecture). The UI also lets the user pick a language
+ * explicitly for reliability.
  */
 
 export type ImportStage =
     | 'staging'
     | 'extracting_audio'
     | 'transcribing'
+    | 'translating'
     | 'saving_subtitles'
     | 'indexing'
     | 'done';
@@ -32,10 +44,10 @@ export type ImportStage =
 export interface ImportProgress {
     stage: ImportStage;
     message: string;
-    /** 0..1 for stages that can report granular progress; undefined
-     *  when the underlying step is opaque (e.g. ffmpeg doesn't stream
-     *  progress over stdin, whisper doesn't either). */
-    fraction?: number;
+    /** Transcribed / total chunks when known, for a progress bar. */
+    transcribedChunks?: number;
+    translatedChunks?: number;
+    totalChunks?: number;
 }
 
 interface WhisperSegment {
@@ -51,6 +63,19 @@ interface TranscriptionResult {
     duration_ms: number;
 }
 
+interface PcmExtractResult {
+    pcm_path: string;
+    duration_sec: number;
+    sample_count: number;
+}
+
+/** Default chunk length. Whisper.cpp's internal windows are 30 s, so
+ *  any multiple of that is safe; 5 min gives ~14 chunks for a 70-min
+ *  lecture which is enough progress granularity without paying too
+ *  much per-chunk model warmup cost. */
+const CHUNK_SEC = 300;
+const TRANSLATE_BATCH = 64;
+
 export const videoImportService = {
     async importVideo(
         lectureId: string,
@@ -63,116 +88,194 @@ export const videoImportService = {
     ): Promise<{ videoPath: string; segmentCount: number; durationMs: number }> {
         const emit = (p: ImportProgress) => options.onProgress?.(p);
 
-        // 1. Stage the source video under {app_data}/videos/{lectureId}.{ext}.
+        // 1. Stage the source video under the app's video dir.
         emit({ stage: 'staging', message: '正在複製影片到應用目錄…' });
         const videoPath = await invoke<string>('import_video_for_lecture', {
             lectureId,
             sourcePath,
         });
 
-        // 2 + 3. Extract PCM + run Whisper inside one Rust call. The
-        // previous split would have serialised up to ~115 MB of i16
-        // samples (1h video × 16kHz × 2 bytes) as JSON over Tauri's
-        // IPC channel, which OOMs the webview. The combined command
-        // keeps the PCM in the Rust process and only returns the
-        // final segment list (a few KB).
-        emit({
-            stage: 'transcribing',
-            message: '抽取音訊並轉錄中…',
-        });
-        const result = await invoke<TranscriptionResult>('transcribe_video_file', {
+        // 2. Extract PCM to a temp file next to the staged video. Disk
+        //    write is I/O-bound and cheap (~3 s for 70 min); doing it
+        //    once up-front means per-chunk transcription only seeks.
+        emit({ stage: 'extracting_audio', message: '抽取音訊…' });
+        const pcm = await invoke<PcmExtractResult>('extract_video_pcm_to_temp', {
             videoPath,
-            initialPrompt: options.initialPrompt ?? null,
-            language: options.language ?? null,
-            options: null,
         });
 
-        // 4a. Batch translate the English segments into Chinese in
-        //     ONE CTranslate2 call, then stitch back to their original
-        //     timestamps. Translating one line at a time would have
-        //     been N IPC round-trips and given the model no surrounding
-        //     context; a batch call lets the local CT2 engine run the
-        //     whole set on a single forward pass. We chunk at 64 lines
-        //     per batch so a 90-min lecture (~1000 segments) doesn't
-        //     push a single IPC payload over a megabyte — CTranslate2
-        //     handles the internal batching anyway.
-        emit({
-            stage: 'saving_subtitles',
-            message: `翻譯 ${result.segments.length} 段字幕…`,
-        });
-        const texts = result.segments.map((s) => s.text.trim());
-        const translations: string[] = new Array(texts.length);
-        const BATCH = 64;
-        for (let i = 0; i < texts.length; i += BATCH) {
-            const slice = texts.slice(i, i + BATCH);
-            try {
-                const translated = await invoke<string[]>('translate_ct2_batch', { texts: slice });
-                for (let j = 0; j < slice.length; j++) {
-                    translations[i + j] = translated[j] ?? '';
-                }
-            } catch (err) {
-                // Degrade gracefully: if the local CT2 model isn't
-                // loaded (user never configured translation, or model
-                // download is pending), keep the English subtitles
-                // and let the user add translations later.
-                console.warn('[videoImport] batch translate failed, falling back to English-only:', err);
-                for (let j = 0; j < slice.length; j++) {
-                    translations[i + j] = '';
-                }
+        try {
+            // 3. Plan chunks. Last chunk may be shorter than CHUNK_SEC.
+            const chunks: { start: number; end: number }[] = [];
+            for (let t = 0; t < pcm.duration_sec; t += CHUNK_SEC) {
+                chunks.push({
+                    start: t,
+                    end: Math.min(t + CHUNK_SEC, pcm.duration_sec),
+                });
             }
-        }
+            const total = chunks.length;
 
-        // 4b. Persist segments as rough subtitles with both English
-        //     and (best-effort) Chinese text. Timestamp = Whisper's
-        //     start_ms converted to seconds (the schema's `timestamp`
-        //     column is seconds-as-float).
-        const subtitles: Subtitle[] = result.segments.map((seg, idx) => ({
-            id: crypto.randomUUID(),
-            lecture_id: lectureId,
-            timestamp: seg.start_ms / 1000,
-            text_en: seg.text.trim(),
-            text_zh: translations[idx]?.trim() || undefined,
-            type: 'rough',
-            confidence: undefined,
-            created_at: new Date().toISOString(),
-        }));
-        if (subtitles.length > 0) {
-            await storageService.saveSubtitles(subtitles);
-        }
+            // 4. Transcribe + translate pipeline.
+            //
+            //    - Transcription runs sequentially (one Whisper context
+            //      at a time; two in parallel would just contend for
+            //      the same Mutex-guarded service).
+            //    - Translation fires-and-forgets: each finished chunk's
+            //      segments are handed to translate_ct2_batch in the
+            //      background while the next chunk transcribes.
+            //    - We join on all translation promises at the end before
+            //      saving subtitles.
+            const allSegments: WhisperSegment[] = [];
+            const translationMap = new Map<WhisperSegment, string>();
+            const translationPromises: Promise<void>[] = [];
 
-        // 5. Update the lecture row — video_path + duration. We leave
-        //    status alone; if the lecture was 'recording' (rare for
-        //    this flow since user usually imports into a fresh
-        //    lecture), the user can manually flip via Save.
-        const lecture = await storageService.getLecture(lectureId);
-        if (lecture) {
-            await storageService.saveLecture({
-                ...lecture,
-                video_path: videoPath,
-                duration: Math.max(lecture.duration, Math.round(result.duration_ms / 1000)),
-                status: 'completed',
-                updated_at: new Date().toISOString(),
+            let transcribed = 0;
+            let translated = 0;
+            // Seed language from caller or leave null for auto-detect.
+            // `'auto'` is the UI sentinel — Rust already normalises it
+            // to None, but we want it to also be blank-ish here so the
+            // first-chunk result can overwrite it.
+            let currentLang: string | null =
+                options.language && options.language.toLowerCase() !== 'auto'
+                    ? options.language
+                    : null;
+
+            const report = (stage: ImportStage) =>
+                emit({
+                    stage,
+                    message:
+                        stage === 'translating'
+                            ? `翻譯 ${translated}/${total}（轉錄已完成）`
+                            : `轉錄 ${transcribed}/${total}，翻譯 ${translated}/${total}`,
+                    transcribedChunks: transcribed,
+                    translatedChunks: translated,
+                    totalChunks: total,
+                });
+
+            report('transcribing');
+
+            for (const chunk of chunks) {
+                const result = await invoke<TranscriptionResult>(
+                    'transcribe_pcm_file_slice',
+                    {
+                        pcmPath: pcm.pcm_path,
+                        startSec: chunk.start,
+                        endSec: chunk.end,
+                        initialPrompt: options.initialPrompt ?? null,
+                        language: currentLang,
+                        options: null,
+                    },
+                );
+
+                // Cache first successful language detection so later
+                // chunks don't redo it (and more importantly so they
+                // don't drift between languages if audio briefly goes
+                // quiet).
+                if (!currentLang && result.language) {
+                    currentLang = result.language;
+                    console.log('[videoImport] language detected:', currentLang);
+                }
+
+                const chunkSegs = result.segments.slice();
+                allSegments.push(...chunkSegs);
+                transcribed++;
+                report('transcribing');
+
+                // Kick off translation for just this chunk. Errors
+                // degrade to English-only — same graceful fallback the
+                // old code had.
+                translationPromises.push(
+                    (async () => {
+                        const texts = chunkSegs.map((s) => s.text.trim());
+                        const outputs: string[] = new Array(texts.length).fill('');
+                        for (let i = 0; i < texts.length; i += TRANSLATE_BATCH) {
+                            const slice = texts.slice(i, i + TRANSLATE_BATCH);
+                            try {
+                                const tr = await invoke<string[]>('translate_ct2_batch', {
+                                    texts: slice,
+                                });
+                                for (let j = 0; j < slice.length; j++) {
+                                    outputs[i + j] = tr[j] ?? '';
+                                }
+                            } catch (err) {
+                                console.warn(
+                                    '[videoImport] batch translate failed:',
+                                    err,
+                                );
+                                // Leave outputs[i..i+slice.length] as '' —
+                                // English subtitle still gets saved.
+                            }
+                        }
+                        for (let i = 0; i < chunkSegs.length; i++) {
+                            translationMap.set(chunkSegs[i], outputs[i]);
+                        }
+                        translated++;
+                        report(transcribed < total ? 'transcribing' : 'translating');
+                    })(),
+                );
+            }
+
+            // Wait for every chunk's translation to finish before we
+            // persist (saveSubtitles expects the full translated set).
+            await Promise.all(translationPromises);
+
+            // 5. Persist subtitles (mirrors the live-recording schema:
+            //    `rough` subtitles with en + best-effort zh).
+            emit({
+                stage: 'saving_subtitles',
+                message: `儲存 ${allSegments.length} 段字幕…`,
+                transcribedChunks: total,
+                translatedChunks: total,
+                totalChunks: total,
             });
+            const now = new Date().toISOString();
+            const subtitles: Subtitle[] = allSegments.map((seg) => ({
+                id: crypto.randomUUID(),
+                lecture_id: lectureId,
+                timestamp: seg.start_ms / 1000,
+                text_en: seg.text.trim(),
+                text_zh: translationMap.get(seg)?.trim() || undefined,
+                type: 'rough',
+                confidence: undefined,
+                created_at: now,
+            }));
+            if (subtitles.length > 0) {
+                await storageService.saveSubtitles(subtitles);
+            }
+
+            // 6. Update lecture with video_path + duration.
+            const lecture = await storageService.getLecture(lectureId);
+            if (lecture) {
+                await storageService.saveLecture({
+                    ...lecture,
+                    video_path: videoPath,
+                    duration: Math.max(
+                        lecture.duration,
+                        Math.round(pcm.duration_sec),
+                    ),
+                    status: 'completed',
+                    updated_at: new Date().toISOString(),
+                });
+            }
+
+            // 7. RAG index: concat all transcript text.
+            emit({ stage: 'indexing', message: '建立 AI 助教索引…' });
+            const transcriptText = allSegments
+                .map((s) => s.text.trim())
+                .filter(Boolean)
+                .join('\n');
+            await ragService.indexLecture(lectureId, null, transcriptText);
+
+            emit({ stage: 'done', message: '完成' });
+            return {
+                videoPath,
+                segmentCount: allSegments.length,
+                durationMs: Math.round(pcm.duration_sec * 1000),
+            };
+        } finally {
+            // Best-effort cleanup of the temp PCM. If the user aborted
+            // mid-run (unlikely in MVP — there's no cancel button), the
+            // leftover .pcm is still deleted here.
+            void invoke('delete_temp_pcm', { pcmPath: pcm.pcm_path }).catch(() => {});
         }
-
-        // 6. RAG index. Concatenate all segments into one transcript
-        //    string; ragService.indexLecture chunks it the same way
-        //    live-recorded transcripts are chunked.
-        emit({ stage: 'indexing', message: '建立 AI 助教索引…' });
-        const transcriptText = result.segments
-            .map((s) => s.text.trim())
-            .filter(Boolean)
-            .join('\n');
-        // `indexLecture` will pull pdfText from the lecture's PDF on
-        // next open if one is attached; here we pass null so only the
-        // transcript goes in. PDF index picks up via its own flow.
-        await ragService.indexLecture(lectureId, null, transcriptText);
-
-        emit({ stage: 'done', message: '完成' });
-        return {
-            videoPath,
-            segmentCount: result.segments.length,
-            durationMs: result.duration_ms,
-        };
     },
 };

--- a/ClassNoteAI/src/services/videoImportService.ts
+++ b/ClassNoteAI/src/services/videoImportService.ts
@@ -195,11 +195,26 @@ export const videoImportService = {
             language?: string;
             initialPrompt?: string;
             quality?: TranscribeQuality;
+            /** When true, run the LLM fine-refinement pass after rough
+             *  transcribe + CT2 translate finish. Off by default (see
+             *  ImportModal rationale about token cost). */
+            refineWithAI?: boolean;
             onProgress?: (p: ImportProgress) => void;
         } = {},
     ): Promise<{ videoPath: string; segmentCount: number; durationMs: number }> {
         const emit = (p: ImportProgress) => options.onProgress?.(p);
         const quality = options.quality ?? 'fast';
+        const refineWithAI = options.refineWithAI ?? false;
+
+        // Per-stage wall-time profiler. Logs a breakdown at the end so
+        // we can see exactly where the pipeline spent its minutes
+        // ("stage"/"extract"/"transcribe+translate"/"rag"/"fine") and
+        // target the slowest bit next round.
+        const t0 = performance.now();
+        const stageTimes: Record<string, number> = {};
+        const markStage = (name: string) => {
+            stageTimes[name] = (performance.now() - t0) / 1000;
+        };
 
         // 1. Stage the source video under the app's video dir, AND
         //    persist the video_path on the lecture row immediately.
@@ -222,6 +237,7 @@ export const videoImportService = {
                 updated_at: new Date().toISOString(),
             });
         }
+        markStage('stage_copy');
         emit({
             stage: 'video_ready',
             message: '影片已就緒，可以先開始觀看。轉錄中…',
@@ -262,6 +278,7 @@ export const videoImportService = {
         const pcm = await invoke<PcmExtractResult>('extract_video_pcm_to_temp', {
             videoPath,
         });
+        markStage('ffmpeg_pcm_extract');
 
         try {
             // 3. Plan chunks. Last chunk may be shorter than CHUNK_SEC.
@@ -375,14 +392,27 @@ export const videoImportService = {
                 //     only the English text. Each row's UUID is captured
                 //     so the translation step (b) can update the exact
                 //     same row without reading back from DB.
+                //
+                //     Timestamp convention: we store *absolute epoch
+                //     seconds* to match the live-recording path (which
+                //     stores Date.now()/1000 at the moment the segment
+                //     was captured). The SubtitleDisplay component and
+                //     section-timestamp math in NotesView both subtract
+                //     `lecture.created_at` at display time to get the
+                //     relative offset. Storing the video's in-media
+                //     offset as epoch seconds = `created_at + start_ms`
+                //     keeps both paths unified.
                 const nowIso = new Date().toISOString();
+                const createdAtEpochSec = lectureBefore
+                    ? new Date(lectureBefore.created_at).getTime() / 1000
+                    : Date.now() / 1000;
                 const chunkSubtitles: Subtitle[] = chunkSegs.map((seg) => {
                     const id = crypto.randomUUID();
                     savedSubtitleIds.set(seg, id);
                     return {
                         id,
                         lecture_id: lectureId,
-                        timestamp: seg.start_ms / 1000,
+                        timestamp: createdAtEpochSec + seg.start_ms / 1000,
                         text_en: seg.text.trim(),
                         text_zh: undefined,
                         type: 'rough',
@@ -442,7 +472,7 @@ export const videoImportService = {
                         const translatedRows: Subtitle[] = chunkSegs.map((seg, k) => ({
                             id: savedSubtitleIds.get(seg)!,
                             lecture_id: lectureId,
-                            timestamp: seg.start_ms / 1000,
+                            timestamp: createdAtEpochSec + seg.start_ms / 1000,
                             text_en: seg.text.trim(),
                             text_zh: outputs[k]?.trim() || undefined,
                             type: 'rough',
@@ -482,6 +512,7 @@ export const videoImportService = {
             // UI can exit the "importing" state as soon as rough +
             // Google-translated captions are all saved.
             await Promise.all(translationPromises);
+            markStage('transcribe_plus_translate');
 
             // 5. Update lecture duration + mark completed. video_path
             //    was written up-front at the staging step so this is
@@ -499,33 +530,52 @@ export const videoImportService = {
                 });
             }
 
-            // 6. Fine refinement (LLM-backed). Upgrades rough subtitles
-            //    to 'fine' type, correcting ASR errors and producing
-            //    natural Chinese. We await this so the import-active
-            //    progress indicator keeps showing while the LLM batches
-            //    crunch — otherwise the UI would flash "完成" and then
-            //    silently keep mutating subtitles behind the user.
-            try {
-                await runFineRefinementPass(lectureId, emit);
-            } catch (err) {
-                console.warn('[videoImport] fine refinement failed:', err);
-            }
+            // 6. Fine refinement + 7. RAG index can run in parallel:
+            //    fine uses the configured LLM (remote/local), RAG uses
+            //    the local embedding model. They don't contend for any
+            //    shared resource. RAG uses the rough English text —
+            //    fine's mutation of `text_zh` doesn't affect retrieval
+            //    quality (which embeds English).
+            //
+            //    Fine refinement is opt-in per-import via the `refineWithAI`
+            //    flag. Default OFF: a 70-min lecture burns ~130k tokens.
+            //    Users who want it see the cost estimate in ImportModal
+            //    before opting in.
+            const fineTask = refineWithAI
+                ? runFineRefinementPass(lectureId, emit).catch((err) => {
+                      console.warn('[videoImport] fine refinement failed:', err);
+                  })
+                : Promise.resolve();
 
-            // 7. RAG index. Build AI-tutor searchable chunks from the
-            //    final transcript. Uses fine text where available, rough
-            //    otherwise (storageService.getSubtitles returns whatever
-            //    the last save left).
             emit({ stage: 'indexing', message: '建立 AI 助教索引…' });
-            try {
-                const finalSubs = await storageService.getSubtitles(lectureId);
-                const transcriptText = finalSubs
-                    .map((s) => (s.text_en || '').trim())
-                    .filter(Boolean)
-                    .join('\n');
-                await ragService.indexLecture(lectureId, null, transcriptText);
-            } catch (err) {
-                console.warn('[videoImport] RAG index failed:', err);
+            const ragTask = (async () => {
+                try {
+                    const finalSubs = await storageService.getSubtitles(lectureId);
+                    const transcriptText = finalSubs
+                        .map((s) => (s.text_en || '').trim())
+                        .filter(Boolean)
+                        .join('\n');
+                    await ragService.indexLecture(lectureId, null, transcriptText);
+                } catch (err) {
+                    console.warn('[videoImport] RAG index failed:', err);
+                }
+            })();
+
+            await Promise.all([fineTask, ragTask]);
+            markStage('fine_plus_rag');
+
+            // Log a compact per-stage breakdown. Previous stages were
+            // cumulative from t0; turn them into deltas for readability.
+            const prev = { name: 'start', t: 0 };
+            const breakdown: string[] = [];
+            for (const [name, t] of Object.entries(stageTimes)) {
+                breakdown.push(`${name}=${(t - prev.t).toFixed(1)}s`);
+                prev.name = name;
+                prev.t = t;
             }
+            console.log(
+                `[videoImport] TIMING total=${((performance.now() - t0) / 1000).toFixed(1)}s  |  ${breakdown.join('  ')}`,
+            );
 
             emit({ stage: 'done', message: '完成' });
             return {

--- a/ClassNoteAI/src/services/videoImportService.ts
+++ b/ClassNoteAI/src/services/videoImportService.ts
@@ -76,6 +76,12 @@ interface PcmExtractResult {
 const CHUNK_SEC = 300;
 const TRANSLATE_BATCH = 64;
 
+/** Which model Rust should use for this import's transcription.
+ *  - `'fast'`: swap in ggml-base.bin (~5x faster than turbo on CPU).
+ *  - `'standard'`: use whatever WHISPER_SERVICE already has loaded
+ *    (what the user picked in settings for live recording). */
+export type TranscribeQuality = 'fast' | 'standard';
+
 export const videoImportService = {
     async importVideo(
         lectureId: string,
@@ -83,10 +89,12 @@ export const videoImportService = {
         options: {
             language?: string;
             initialPrompt?: string;
+            quality?: TranscribeQuality;
             onProgress?: (p: ImportProgress) => void;
         } = {},
     ): Promise<{ videoPath: string; segmentCount: number; durationMs: number }> {
         const emit = (p: ImportProgress) => options.onProgress?.(p);
+        const quality = options.quality ?? 'fast';
 
         // 1. Stage the source video under the app's video dir.
         emit({ stage: 'staging', message: '正在複製影片到應用目錄…' });
@@ -94,6 +102,33 @@ export const videoImportService = {
             lectureId,
             sourcePath,
         });
+
+        // 1.5. Resolve model override up-front. Failing early lets us
+        //      surface "fast mode requires ggml-base.bin" before the
+        //      user waits through ffmpeg + chunk planning only to hit
+        //      the error on slice #1. 'standard' skips this entirely
+        //      and keeps model_override_path null.
+        let modelOverridePath: string | null = null;
+        if (quality === 'fast') {
+            try {
+                modelOverridePath = await invoke<string>('resolve_whisper_model_path', {
+                    preset: 'base',
+                });
+                console.log(
+                    '[videoImport] fast mode — using model:',
+                    modelOverridePath,
+                );
+            } catch (err) {
+                console.warn(
+                    '[videoImport] fast-mode model unavailable, falling back to standard:',
+                    err,
+                );
+                // Degrade gracefully to the user's main model. An
+                // alternative would be to abort with a "please
+                // download base first" dialog; preferring to just
+                // work-slowly-but-work for the MVP.
+            }
+        }
 
         // 2. Extract PCM to a temp file next to the staged video. Disk
         //    write is I/O-bound and cheap (~3 s for 70 min); doing it
@@ -186,6 +221,7 @@ export const videoImportService = {
                         initialPrompt: options.initialPrompt ?? null,
                         language: currentLang,
                         options: null,
+                        modelOverridePath,
                     },
                 );
 
@@ -312,6 +348,12 @@ export const videoImportService = {
             // mid-run (unlikely in MVP — there's no cancel button), the
             // leftover .pcm is still deleted here.
             void invoke('delete_temp_pcm', { pcmPath: pcm.pcm_path }).catch(() => {});
+            // Also release the import-side Whisper model so we're not
+            // holding ~150 MB idle. Next import will reload on first
+            // slice (~1 s).
+            if (modelOverridePath) {
+                void invoke('release_import_whisper').catch(() => {});
+            }
         }
     },
 };

--- a/ClassNoteAI/src/services/videoImportService.ts
+++ b/ClassNoteAI/src/services/videoImportService.ts
@@ -34,10 +34,10 @@ import type { Subtitle } from '../types';
 
 export type ImportStage =
     | 'staging'
+    | 'video_ready'
     | 'extracting_audio'
     | 'transcribing'
     | 'translating'
-    | 'saving_subtitles'
     | 'indexing'
     | 'done';
 
@@ -48,6 +48,15 @@ export interface ImportProgress {
     transcribedChunks?: number;
     translatedChunks?: number;
     totalChunks?: number;
+    /** `video_ready` fires as soon as the staged video file is playable
+     *  from its final path (step 1 of the pipeline). Frontend can then
+     *  close the import modal, flip the UI into Review mode and show
+     *  the <video> while transcription continues in the background. */
+    videoPath?: string;
+    /** `subtitles_changed` fires whenever a chunk's subtitles have
+     *  been persisted. Frontend re-reads from the DB to refresh its
+     *  display — cheap, and keeps a single source of truth. */
+    subtitlesChanged?: boolean;
 }
 
 interface WhisperSegment {
@@ -69,11 +78,23 @@ interface PcmExtractResult {
     sample_count: number;
 }
 
-/** Default chunk length. Whisper.cpp's internal windows are 30 s, so
- *  any multiple of that is safe; 5 min gives ~14 chunks for a 70-min
- *  lecture which is enough progress granularity without paying too
- *  much per-chunk model warmup cost. */
-const CHUNK_SEC = 300;
+/** Chunk length trade-off. Smaller chunks → first subtitles appear
+ *  faster (better perceived latency) at the cost of more per-chunk
+ *  warmup overhead. 60 s is the sweet spot for batch import:
+ *    - base model transcribes 60 s of audio in ~10–15 s on CPU, so
+ *      subtitles stream in well ahead of 1× playback.
+ *    - 70-min video → 70 chunks; per-chunk state-create cost is
+ *      ~0.1 s, total overhead ~7 s, negligible vs total runtime.
+ *    - A 30 s chunk would be faster still but whisper.cpp's decoder
+ *      wants at least its internal 30 s window, so going smaller
+ *      forces padding and wastes compute.
+ *
+ *  Industry reference: whisper_streaming / SimulStreaming target
+ *  sub-second latency for *live* captioning via LocalAgreement-2 on
+ *  continuously-growing audio. Our case is *batch* — a pre-recorded
+ *  video where we already have the whole file — so we don't need
+ *  LocalAgreement; just a small-enough chunk to feel responsive. */
+const CHUNK_SEC = 60;
 const TRANSLATE_BATCH = 64;
 
 /** Which model Rust should use for this import's transcription.
@@ -96,11 +117,31 @@ export const videoImportService = {
         const emit = (p: ImportProgress) => options.onProgress?.(p);
         const quality = options.quality ?? 'fast';
 
-        // 1. Stage the source video under the app's video dir.
+        // 1. Stage the source video under the app's video dir, AND
+        //    persist the video_path on the lecture row immediately.
+        //    Prior to v0.6.1 we only wrote video_path at the very end,
+        //    which meant the user stared at a progress modal for 30+
+        //    min before the video was even playable. The industry
+        //    pattern for batch import UX is "media available
+        //    immediately, captions stream in progressively" — same
+        //    approach YouTube's auto-captions and Descript use.
         emit({ stage: 'staging', message: '正在複製影片到應用目錄…' });
         const videoPath = await invoke<string>('import_video_for_lecture', {
             lectureId,
             sourcePath,
+        });
+        const lectureBefore = await storageService.getLecture(lectureId);
+        if (lectureBefore) {
+            await storageService.saveLecture({
+                ...lectureBefore,
+                video_path: videoPath,
+                updated_at: new Date().toISOString(),
+            });
+        }
+        emit({
+            stage: 'video_ready',
+            message: '影片已就緒，可以先開始觀看。轉錄中…',
+            videoPath,
         });
 
         // 1.5. Resolve model override up-front. Failing early lets us
@@ -149,18 +190,27 @@ export const videoImportService = {
             }
             const total = chunks.length;
 
-            // 4. Transcribe + translate pipeline.
+            // 4. Transcribe + translate pipeline, with progressive
+            //    persistence. Each chunk flows through three distinct
+            //    "commit" points so the UI can reflect partial state:
             //
-            //    - Transcription runs sequentially (one Whisper context
-            //      at a time; two in parallel would just contend for
-            //      the same Mutex-guarded service).
-            //    - Translation fires-and-forgets: each finished chunk's
-            //      segments are handed to translate_ct2_batch in the
-            //      background while the next chunk transcribes.
-            //    - We join on all translation promises at the end before
-            //      saving subtitles.
+            //      a) transcribe finishes → save rough en subtitles to
+            //         DB and emit `subtitlesChanged`. User sees English
+            //         captions roll in chunk-by-chunk.
+            //      b) translate finishes → update those rows with
+            //         text_zh and emit again. Chinese fills in behind
+            //         the English.
+            //      c) all chunks done → RAG index + mark completed.
+            //
+            //    Industry reference: this is the "progressive captions"
+            //    pattern used by Descript / Otter — media plays while
+            //    the transcript materialises behind it. We don't need
+            //    whisper_streaming's LocalAgreement-2 because we have
+            //    the full audio up-front; LocalAgreement is for live
+            //    captioning where partial results get rewritten as
+            //    more audio arrives.
+            const savedSubtitleIds = new Map<WhisperSegment, string>();
             const allSegments: WhisperSegment[] = [];
-            const translationMap = new Map<WhisperSegment, string>();
             const translationPromises: Promise<void>[] = [];
 
             let transcribed = 0;
@@ -181,14 +231,6 @@ export const videoImportService = {
                         activeIdx !== null
                             ? `轉錄第 ${activeIdx + 1}/${total} 段中（已完成 ${transcribed}，翻譯 ${translated}/${total}）`
                             : `轉錄 ${transcribed}/${total}，翻譯 ${translated}/${total}`,
-                    transcribedChunks: transcribed,
-                    translatedChunks: translated,
-                    totalChunks: total,
-                });
-            const reportTranslating = () =>
-                emit({
-                    stage: 'translating',
-                    message: `翻譯 ${translated}/${total}（轉錄已完成）`,
                     transcribedChunks: transcribed,
                     translatedChunks: translated,
                     totalChunks: total,
@@ -245,9 +287,48 @@ export const videoImportService = {
                 const chunkIndex = i; // captured for translate promise below
                 reportTranscribing(i + 1 < total ? i + 1 : null);
 
-                // Kick off translation for just this chunk. Errors
-                // degrade to English-only — same graceful fallback the
-                // old code had.
+                // (a) Persist this chunk's subtitles immediately with
+                //     only the English text. Each row's UUID is captured
+                //     so the translation step (b) can update the exact
+                //     same row without reading back from DB.
+                const nowIso = new Date().toISOString();
+                const chunkSubtitles: Subtitle[] = chunkSegs.map((seg) => {
+                    const id = crypto.randomUUID();
+                    savedSubtitleIds.set(seg, id);
+                    return {
+                        id,
+                        lecture_id: lectureId,
+                        timestamp: seg.start_ms / 1000,
+                        text_en: seg.text.trim(),
+                        text_zh: undefined,
+                        type: 'rough',
+                        confidence: undefined,
+                        created_at: nowIso,
+                    };
+                });
+                if (chunkSubtitles.length > 0) {
+                    try {
+                        await storageService.saveSubtitles(chunkSubtitles);
+                        emit({
+                            stage: 'transcribing',
+                            message: `轉錄第 ${i + 1}/${total} 段中（已完成 ${transcribed}，翻譯 ${translated}/${total}）`,
+                            transcribedChunks: transcribed,
+                            translatedChunks: translated,
+                            totalChunks: total,
+                            subtitlesChanged: true,
+                        });
+                    } catch (err) {
+                        console.warn(
+                            `[videoImport] chunk ${i + 1} subtitle save failed:`,
+                            err,
+                        );
+                    }
+                }
+
+                // (b) Kick off translation for just this chunk. When it
+                //     finishes we update the rows saved in (a) in place
+                //     with the Chinese text. Errors degrade to
+                //     English-only — same graceful fallback as before.
                 translationPromises.push(
                     (async () => {
                         const texts = chunkSegs.map((s) => s.text.trim());
@@ -267,59 +348,61 @@ export const videoImportService = {
                                     err,
                                 );
                                 // Leave outputs[i..i+slice.length] as '' —
-                                // English subtitle still gets saved.
+                                // English subtitle stays as-is.
                             }
                         }
-                        for (let k = 0; k < chunkSegs.length; k++) {
-                            translationMap.set(chunkSegs[k], outputs[k]);
+                        // Re-save those rows with text_zh filled in.
+                        // saveSubtitles uses INSERT ... ON CONFLICT(id)
+                        // DO UPDATE, so reusing the captured id updates
+                        // in place without touching other rows.
+                        const translatedRows: Subtitle[] = chunkSegs.map((seg, k) => ({
+                            id: savedSubtitleIds.get(seg)!,
+                            lecture_id: lectureId,
+                            timestamp: seg.start_ms / 1000,
+                            text_en: seg.text.trim(),
+                            text_zh: outputs[k]?.trim() || undefined,
+                            type: 'rough',
+                            confidence: undefined,
+                            created_at: nowIso,
+                        }));
+                        try {
+                            await storageService.saveSubtitles(translatedRows);
+                        } catch (err) {
+                            console.warn(
+                                `[videoImport] chunk ${chunkIndex + 1} translate-save failed:`,
+                                err,
+                            );
                         }
                         translated++;
                         console.log(
                             `[videoImport] chunk ${chunkIndex + 1}/${total} translate done — ${translated}/${total} total`,
                         );
-                        if (transcribed < total) {
-                            reportTranscribing(null);
-                        } else {
-                            reportTranslating();
-                        }
+                        emit({
+                            stage: transcribed < total ? 'transcribing' : 'translating',
+                            message:
+                                transcribed < total
+                                    ? `轉錄 ${transcribed}/${total}，翻譯 ${translated}/${total}`
+                                    : `翻譯 ${translated}/${total}（轉錄已完成）`,
+                            transcribedChunks: transcribed,
+                            translatedChunks: translated,
+                            totalChunks: total,
+                            subtitlesChanged: true,
+                        });
                     })(),
                 );
             }
 
             // Wait for every chunk's translation to finish before we
-            // persist (saveSubtitles expects the full translated set).
+            // build the RAG index (needs the full concatenated text).
             await Promise.all(translationPromises);
 
-            // 5. Persist subtitles (mirrors the live-recording schema:
-            //    `rough` subtitles with en + best-effort zh).
-            emit({
-                stage: 'saving_subtitles',
-                message: `儲存 ${allSegments.length} 段字幕…`,
-                transcribedChunks: total,
-                translatedChunks: total,
-                totalChunks: total,
-            });
-            const now = new Date().toISOString();
-            const subtitles: Subtitle[] = allSegments.map((seg) => ({
-                id: crypto.randomUUID(),
-                lecture_id: lectureId,
-                timestamp: seg.start_ms / 1000,
-                text_en: seg.text.trim(),
-                text_zh: translationMap.get(seg)?.trim() || undefined,
-                type: 'rough',
-                confidence: undefined,
-                created_at: now,
-            }));
-            if (subtitles.length > 0) {
-                await storageService.saveSubtitles(subtitles);
-            }
-
-            // 6. Update lecture with video_path + duration.
+            // 5. Update lecture duration + mark completed. video_path
+            //    was written up-front at the staging step so this is
+            //    just a status flip.
             const lecture = await storageService.getLecture(lectureId);
             if (lecture) {
                 await storageService.saveLecture({
                     ...lecture,
-                    video_path: videoPath,
                     duration: Math.max(
                         lecture.duration,
                         Math.round(pcm.duration_sec),

--- a/ClassNoteAI/src/services/videoImportService.ts
+++ b/ClassNoteAI/src/services/videoImportService.ts
@@ -70,38 +70,68 @@ export const videoImportService = {
             sourcePath,
         });
 
-        // 2. Extract PCM via ffmpeg. Whole-file in-memory result is
-        //    fine for lecture lengths; if we ever need to support 4 h+
-        //    videos we switch to streaming PCM chunks.
-        emit({ stage: 'extracting_audio', message: '抽取音訊中…' });
-        const pcm = await invoke<number[]>('extract_pcm_from_video', {
-            videoPath,
-        });
-
-        // 3. Whisper transcribe. Reuses the exact same command the
-        //    live-recording path uses — no new model state, no new
-        //    code path, same quality.
+        // 2 + 3. Extract PCM + run Whisper inside one Rust call. The
+        // previous split would have serialised up to ~115 MB of i16
+        // samples (1h video × 16kHz × 2 bytes) as JSON over Tauri's
+        // IPC channel, which OOMs the webview. The combined command
+        // keeps the PCM in the Rust process and only returns the
+        // final segment list (a few KB).
         emit({
             stage: 'transcribing',
-            message: `轉錄中（約 ${Math.round(pcm.length / 16000)} 秒音訊）…`,
+            message: '抽取音訊並轉錄中…',
         });
-        const result = await invoke<TranscriptionResult>('transcribe_audio', {
-            audioData: pcm,
-            sampleRate: 16000,
+        const result = await invoke<TranscriptionResult>('transcribe_video_file', {
+            videoPath,
             initialPrompt: options.initialPrompt ?? null,
             language: options.language ?? null,
             options: null,
         });
 
-        // 4. Persist segments as rough subtitles. `timestamp` on the
-        //    Subtitle row is in seconds (float) per the existing
-        //    schema; Whisper gives us ms, so divide.
-        emit({ stage: 'saving_subtitles', message: '寫入字幕…' });
-        const subtitles: Subtitle[] = result.segments.map((seg) => ({
+        // 4a. Batch translate the English segments into Chinese in
+        //     ONE CTranslate2 call, then stitch back to their original
+        //     timestamps. Translating one line at a time would have
+        //     been N IPC round-trips and given the model no surrounding
+        //     context; a batch call lets the local CT2 engine run the
+        //     whole set on a single forward pass. We chunk at 64 lines
+        //     per batch so a 90-min lecture (~1000 segments) doesn't
+        //     push a single IPC payload over a megabyte — CTranslate2
+        //     handles the internal batching anyway.
+        emit({
+            stage: 'saving_subtitles',
+            message: `翻譯 ${result.segments.length} 段字幕…`,
+        });
+        const texts = result.segments.map((s) => s.text.trim());
+        const translations: string[] = new Array(texts.length);
+        const BATCH = 64;
+        for (let i = 0; i < texts.length; i += BATCH) {
+            const slice = texts.slice(i, i + BATCH);
+            try {
+                const translated = await invoke<string[]>('translate_ct2_batch', { texts: slice });
+                for (let j = 0; j < slice.length; j++) {
+                    translations[i + j] = translated[j] ?? '';
+                }
+            } catch (err) {
+                // Degrade gracefully: if the local CT2 model isn't
+                // loaded (user never configured translation, or model
+                // download is pending), keep the English subtitles
+                // and let the user add translations later.
+                console.warn('[videoImport] batch translate failed, falling back to English-only:', err);
+                for (let j = 0; j < slice.length; j++) {
+                    translations[i + j] = '';
+                }
+            }
+        }
+
+        // 4b. Persist segments as rough subtitles with both English
+        //     and (best-effort) Chinese text. Timestamp = Whisper's
+        //     start_ms converted to seconds (the schema's `timestamp`
+        //     column is seconds-as-float).
+        const subtitles: Subtitle[] = result.segments.map((seg, idx) => ({
             id: crypto.randomUUID(),
             lecture_id: lectureId,
             timestamp: seg.start_ms / 1000,
             text_en: seg.text.trim(),
+            text_zh: translations[idx]?.trim() || undefined,
             type: 'rough',
             confidence: undefined,
             created_at: new Date().toISOString(),

--- a/ClassNoteAI/src/services/videoImportService.ts
+++ b/ClassNoteAI/src/services/videoImportService.ts
@@ -1,0 +1,148 @@
+import { invoke } from '@tauri-apps/api/core';
+import { storageService } from './storageService';
+import { ragService } from './ragService';
+import type { Subtitle } from '../types';
+
+/**
+ * v0.6.0 — import a recorded lecture video and produce the same
+ * artifacts a live-recorded lecture produces:
+ *
+ *   1. Copy the user-selected video file into the app's video dir.
+ *   2. Pipe it through ffmpeg to get 16 kHz mono i16 PCM.
+ *   3. Run whisper-rs over the PCM to get timed segments.
+ *   4. Persist the segments as `subtitles` rows (role = "rough";
+ *      the streaming fine-refine pass can upgrade them to "fine"
+ *      later if needed).
+ *   5. Update the lecture row with `video_path` + durations.
+ *   6. Re-index the lecture for RAG so AI 助教 can use the
+ *      transcript immediately.
+ *
+ * Everything after step 1 is background work. The UI surfaces
+ * progress via the callback.
+ */
+
+export type ImportStage =
+    | 'staging'
+    | 'extracting_audio'
+    | 'transcribing'
+    | 'saving_subtitles'
+    | 'indexing'
+    | 'done';
+
+export interface ImportProgress {
+    stage: ImportStage;
+    message: string;
+    /** 0..1 for stages that can report granular progress; undefined
+     *  when the underlying step is opaque (e.g. ffmpeg doesn't stream
+     *  progress over stdin, whisper doesn't either). */
+    fraction?: number;
+}
+
+interface WhisperSegment {
+    text: string;
+    start_ms: number;
+    end_ms: number;
+}
+
+interface TranscriptionResult {
+    text: string;
+    segments: WhisperSegment[];
+    language?: string | null;
+    duration_ms: number;
+}
+
+export const videoImportService = {
+    async importVideo(
+        lectureId: string,
+        sourcePath: string,
+        options: {
+            language?: string;
+            initialPrompt?: string;
+            onProgress?: (p: ImportProgress) => void;
+        } = {},
+    ): Promise<{ videoPath: string; segmentCount: number; durationMs: number }> {
+        const emit = (p: ImportProgress) => options.onProgress?.(p);
+
+        // 1. Stage the source video under {app_data}/videos/{lectureId}.{ext}.
+        emit({ stage: 'staging', message: '正在複製影片到應用目錄…' });
+        const videoPath = await invoke<string>('import_video_for_lecture', {
+            lectureId,
+            sourcePath,
+        });
+
+        // 2. Extract PCM via ffmpeg. Whole-file in-memory result is
+        //    fine for lecture lengths; if we ever need to support 4 h+
+        //    videos we switch to streaming PCM chunks.
+        emit({ stage: 'extracting_audio', message: '抽取音訊中…' });
+        const pcm = await invoke<number[]>('extract_pcm_from_video', {
+            videoPath,
+        });
+
+        // 3. Whisper transcribe. Reuses the exact same command the
+        //    live-recording path uses — no new model state, no new
+        //    code path, same quality.
+        emit({
+            stage: 'transcribing',
+            message: `轉錄中（約 ${Math.round(pcm.length / 16000)} 秒音訊）…`,
+        });
+        const result = await invoke<TranscriptionResult>('transcribe_audio', {
+            audioData: pcm,
+            sampleRate: 16000,
+            initialPrompt: options.initialPrompt ?? null,
+            language: options.language ?? null,
+            options: null,
+        });
+
+        // 4. Persist segments as rough subtitles. `timestamp` on the
+        //    Subtitle row is in seconds (float) per the existing
+        //    schema; Whisper gives us ms, so divide.
+        emit({ stage: 'saving_subtitles', message: '寫入字幕…' });
+        const subtitles: Subtitle[] = result.segments.map((seg) => ({
+            id: crypto.randomUUID(),
+            lecture_id: lectureId,
+            timestamp: seg.start_ms / 1000,
+            text_en: seg.text.trim(),
+            type: 'rough',
+            confidence: undefined,
+            created_at: new Date().toISOString(),
+        }));
+        if (subtitles.length > 0) {
+            await storageService.saveSubtitles(subtitles);
+        }
+
+        // 5. Update the lecture row — video_path + duration. We leave
+        //    status alone; if the lecture was 'recording' (rare for
+        //    this flow since user usually imports into a fresh
+        //    lecture), the user can manually flip via Save.
+        const lecture = await storageService.getLecture(lectureId);
+        if (lecture) {
+            await storageService.saveLecture({
+                ...lecture,
+                video_path: videoPath,
+                duration: Math.max(lecture.duration, Math.round(result.duration_ms / 1000)),
+                status: 'completed',
+                updated_at: new Date().toISOString(),
+            });
+        }
+
+        // 6. RAG index. Concatenate all segments into one transcript
+        //    string; ragService.indexLecture chunks it the same way
+        //    live-recorded transcripts are chunked.
+        emit({ stage: 'indexing', message: '建立 AI 助教索引…' });
+        const transcriptText = result.segments
+            .map((s) => s.text.trim())
+            .filter(Boolean)
+            .join('\n');
+        // `indexLecture` will pull pdfText from the lecture's PDF on
+        // next open if one is attached; here we pass null so only the
+        // transcript goes in. PDF index picks up via its own flow.
+        await ragService.indexLecture(lectureId, null, transcriptText);
+
+        emit({ stage: 'done', message: '完成' });
+        return {
+            videoPath,
+            segmentCount: result.segments.length,
+            durationMs: result.duration_ms,
+        };
+    },
+};

--- a/ClassNoteAI/src/services/videoImportService.ts
+++ b/ClassNoteAI/src/services/videoImportService.ts
@@ -97,6 +97,90 @@ interface PcmExtractResult {
 const CHUNK_SEC = 60;
 const TRANSLATE_BATCH = 64;
 
+/** LLM-backed fine refinement pass. Runs AFTER rough transcribe +
+ *  CT2 translate have landed all subtitles to DB. Each batch asks the
+ *  user's configured LLM provider to correct ASR mistakes and produce
+ *  a natural Chinese translation in one shot, then writes those back
+ *  as `type='fine'`. Mirrors what transcriptionService does inline for
+ *  live recordings — we just didn't have a hook to reach it from the
+ *  batch video-import pipeline.
+ *
+ *  Skips entirely when no LLM provider is configured (same check
+ *  `refreshFineRefinementAvailability` does for live), so users
+ *  running fully offline don't pay a per-batch "no provider" retry.
+ *
+ *  Errors are treated as soft — we keep whatever rough refinement got
+ *  through and move on. The user can retry later by deleting the
+ *  lecture and re-importing, or we can add a "refine again" button.
+ */
+async function runFineRefinementPass(
+    lectureId: string,
+    emit: (p: ImportProgress) => void,
+): Promise<void> {
+    let refineTranscriptsFn: typeof import('./llm').refineTranscripts;
+    try {
+        const llm = await import('./llm');
+        refineTranscriptsFn = llm.refineTranscripts;
+        // Cheap availability check — probe a zero-length batch. If the
+        // provider isn't configured, refineTranscripts itself bails
+        // fast; we just catch that and skip silently.
+    } catch (err) {
+        console.warn('[videoImport] llm module unavailable, skipping fine refine:', err);
+        return;
+    }
+
+    const subs = await storageService.getSubtitles(lectureId);
+    if (subs.length === 0) return;
+
+    // Work in batches of 20 — same as the live-recording path's
+    // FINE_BATCH_SIZE. Large enough that per-call LLM overhead
+    // amortises, small enough that a single failure only costs 20
+    // segments of progress.
+    const BATCH = 20;
+    let done = 0;
+    const total = subs.length;
+
+    for (let i = 0; i < subs.length; i += BATCH) {
+        const slice = subs.slice(i, i + BATCH);
+        const input = slice
+            .map((s) => ({ id: s.id, text: s.text_en || '' }))
+            .filter((s) => s.text.length > 0);
+        if (input.length === 0) {
+            done += slice.length;
+            continue;
+        }
+
+        try {
+            const refinements = await refineTranscriptsFn(input);
+            const byId = new Map(refinements.map((r) => [r.id, r]));
+            const updates: Subtitle[] = slice.map((s) => {
+                const r = byId.get(s.id);
+                if (!r) return s;
+                return {
+                    ...s,
+                    text_en: r.en,
+                    text_zh: r.zh,
+                    type: 'fine' as const,
+                };
+            });
+            await storageService.saveSubtitles(updates);
+            done += slice.length;
+            emit({
+                stage: 'translating',
+                message: `精翻中 ${Math.min(done, total)}/${total}…`,
+                subtitlesChanged: true,
+            });
+        } catch (err) {
+            // Most likely cause: no AI provider configured. Bail out
+            // entirely rather than spamming N failed batches.
+            console.warn('[videoImport] refineTranscripts batch failed, stopping:', err);
+            return;
+        }
+    }
+
+    emit({ stage: 'done', message: '精翻完成', subtitlesChanged: true });
+}
+
 /** Which model Rust should use for this import's transcription.
  *  - `'fast'`: swap in ggml-base.bin (~5x faster than turbo on CPU).
  *  - `'standard'`: use whatever WHISPER_SERVICE already has loaded
@@ -393,7 +477,10 @@ export const videoImportService = {
             }
 
             // Wait for every chunk's translation to finish before we
-            // build the RAG index (needs the full concatenated text).
+            // mark the lecture completed. Fine refinement + RAG index
+            // run AFTER completion in the background (see below) so the
+            // UI can exit the "importing" state as soon as rough +
+            // Google-translated captions are all saved.
             await Promise.all(translationPromises);
 
             // 5. Update lecture duration + mark completed. video_path
@@ -412,13 +499,33 @@ export const videoImportService = {
                 });
             }
 
-            // 7. RAG index: concat all transcript text.
+            // 6. Fine refinement (LLM-backed). Upgrades rough subtitles
+            //    to 'fine' type, correcting ASR errors and producing
+            //    natural Chinese. We await this so the import-active
+            //    progress indicator keeps showing while the LLM batches
+            //    crunch — otherwise the UI would flash "完成" and then
+            //    silently keep mutating subtitles behind the user.
+            try {
+                await runFineRefinementPass(lectureId, emit);
+            } catch (err) {
+                console.warn('[videoImport] fine refinement failed:', err);
+            }
+
+            // 7. RAG index. Build AI-tutor searchable chunks from the
+            //    final transcript. Uses fine text where available, rough
+            //    otherwise (storageService.getSubtitles returns whatever
+            //    the last save left).
             emit({ stage: 'indexing', message: '建立 AI 助教索引…' });
-            const transcriptText = allSegments
-                .map((s) => s.text.trim())
-                .filter(Boolean)
-                .join('\n');
-            await ragService.indexLecture(lectureId, null, transcriptText);
+            try {
+                const finalSubs = await storageService.getSubtitles(lectureId);
+                const transcriptText = finalSubs
+                    .map((s) => (s.text_en || '').trim())
+                    .filter(Boolean)
+                    .join('\n');
+                await ragService.indexLecture(lectureId, null, transcriptText);
+            } catch (err) {
+                console.warn('[videoImport] RAG index failed:', err);
+            }
 
             emit({ stage: 'done', message: '完成' });
             return {

--- a/ClassNoteAI/src/services/videoImportService.ts
+++ b/ClassNoteAI/src/services/videoImportService.ts
@@ -139,21 +139,44 @@ export const videoImportService = {
                     ? options.language
                     : null;
 
-            const report = (stage: ImportStage) =>
+            const reportTranscribing = (activeIdx: number | null) =>
                 emit({
-                    stage,
+                    stage: 'transcribing',
                     message:
-                        stage === 'translating'
-                            ? `翻譯 ${translated}/${total}（轉錄已完成）`
+                        activeIdx !== null
+                            ? `轉錄第 ${activeIdx + 1}/${total} 段中（已完成 ${transcribed}，翻譯 ${translated}/${total}）`
                             : `轉錄 ${transcribed}/${total}，翻譯 ${translated}/${total}`,
                     transcribedChunks: transcribed,
                     translatedChunks: translated,
                     totalChunks: total,
                 });
+            const reportTranslating = () =>
+                emit({
+                    stage: 'translating',
+                    message: `翻譯 ${translated}/${total}（轉錄已完成）`,
+                    transcribedChunks: transcribed,
+                    translatedChunks: translated,
+                    totalChunks: total,
+                });
 
-            report('transcribing');
+            console.log(
+                '[videoImport] pipeline start — total chunks:',
+                total,
+                'duration:',
+                pcm.duration_sec.toFixed(1),
+                's, pcm:',
+                pcm.pcm_path,
+            );
+            reportTranscribing(null);
 
-            for (const chunk of chunks) {
+            for (let i = 0; i < chunks.length; i++) {
+                const chunk = chunks[i];
+                const t0 = performance.now();
+                console.log(
+                    `[videoImport] chunk ${i + 1}/${total} transcribe start — ${chunk.start.toFixed(1)}..${chunk.end.toFixed(1)}s, lang=${currentLang ?? 'auto'}`,
+                );
+                reportTranscribing(i);
+
                 const result = await invoke<TranscriptionResult>(
                     'transcribe_pcm_file_slice',
                     {
@@ -166,19 +189,25 @@ export const videoImportService = {
                     },
                 );
 
+                const elapsed = ((performance.now() - t0) / 1000).toFixed(1);
+                console.log(
+                    `[videoImport] chunk ${i + 1}/${total} transcribe done in ${elapsed}s — segments=${result.segments.length}, lang=${result.language ?? 'unknown'}`,
+                );
+
                 // Cache first successful language detection so later
                 // chunks don't redo it (and more importantly so they
                 // don't drift between languages if audio briefly goes
                 // quiet).
                 if (!currentLang && result.language) {
                     currentLang = result.language;
-                    console.log('[videoImport] language detected:', currentLang);
+                    console.log('[videoImport] language cached as:', currentLang);
                 }
 
                 const chunkSegs = result.segments.slice();
                 allSegments.push(...chunkSegs);
                 transcribed++;
-                report('transcribing');
+                const chunkIndex = i; // captured for translate promise below
+                reportTranscribing(i + 1 < total ? i + 1 : null);
 
                 // Kick off translation for just this chunk. Errors
                 // degrade to English-only — same graceful fallback the
@@ -205,11 +234,18 @@ export const videoImportService = {
                                 // English subtitle still gets saved.
                             }
                         }
-                        for (let i = 0; i < chunkSegs.length; i++) {
-                            translationMap.set(chunkSegs[i], outputs[i]);
+                        for (let k = 0; k < chunkSegs.length; k++) {
+                            translationMap.set(chunkSegs[k], outputs[k]);
                         }
                         translated++;
-                        report(transcribed < total ? 'transcribing' : 'translating');
+                        console.log(
+                            `[videoImport] chunk ${chunkIndex + 1}/${total} translate done — ${translated}/${total} total`,
+                        );
+                        if (transcribed < total) {
+                            reportTranscribing(null);
+                        } else {
+                            reportTranslating();
+                        }
                     })(),
                 );
             }

--- a/ClassNoteAI/src/types/index.ts
+++ b/ClassNoteAI/src/types/index.ts
@@ -160,6 +160,20 @@ export interface AppSettings {
   aiTutor?: {
     displayMode?: 'floating' | 'sidebar' | 'detached';
   };
+  /**
+   * Layout for lectures that have both an imported video and an
+   * attached PDF/PPT.
+   *   - `split` — vertical resizable split on the left panel: video
+   *               on top, slides on bottom. Both visible at once.
+   *   - `pip`   — slides take the main left panel, video floats as a
+   *               draggable / resizable overlay like a Zoom PiP. Less
+   *               visual footprint, closer to the "slides are the main
+   *               thing, glance at the prof occasionally" workflow.
+   * Defaults to `split` (see settings default-fill logic).
+   */
+  lectureLayout?: {
+    videoPdfMode?: 'split' | 'pip';
+  };
   sync?: {
     username: string;
     deviceId?: string;

--- a/ClassNoteAI/src/types/index.ts
+++ b/ClassNoteAI/src/types/index.ts
@@ -36,6 +36,10 @@ export interface Lecture {
   updated_at: string; // ISO 8601 - 必需字段
   audio_path?: string;
   audio_hash?: string;
+  /** v0.6.0: path to an imported video file (under {app_data}/videos/).
+   *  When present, Notes Review mode renders a <video> player and the
+   *  transcript + RAG index are derived from the video's audio track. */
+  video_path?: string;
   subtitles?: Subtitle[]; // 可選，用於前端顯示，數據庫中不存儲
   notes?: Note; // 可選，用於前端顯示，數據庫中不存儲
   is_deleted?: boolean; // Soft Delete


### PR DESCRIPTION
## Summary

v0.6.0's headline feature: drop a recorded lecture video into an empty lecture → ffmpeg extracts audio → chunked Whisper → CT2 batch-translates → streams subtitles to the DB as each chunk finishes → Notes Review mode plays the video with synced captions. Works for courses that provide only subtitles too (paste SRT/VTT/plain text).

12 commits; one branch.

## What's inside

**Core feature** — `import_video_for_lecture` + `extract_video_pcm_to_temp` + `transcribe_pcm_file_slice` Rust commands. Frontend pipeline in `videoImportService` chunks at 60s, transcribes sequentially, translates each chunk's segments in a background pipeline. A 70-min video finishes ~5–10 min on CPU base model.

**Streaming UX** — video is playable ~2s after clicking Import (the staging file copy). Subtitles stream into the Notes Review subtitle panel every 10–15s as each chunk's Whisper pass completes. Users can close the modal, watch the video, and the captions fill in behind them. Modelled after Descript / Otter's progressive-caption pattern; research note in the [streaming UX commit](https://github.com/sklonely/ClassNoteAI/commit/5b29108).

**ImportModal** — single 匯入 button replaces the old standalone 匯入影片 button. Three inputs (video file pick, video drop, subtitle paste) + cost-aware toggles (fast vs standard model, source language pin, opt-in AI refine with explicit token-cost copy).

**Dual video+PDF layout** — split (vertical) or PiP (floating). User chooses in Settings. Mirrors the AI 助教 display-mode pattern.

**Native drag-drop** — \`dragDropEnabled=true\`; new \`useTauriFileDrop\` hook returns filesystem paths instead of File objects. Videos can be dragged onto either the import modal or the lecture page without reading the bytes into the webview. Route-by-extension in NotesView: video → import, PDF → attach, PPT/Word → convert.

**Subtitle precision fix** — \`full_get_segment_t0\` returns centiseconds (10 ms units), not sample indices. The old \`(t * 1000) / sample_rate\` math compressed every timestamp to ~1/16 of true value; chunked import made it obvious as minute-level clumping. One-line unit fix in [transcribe.rs](https://github.com/sklonely/ClassNoteAI/commit/05d000b).

**Video keep-alive across Live ↔ Notes tab toggle** — both mode layouts now render simultaneously with one hidden via HTML \`hidden\` attribute. Preserves \`<video>\` currentTime / buffered state instead of forcing a disk-reload on every tab switch.

**Active-segment highlight** — subtitle panel now shows a blue ring on the currently-playing segment and auto-scrolls it to the middle of the viewport. Click any subtitle to seek.

**Progressive persistence** — each chunk saves to DB immediately after Whisper returns, so the lecture survives crashes mid-import and the UI can show partial captions.

**Fine refinement opt-in** — LLM batch refinement is available but defaults OFF with explicit cost display (1 小時 ≈ 130k tokens / GPT-4o ≈ \$1 / GitHub Models 免費但可能撞 rate limit).

**Parallel post-processing** — fine refine + RAG index run concurrently when both enabled (different resources: LLM vs local embedding model).

**Embedding batch** — 16 → 32. BGE-small-en-v1.5 is tiny enough; cuts RAG index batches in half.

**CDP tooling** — \`scripts/cdp.cjs\` so maintainers (and the agent) can tail console, eval JS, take screenshots, or dump DOM against the running dev app without bugging the user.

## Known follow-ups (not in this PR)

- **GPU acceleration** — \`whisper-rs 0.11 → 0.16\` + \`cuda\`/\`metal\`/\`vulkan\` features. Auto-Metal on macOS, CUDA on NVIDIA Windows/Linux, Vulkan as cross-vendor fallback. Needs the setup wizard to handle CUDA Toolkit install/detection, which is why it's deferred to its own PR.
- **VAD-based chunk boundaries** via ffmpeg silencedetect — avoids splitting sentences mid-word for cleaner chunk translations.

## Test plan

- [ ] Fresh lecture → 匯入 → 快速 + 英文 + refine OFF → pick any .mp4 ≥ 10 min. Video plays < 5 s, subtitles roll in every ~10 s, done in ~1/7 of video length.
- [ ] Click any subtitle → video seeks to that timestamp. Playing the video highlights the active segment in blue ring and auto-scrolls.
- [ ] Toggle Live Recording ↔ Notes Review tabs mid-playback — video keeps its currentTime, doesn't refetch from disk.
- [ ] Both Split and PiP layouts render cleanly when a lecture has both video and PDF.
- [ ] Drag a .mp4 onto the lecture page → import starts with sensible defaults.
- [ ] Drag a .pdf onto the lecture page → attaches as slides, doesn't trigger video import.
- [ ] Paste subtitles (SRT / VTT / plain text) → lecture becomes searchable via AI Tutor without video.
- [ ] Opt-in AI refine → cost display is accurate and the pass actually upgrades rows to \`type='fine'\`.
- [ ] Profiler line \`[videoImport] TIMING total=... stage_copy=... ffmpeg_pcm_extract=... transcribe_plus_translate=... fine_plus_rag=...\` appears in console on every run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)