### PR TITLE
v0.6.1: Whisper + Candle GPU acceleration (CUDA/Metal/Vulkan) + settings reorg

### DIFF
--- a/.github/workflows/merge-update-manifest.yml
+++ b/.github/workflows/merge-update-manifest.yml
@@ -88,21 +88,39 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           TAG: ${{ steps.ctx.outputs.tag }}
         run: |
+          # v0.6.1: Windows release ships TWO fragments — CPU and CUDA.
+          # Both platforms key into the same merged latest.json under
+          # different platform ids (windows-x86_64 vs windows-x86_64-cuda)
+          # so the client updater can pick the right one based on local
+          # GPU detection.
           gh release download "$TAG" \
             -R "${GITHUB_REPOSITORY}" \
             --pattern "latest-macos-aarch64.json" \
             --pattern "latest-windows-x86_64.json" \
+            --pattern "latest-windows-x86_64-cuda.json" \
             --clobber
+          # The CUDA fragment is optional: an older release from before
+          # the Windows-CUDA matrix existed won't have one, and that's
+          # fine — merge logic handles the absence below.
+          ls -la latest-*.json || true
 
       - name: Merge into latest.json
         if: steps.wait.outputs.ok == 'true'
         run: |
           # Take version/notes/pub_date from the macOS fragment (arbitrary —
-          # both fragments carry the same version for a given tag) and union
-          # the `platforms` objects.
-          jq -s '.[0] * {platforms: (.[0].platforms + .[1].platforms)}' \
-            latest-macos-aarch64.json \
-            latest-windows-x86_64.json \
+          # all fragments carry the same version for a given tag) and union
+          # the `platforms` objects across however many fragments exist.
+          # The CUDA fragment may be absent for old releases; fall back to
+          # merging just what's there.
+          FRAGMENTS=(latest-macos-aarch64.json latest-windows-x86_64.json)
+          if [ -f latest-windows-x86_64-cuda.json ]; then
+            FRAGMENTS+=(latest-windows-x86_64-cuda.json)
+          fi
+          # Use reduce to merge any number of fragments: first fragment
+          # carries the top-level metadata, subsequent ones just add
+          # their platform entries.
+          jq -s 'reduce .[1:][] as $f (.[0]; .platforms += $f.platforms)' \
+            "${FRAGMENTS[@]}" \
             > latest.json
           echo "--- merged latest.json ---"
           cat latest.json
@@ -110,8 +128,8 @@ jobs:
       - name: Sanity check merged manifest
         if: steps.wait.outputs.ok == 'true'
         run: |
-          # Both platform keys must be present, otherwise we would regress
-          # the very bug this workflow was added to fix.
+          # Both baseline platforms must be present. Windows-cuda is
+          # optional for back-compat with pre-v0.6.1 tags.
           for key in "darwin-aarch64" "windows-x86_64"; do
             if ! jq -e ".platforms[\"$key\"].url" latest.json > /dev/null; then
               echo "ERROR: merged latest.json missing platforms.$key.url"
@@ -119,7 +137,12 @@ jobs:
               exit 1
             fi
           done
-          echo "OK: latest.json has both platforms."
+          if jq -e '.platforms["windows-x86_64-cuda"].url' latest.json > /dev/null; then
+            echo "OK: latest.json includes Windows CUDA variant."
+          else
+            echo "NOTE: latest.json does not include Windows CUDA variant (expected on older tags)."
+          fi
+          echo "OK: latest.json has all required platforms."
 
       - name: Upload merged manifest
         if: steps.wait.outputs.ok == 'true'

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -82,6 +82,15 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Setup sccache
+        uses: mozilla-actions/sccache-action@v0.0.4
+
+      - name: Enable sccache for rustc
+        run: |
+          echo "RUSTC_WRAPPER=sccache" >> $GITHUB_ENV
+          echo "SCCACHE_GHA_ENABLED=true" >> $GITHUB_ENV
+        shell: bash
+
       - uses: actions/setup-node@v4
         with:
           node-version: '20'
@@ -135,4 +144,5 @@ jobs:
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           cd src-tauri
-          cargo check --message-format=short
+          # --no-default-features skips candle-embed heavy deps; embedding regressions caught at release build (saves ~3-5 min, fixes #29)
+          cargo check --no-default-features --message-format=short

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -94,8 +94,62 @@ jobs:
       - name: Build frontend
         run: npm run build
 
+      # ===== Apple code-signing setup =====
+      # We import the Developer ID Application cert into a dedicated
+      # keychain, then discover the identity name and export it for
+      # `tauri build` to consume. Skips cleanly on PR / manual runs that
+      # don't have the secrets set so unsigned local builds still work.
+      - name: Import Apple code-signing certificate
+        id: apple_cert
+        if: startsWith(github.ref, 'refs/tags/')
+        working-directory: .
+        env:
+          APPLE_CERTIFICATE: ${{ secrets.APPLE_CERTIFICATE }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+        run: |
+          set -euo pipefail
+          KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
+          KEYCHAIN_PASSWORD="$(uuidgen)"
+          CERT_PATH="$RUNNER_TEMP/certificate.p12"
+
+          echo "$APPLE_CERTIFICATE" | base64 --decode -o "$CERT_PATH"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security import "$CERT_PATH" \
+            -P "$APPLE_CERTIFICATE_PASSWORD" \
+            -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          # Put our keychain in the search list so codesign can see it.
+          security list-keychain -d user -s "$KEYCHAIN_PATH" login.keychain-db
+
+          # Discover the first Developer ID Application identity so we
+          # don't need a 6th APPLE_SIGNING_IDENTITY secret.
+          IDENTITY="$(security find-identity -v -p codesigning "$KEYCHAIN_PATH" \
+            | awk -F'"' '/Developer ID Application/{print $2; exit}')"
+          if [ -z "$IDENTITY" ]; then
+            echo "::error::No 'Developer ID Application' identity found in imported cert."
+            security find-identity -v -p codesigning "$KEYCHAIN_PATH"
+            exit 1
+          fi
+          echo "signing_identity=$IDENTITY" >> "$GITHUB_OUTPUT"
+          echo "Discovered signing identity: $IDENTITY"
+
       # ===== Build Tauri =====
+      # When APPLE_* secrets are present, Tauri's macOS bundler signs the
+      # .app with APPLE_SIGNING_IDENTITY (discovered above) and notarizes
+      # via APPLE_ID / APPLE_PASSWORD (app-specific password) / APPLE_TEAM_ID.
+      # PR / manual runs without secrets skip signing — env vars just expand
+      # to empty strings and Tauri produces an unsigned dev bundle.
       - name: Build Tauri (Apple Silicon)
+        env:
+          APPLE_SIGNING_IDENTITY: ${{ steps.apple_cert.outputs.signing_identity }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_PASSWORD: ${{ secrets.APPLE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
         run: npm run tauri build -- --target aarch64-apple-darwin
 
       # Intel x86_64 暫時禁用 - GitHub Actions macOS runner 不支持 AVX-512

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -153,10 +153,20 @@ jobs:
           TAURI_FEATURES: ${{ matrix.variant.features }}
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
+          REM Pin to nsis + updater bundles only. MSI rejects any
+          REM pre-release version suffix that isn't a plain
+          REM 1-65535 integer (`0.6.0-alpha.1` breaks the MSI
+          REM ProductVersion field at bundling time), while NSIS
+          REM happily accepts full SemVer. Stable releases could
+          REM add "msi" back — revisit when the first non-pre-
+          REM release 0.6.0 ships. Skipping MSI costs users nothing
+          REM today: we already primarily distribute the NSIS
+          REM setup.exe, the updater picks it up, and auto-update
+          REM works off the nsis .exe.sig either way.
           if "%TAURI_FEATURES%"=="" (
-            npx tauri build
+            npx tauri build --bundles nsis,updater
           ) else (
-            npx tauri build --features %TAURI_FEATURES%
+            npx tauri build --features %TAURI_FEATURES% --bundles nsis,updater
           )
 
       - name: Upload artifacts (PR / manual runs)

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -96,7 +96,15 @@ jobs:
         with:
           cuda: '12.5.1'
           method: 'network'
-          sub-packages: '["nvcc", "cudart", "cublas", "cublas_dev", "thrust", "visual_studio_integration"]'
+          # curand_dev is not optional — CTranslate2's CMake configure
+          # step fails with "Could not find curand" when it's absent,
+          # even though our app doesn't directly generate random
+          # numbers. CT2 pulls it in through its internal sampling
+          # utilities, and the link step only surfaces the miss at
+          # the very end of a 20-minute build. Hit confirmed on
+          # OpenNMT/CTranslate2's own ci.yml: they install
+          # `cublas_dev curand_dev` together.
+          sub-packages: '["nvcc", "cudart", "cublas", "cublas_dev", "curand", "curand_dev", "thrust", "visual_studio_integration"]'
 
       # Rust cache: keyed separately per variant so cpu and cuda compile
       # objects don't clobber each other (the gpu-cuda feature changes
@@ -164,6 +172,25 @@ jobs:
           # Older archs (Volta / Pascal) are already dropped by
           # CUDA 12.5's support matrix anyway.
           CUDA_COMPUTE_CAP: "75"
+          # Redundant CUDA root variables — different crates look at
+          # different names. `bindgen_cuda` reads CUDA_PATH / CUDA_ROOT;
+          # cmake's FindCUDAToolkit reads CUDA_TOOLKIT_ROOT_DIR;
+          # ct2rs' build.rs reads CUDA_HOME. Jimver exports CUDA_PATH
+          # but cargo sometimes strips environment mid-build; setting
+          # all of them here is cheap insurance.
+          CUDA_PATH: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.5
+          CUDA_ROOT: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.5
+          CUDA_TOOLKIT_ROOT_DIR: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.5
+          CUDA_HOME: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.5
+          # Limit simultaneous nvcc processes to N-1 cores on the
+          # 4-core runner. PTXAS can take 2-3 GB per compile unit;
+          # fully-parallel (4 concurrent) blew up compiling
+          # candle-kernels' moe_wmma.cu with an OOM kill that nvcc
+          # reports as exit 1 with empty stdout/stderr (see
+          # whisper.cpp's own build.yml — they set the same pattern
+          # via NINJA_JOBS). Doesn't affect cargo's outer
+          # parallelism, only inner nvcc/cmake parallel builds.
+          CMAKE_BUILD_PARALLEL_LEVEL: "3"
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           REM Pin to nsis + updater bundles only. MSI rejects any

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -151,6 +151,19 @@ jobs:
           CMAKE_GENERATOR: Visual Studio 17 2022
           CMAKE_TOOLCHAIN_FILE: ${{ github.workspace }}\ClassNoteAI\src-tauri\scripts\win-toolchain.cmake
           TAURI_FEATURES: ${{ matrix.variant.features }}
+          # candle-kernels' build.rs defers to `bindgen_cuda` 0.1.6,
+          # which calls `nvidia-smi` to detect the local compute cap.
+          # CI runners are CPU-only VMs — no GPU, no nvidia-smi on
+          # PATH — so the call panics with "program not found" even
+          # when CUDA Toolkit is installed. Setting CUDA_COMPUTE_CAP
+          # up-front makes bindgen_cuda skip the probe and use the
+          # value we hand it. 7.5 (Turing) is our distribution
+          # floor: anything newer (Ampere, Ada, Hopper, Blackwell)
+          # gets SASS via driver-side PTX JIT at first model load,
+          # which adds ~1-2 s cold-start cost but stays correct.
+          # Older archs (Volta / Pascal) are already dropped by
+          # CUDA 12.5's support matrix anyway.
+          CUDA_COMPUTE_CAP: "75"
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           REM Pin to nsis + updater bundles only. MSI rejects any

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -178,10 +178,10 @@ jobs:
           # ct2rs' build.rs reads CUDA_HOME. Jimver exports CUDA_PATH
           # but cargo sometimes strips environment mid-build; setting
           # all of them here is cheap insurance.
-          CUDA_PATH: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.5
-          CUDA_ROOT: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.5
-          CUDA_TOOLKIT_ROOT_DIR: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.5
-          CUDA_HOME: C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v12.5
+          CUDA_PATH: C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.5
+          CUDA_ROOT: C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.5
+          CUDA_TOOLKIT_ROOT_DIR: C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.5
+          CUDA_HOME: C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v12.5
           # Limit simultaneous nvcc processes to N-1 cores on the
           # 4-core runner. PTXAS can take 2-3 GB per compile unit;
           # fully-parallel (4 concurrent) blew up compiling

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -1,9 +1,9 @@
 name: Build and Release (Windows)
 
 on:
-  # Release bundles are expensive (~15–20 min). Only run when we're
-  # actually cutting a release (tag push) or when someone manually
-  # kicks it off. Lightweight PR feedback lives in pr-check.yml.
+  # Release bundles are expensive (~15–20 min per variant). Only run
+  # when we're actually cutting a release (tag push) or when someone
+  # manually kicks it off. Lightweight PR feedback lives in pr-check.yml.
   push:
     tags:
       - 'v*'
@@ -27,10 +27,32 @@ defaults:
     working-directory: ClassNoteAI
 
 jobs:
+  # v0.6.1: two Windows variants in a matrix.
+  #
+  #   cpu  — the historical build. No GPU code linked; smaller installer
+  #          (~250 MB). Works on every x64 Windows machine regardless of
+  #          GPU.
+  #   cuda — Whisper + Candle compiled with the CUDA backend. Ships the
+  #          runtime cudart/cuBLAS DLLs alongside the exe so the user
+  #          needs only the NVIDIA driver (already present on every
+  #          machine that's ever played a modern game). ~2 GB extra at
+  #          install-time because of cuBLAS, but transcription jumps
+  #          from ~0.5× realtime on CPU to ~20× on a mid-range RTX.
+  #
+  # The matrix items stay close enough that the shared checkout / toolchain
+  # setup deduplicates naturally; only the CUDA-specific steps gate on
+  # `matrix.variant.id == 'cuda'`.
   build-windows:
     runs-on: windows-latest
     permissions:
       contents: write
+    strategy:
+      fail-fast: false
+      matrix:
+        variant:
+          - { id: cpu,  features: "",         suffix: "",      label: "CPU" }
+          - { id: cuda, features: "gpu-cuda", suffix: "-cuda", label: "CUDA" }
+    name: build-windows-${{ matrix.variant.id }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -55,16 +77,40 @@ jobs:
           version: "18"
           directory: ${{ runner.temp }}/llvm
 
+      # CUDA-variant only: install the Toolkit so nvcc / cudart / cuBLAS
+      # are available at build time. The Jimver action caches the Toolkit
+      # payload and is the canonical way to install CUDA on GitHub Actions
+      # without baking it into a custom runner image.
+      #
+      # Pinned to CUDA 12.5 because whisper-rs 0.16 + Candle 0.8's CUDA
+      # paths have been tested against 12.x; bumping to a newer toolkit
+      # requires a compatible host driver, and we want the artifact to
+      # work on the widest driver range (571+ ships CUDA 12 runtime).
+      #
+      # `method: network` streams the toolkit installer and picks only
+      # the sub-components we use (compiler, cudart, cublas) — saves
+      # ~6 GB of download vs the full offline installer.
+      - name: Install CUDA Toolkit
+        if: matrix.variant.id == 'cuda'
+        uses: Jimver/cuda-toolkit@v0.2.19
+        with:
+          cuda: '12.5.1'
+          method: 'network'
+          sub-packages: '["nvcc", "cudart", "cublas", "cublas_dev", "thrust", "visual_studio_integration"]'
+
+      # Rust cache: keyed separately per variant so cpu and cuda compile
+      # objects don't clobber each other (the gpu-cuda feature changes
+      # every whisper-rs-sys / candle-core artifact).
       - name: Rust cache
         uses: Swatinem/rust-cache@v2
         with:
           workspaces: ClassNoteAI/src-tauri -> target
-          shared-key: "windows-rust-cache"
+          shared-key: "windows-${{ matrix.variant.id }}-rust-cache"
           cache-all-crates: true
 
       # CTranslate2 + whisper.cpp + sentencepiece each take a few minutes;
-      # cache their build dirs keyed to Cargo.lock + vendor patches so we
-      # only rebuild when those actually change.
+      # cache their build dirs keyed to Cargo.lock + vendor patches +
+      # variant so we only rebuild when those actually change.
       - name: Cache native C++ builds
         uses: actions/cache@v4
         with:
@@ -72,7 +118,7 @@ jobs:
             ClassNoteAI/src-tauri/target/release/build/ct2rs-*
             ClassNoteAI/src-tauri/target/release/build/whisper-rs-sys-*
             ClassNoteAI/src-tauri/target/release/build/sentencepiece-sys-*
-          key: native-windows-${{ hashFiles('ClassNoteAI/src-tauri/Cargo.lock', 'ClassNoteAI/src-tauri/vendor-patches/**') }}
+          key: native-windows-${{ matrix.variant.id }}-${{ hashFiles('ClassNoteAI/src-tauri/Cargo.lock', 'ClassNoteAI/src-tauri/vendor-patches/**') }}
 
       - name: Hydrate vendor/ (ct2rs, esaxx-rs with Windows patches)
         shell: bash
@@ -84,21 +130,40 @@ jobs:
       - name: Build frontend
         run: npm run build
 
-      - name: Build Tauri
+      # Stage the CUDA runtime DLLs where tauri.conf.json's
+      # `bundle.resources` glob can pick them up. Only runs for the
+      # cuda variant; for cpu the `src-tauri/resources/cuda/` dir
+      # stays empty and the glob matches nothing.
+      - name: Stage CUDA runtime DLLs
+        if: matrix.variant.id == 'cuda'
+        shell: bash
+        run: |
+          mkdir -p src-tauri/resources/cuda
+          cp "$CUDA_PATH/bin/cudart64_12.dll"     src-tauri/resources/cuda/
+          cp "$CUDA_PATH/bin/cublas64_12.dll"     src-tauri/resources/cuda/
+          cp "$CUDA_PATH/bin/cublasLt64_12.dll"   src-tauri/resources/cuda/
+          ls -la src-tauri/resources/cuda/
+
+      - name: Build Tauri (${{ matrix.variant.label }})
         shell: cmd
         env:
           LIBCLANG_PATH: ${{ runner.temp }}\llvm\bin
           CMAKE_GENERATOR: Visual Studio 17 2022
           CMAKE_TOOLCHAIN_FILE: ${{ github.workspace }}\ClassNoteAI\src-tauri\scripts\win-toolchain.cmake
+          TAURI_FEATURES: ${{ matrix.variant.features }}
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
-          npx tauri build
+          if "%TAURI_FEATURES%"=="" (
+            npx tauri build
+          ) else (
+            npx tauri build --features %TAURI_FEATURES%
+          )
 
       - name: Upload artifacts (PR / manual runs)
         if: "!startsWith(github.ref, 'refs/tags/')"
         uses: actions/upload-artifact@v4
         with:
-          name: windows-installers
+          name: windows-installers-${{ matrix.variant.id }}
           path: |
             ClassNoteAI/src-tauri/target/release/bundle/msi/*.msi
             ClassNoteAI/src-tauri/target/release/bundle/nsis/*-setup.exe
@@ -111,39 +176,48 @@ jobs:
         run: echo "VERSION=${GITHUB_REF#refs/tags/v}" >> $GITHUB_OUTPUT
         working-directory: .
 
-      # Write a platform-specific updater manifest so Mac and Windows jobs
-      # don't overwrite each other's latest.json. See notes at bottom of file
-      # for how to merge them into a single latest.json if you use the updater.
-      - name: Generate updater manifest (Windows)
+      # Per-variant updater manifest fragment. The client decides at
+      # install time which one to apply based on local GPU detection
+      # (see updaterService.pickPlatformKey in Phase 5).
+      #
+      #   cpu  → platforms.windows-x86_64
+      #   cuda → platforms.windows-x86_64-cuda
+      #
+      # merge-update-manifest.yml fuses these fragments into the single
+      # latest.json clients poll.
+      - name: Generate updater manifest (Windows / ${{ matrix.variant.label }})
         if: startsWith(github.ref, 'refs/tags/')
         shell: bash
         run: |
           VERSION="${{ steps.get_version.outputs.VERSION }}"
           SIG=$(cat src-tauri/target/release/bundle/nsis/*.exe.sig 2>/dev/null || echo "")
-          cat > latest-windows-x86_64.json << EOF
+          PLATFORM_KEY="windows-x86_64${{ matrix.variant.suffix == '-cuda' && '-cuda' || '' }}"
+          SUFFIX="${{ matrix.variant.suffix }}"
+          cat > latest-windows-x86_64${SUFFIX}.json << EOF
           {
             "version": "${VERSION}",
-            "notes": "ClassNoteAI ${VERSION} update",
+            "notes": "ClassNoteAI ${VERSION} update (${{ matrix.variant.label }})",
             "pub_date": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
             "platforms": {
-              "windows-x86_64": {
+              "${PLATFORM_KEY}": {
                 "signature": "${SIG}",
-                "url": "https://github.com/${{ github.repository }}/releases/download/v${VERSION}/ClassNoteAI_${VERSION}_x64-setup.exe"
+                "url": "https://github.com/${{ github.repository }}/releases/download/v${VERSION}/ClassNoteAI_${VERSION}_x64${SUFFIX}-setup.exe"
               }
             }
           }
           EOF
 
-      - name: Prepare release assets
+      - name: Prepare release assets (${{ matrix.variant.label }})
         if: startsWith(github.ref, 'refs/tags/')
         shell: bash
         run: |
           VERSION="${{ steps.get_version.outputs.VERSION }}"
+          SUFFIX="${{ matrix.variant.suffix }}"
           mkdir -p release-assets
-          cp src-tauri/target/release/bundle/msi/*.msi              "release-assets/ClassNoteAI_${VERSION}_x64.msi"            || true
-          cp src-tauri/target/release/bundle/nsis/*-setup.exe       "release-assets/ClassNoteAI_${VERSION}_x64-setup.exe"     || true
-          cp src-tauri/target/release/bundle/nsis/*-setup.exe.sig   "release-assets/ClassNoteAI_${VERSION}_x64-setup.exe.sig" || true
-          cp latest-windows-x86_64.json                              release-assets/
+          cp src-tauri/target/release/bundle/msi/*.msi              "release-assets/ClassNoteAI_${VERSION}_x64${SUFFIX}.msi"            || true
+          cp src-tauri/target/release/bundle/nsis/*-setup.exe       "release-assets/ClassNoteAI_${VERSION}_x64${SUFFIX}-setup.exe"     || true
+          cp src-tauri/target/release/bundle/nsis/*-setup.exe.sig   "release-assets/ClassNoteAI_${VERSION}_x64${SUFFIX}-setup.exe.sig" || true
+          cp latest-windows-x86_64${SUFFIX}.json                     release-assets/
 
       - name: Attach to Release
         if: startsWith(github.ref, 'refs/tags/')
@@ -151,18 +225,19 @@ jobs:
         with:
           # Upload as draft. The release is flipped to published by
           # merge-update-manifest.yml once both platforms' builds have
-          # succeeded and the unified latest.json is uploaded. This way,
-          # users never see a half-populated release.
+          # succeeded and the unified latest.json is uploaded.
           draft: true
           prerelease: ${{ contains(github.ref, 'alpha') || contains(github.ref, 'beta') }}
           files: |
             ClassNoteAI/release-assets/*
 
 # NOTES ----------------------------------------------------------------
-# This workflow uploads `latest-windows-x86_64.json`; the macOS workflow
-# uploads `latest-macos-aarch64.json`. Neither alone is a valid Tauri
-# updater manifest. The unified `latest.json` (which a v0.5.1+ client
-# polls via the single endpoint compiled into its binary) is produced
-# by `.github/workflows/merge-update-manifest.yml`, which fires once
-# both release workflows finish on a tag and merges both fragments.
-# See issue #33.
+# This workflow uploads two Windows updater fragments —
+# `latest-windows-x86_64.json` (CPU) and `latest-windows-x86_64-cuda.json`
+# — plus the macOS workflow's `latest-macos-aarch64.json`. None alone is a
+# valid Tauri updater manifest; the unified `latest.json` (which a
+# v0.5.1+ client polls via the single endpoint compiled into its binary)
+# is produced by `.github/workflows/merge-update-manifest.yml`. The
+# merged document has three `platforms` entries for Windows: `windows-
+# x86_64` (CPU, default), `windows-x86_64-cuda` (GPU, opt-in via updater
+# settings), and `darwin-aarch64` (macOS).

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -191,6 +191,31 @@ jobs:
           # via NINJA_JOBS). Doesn't affect cargo's outer
           # parallelism, only inner nvcc/cmake parallel builds.
           CMAKE_BUILD_PARALLEL_LEVEL: "3"
+          # CPU portability baseline. Without these flags, whisper.cpp
+          # (via whisper-rs-sys' CMake) sets `GGML_NATIVE=ON` and bakes
+          # the CI runner's full SIMD feature set into the binary —
+          # including AVX-512 / VNNI / BF16 that the GitHub
+          # windows-latest Xeon has. All 12th-gen+ Intel consumer CPUs
+          # (Alder Lake / Raptor Lake onwards) ship WITHOUT AVX-512
+          # (disabled in microcode). Users on those CPUs get
+          # STATUS_ILLEGAL_INSTRUCTION (c000001d) the first time
+          # whisper tries to run. Same applies to ggml's inner ops
+          # even in the CUDA build — there's still CPU-side
+          # pre/post-processing.
+          #
+          # `x86-64-v3` pins Rust's target ISA to the
+          # SSE4.2/AVX2/BMI2/FMA level (Haswell 2013 / Excavator 2015),
+          # a practical "modern consumer" floor. ~99% of 2014-onwards
+          # machines qualify. GGML_NATIVE=OFF tells the C++ side not
+          # to auto-detect; GGML_AVX2=ON keeps the useful modern
+          # intrinsics; the *_AVX512_* toggles stay off.
+          #
+          # Revisit when we ship a second Xeon-tier variant
+          # (recommended path: matrix × cpu-isa = {v3, v4} producing
+          # two installers, updater picks at download time based on
+          # cpuid).
+          RUSTFLAGS: "-C target-cpu=x86-64-v3"
+          CMAKE_ARGS: "-DGGML_NATIVE=OFF -DGGML_AVX2=ON -DGGML_AVX512=OFF -DGGML_AVX512_VBMI=OFF -DGGML_AVX512_VNNI=OFF -DGGML_AVX512_BF16=OFF -DGGML_FMA=ON -DGGML_F16C=ON"
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           REM Pin to nsis + updater bundles only. MSI rejects any

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -104,6 +104,22 @@ ClassNoteAI/
 └── .github/workflows/         # Dual-platform CI (build-windows + build-macos)
 ```
 
+## Branch strategy
+
+Trunk-based development:
+
+- **`main`** is the sole long-lived branch. Every merged PR lands here. CI runs on `main`. Dependabot targets `main`.
+- **Releases are tags, not branches.** Stable: `v0.6.0`, `v0.7.0`. Pre-release: `v0.6.0-alpha.4`, `v0.6.0-beta.1`. The auto-updater fetches by tag, not by branch.
+- **Short-lived `feat/*` branches** only for multi-week work (e.g. the v0.6.5 speech pipeline overhaul). Everyday fixes and small features land directly on `main`.
+- **After a feature branch merges**, archive it as a tag and delete the branch: `git tag archive/<name> <old-tip-sha> && git push origin archive/<name> && git push origin --delete <name>`. History stays reachable; branch list stays clean.
+- **PRs merge via squash** by default. Use merge-commit only when the branch's per-commit history is intentionally atomic and meaningful (rare).
+
+### Why not GitFlow / main-vs-develop split
+
+Considered and rejected for a solo-maintainer alpha-stage project. GitFlow works when a dedicated release manager cuts stable releases on cadence; a two-long-lived-branch model creates dependabot-target confusion, merge-conflict tax at every stable cut, and "which branch is authoritative?" questions from visitors. Trunk-based with disciplined tagging solves the same problem with one moving part.
+
+The README banner at the repo root tells visitors the latest stable + latest pre-release tag so they don't have to infer state from `main`'s commit log.
+
 ## CI
 
 Every PR runs `build-windows` and `build-macos`. The ruleset on `main` requires both status checks + one approving review (bypassable by repo admins). See [.github/workflows/](.github/workflows/) for details.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -114,11 +114,15 @@ Trunk-based development:
 - **After a feature branch merges**, archive it as a tag and delete the branch: `git tag archive/<name> <old-tip-sha> && git push origin archive/<name> && git push origin --delete <name>`. History stays reachable; branch list stays clean.
 - **PRs merge via squash** by default. Use merge-commit only when the branch's per-commit history is intentionally atomic and meaningful (rare).
 
+### Current state
+
+The state of `main` at any moment: it contains every merged PR, both stable and pre-release work. **Users should never `git clone main` for production use** — install from the [Releases page](https://github.com/sklonely/ClassNoteAI/releases) instead, where tagged builds are signed, notarized (macOS), and tested. `main` exists for contributors.
+
+Latest stable tag: `v0.6.0`. Latest pre-release tag at time of writing: `v0.6.0-alpha.4`. Check the [Releases page](https://github.com/sklonely/ClassNoteAI/releases) for the current newest of each.
+
 ### Why not GitFlow / main-vs-develop split
 
 Considered and rejected for a solo-maintainer alpha-stage project. GitFlow works when a dedicated release manager cuts stable releases on cadence; a two-long-lived-branch model creates dependabot-target confusion, merge-conflict tax at every stable cut, and "which branch is authoritative?" questions from visitors. Trunk-based with disciplined tagging solves the same problem with one moving part.
-
-The README banner at the repo root tells visitors the latest stable + latest pre-release tag so they don't have to infer state from `main`'s commit log.
 
 ## CI
 

--- a/ClassNoteAI/docs/sop/delegating-to-codex.md
+++ b/ClassNoteAI/docs/sop/delegating-to-codex.md
@@ -1,0 +1,229 @@
+# Delegating tasks to Codex as the commander's worker
+
+Claude Code (commander) → Codex (worker) delegation pattern. Saves
+commander-side tokens by handing off well-scoped subtasks to a second
+AI running under the user's ChatGPT Plus quota.
+
+## Preferred path: `codex:rescue` subagent
+
+The Codex Claude Code plugin exposes a `codex:codex-rescue` subagent.
+That is the primary delegation path:
+
+```
+Agent(subagent_type="codex:codex-rescue", prompt="<preamble + task body>")
+```
+
+The plugin shares a Codex runtime across delegations, handles OAuth
+(via `auth.json`), and survives backend reconnects. Parallel
+delegations work — the commander can fan out 3+ tasks to different
+files in one message and collect the results.
+
+Keep `src-tauri/scripts/codex-delegate.sh` as a headless fallback
+(cron, CI, non-Claude-Code shells). See its header comment for usage.
+
+## When to delegate (and when not to)
+
+### ✅ Worth delegating
+
+- **Single-file fixes with a clear recipe**: wrap N parse calls,
+  retry one call site, replace hardcoded version with a discovery
+  loop. Codex respects literal numbered constraints well.
+- **Uniform boilerplate**: add error handling / logging / docstrings
+  to a module consistently.
+- **Long-running read + audit**: "find every `unwrap()` in these
+  crates and fix the ones on fallible IO paths."
+- **Parallelizable work** the commander wants to interleave with its
+  own thinking.
+
+### ❌ Not worth it
+
+- **1-2 line fixes**: prompt-writing overhead > the edit itself.
+- **Tasks needing commander-specific tools**: CDP eval, Monitor,
+  `gh run view`, existing Bash sessions, editor state. Codex
+  starts from scratch each time.
+- **Interactive judgment**: "figure out what to do here." Scope the
+  decision yourself, then hand Codex a concrete plan.
+- **Commander-side prompt > ~1k tokens**: you've already paid most
+  of the thinking cost; finish the task yourself.
+
+## Prompt structure: universal preamble + task body
+
+Every delegation should have two parts. The preamble is **reusable
+verbatim** across all tasks; the body is minimal — just the
+task-specific facts.
+
+### Universal preamble (paste as-is)
+
+```
+## Delegation protocol for this task
+
+### Scope constraints — numbered, literal, non-negotiable
+1. Edit only the target file(s) listed in the task body. No other files.
+2. Do not commit. Do not `git add`. Do not push.
+3. Do not reformat lines that aren't part of the fix. No `cargo fmt`,
+   `prettier`, `eslint --fix`, `rustfmt`, `black`, `gofmt`, or equivalent.
+4. Do not add new crate / package dependencies.
+5. Do not add new `use` / `import` / `require` statements unless
+   strictly necessary. Prefer fully-qualified paths (e.g.
+   `std::fs::read_dir`, `std::thread::sleep`).
+6. Do not change public function signatures, exported types, or
+   non-target code paths.
+
+### Non-ASCII byte preservation — critical
+Many files in this repo contain CJK (Chinese/Japanese/Korean)
+characters in comments, docstrings, log messages, and string
+literals. Some patch tools round-trip bytes through a non-UTF-8
+codec on Windows, which silently corrupts those characters —
+they mojibake into sequences like `?`, `�`, `撠`, `摮`, `銝`,
+`脰`, `澆`, or interleaved `?`-runs.
+
+After generating your patch:
+1. Scan your own output diff for `?`-runs that replaced CJK text,
+   for `�` (U+FFFD), or for unexpected `-` lines on context
+   bytes you did not intend to touch.
+2. If any of the above appear, the edit is broken — retry or
+   report the problem. Do not ship a corrupted patch.
+3. Preserve every non-ASCII byte byte-for-byte in regions you
+   are not deliberately rewriting.
+
+### Verify semantics — do not misinterpret
+Run the verify command listed in the task body and report what you
+see. The commander re-verifies locally regardless.
+
+Success = NO output lines begin with `error:` (Rust / cargo) or
+contain `error TS` (TypeScript / tsc), or whatever hard-error
+marker the tool uses.
+
+These are NOT failures and must be IGNORED:
+- `warning:` / `warning TS` lines (pre-existing noise)
+- Silent exit on clean (tsc, prettier --check, rustfmt --check)
+- `--quiet` flag suppressing normal build output
+- Sandbox `os error 5` / access-denied to `target/`, `node_modules/`,
+  `dist/`, `.next/` — an environment limitation of the Codex
+  sandbox, not a code defect. Note it in your summary and stop.
+
+Only `error:` / `error TS` lines count as real failure.
+
+### Behaviour contracts — preserve unless explicitly asked to change
+User-visible strings carry meaning the commander relies on: error
+messages, log messages, download URLs, i18n copy, CLI output, version
+strings, help text. Treat them as part of the public contract:
+- If the task body gives a new exact string, use it verbatim.
+- If the task body does NOT mention a user-visible string, preserve
+  the existing text semantically: do not shorten, condense, drop URLs,
+  drop secondary-language copy, or "tidy up" the wording.
+- If you must produce a new string not prescribed by the body, carry
+  every piece of information the old string held (URLs, paths,
+  version numbers, bilingual copy).
+
+Observability contracts: when a fix adds a retry, fallback, or
+recovery loop, every branch of that loop must emit equivalent
+log/trace evidence. If the last attempt in a retry chain fails,
+log it — commander debugging relies on having a line per attempt.
+
+### Touching adjacent lines when strictly required
+Constraint #6 ("do not change non-target code paths") sometimes
+collides with correctness: introducing a new nullable value may force
+a downstream access to become null-safe, or adding a new Result arm
+may require the match below to add a case. When an adjacent-line
+change is strictly necessary to prevent a runtime or compile failure,
+make the change AND call it out in the self-report below as point 4.
+Do not use this as an excuse to reformat. The bar is: "without this
+edit, the fix introduces a runtime crash or compile error." If the
+existing adjacent line still works with your new value, leave it.
+
+### Self-report contract
+Your final sentence(s) must state explicitly:
+1. Which file(s) you edited. Confirm no others were touched.
+2. What verify command you ran and whether any `error:`-class lines
+   appeared (and if the sandbox blocked the verify, say so).
+3. That you scanned your patch for CJK byte corruption per the
+   preamble — and either found none, or found and fixed it.
+4. Any user-visible strings you modified and any adjacent lines you
+   touched per the rules above, each with a one-sentence justification.
+   (Omit if none.)
+
+The commander treats your self-report as a hint, not ground truth.
+Be honest about what you did and did not check.
+```
+
+### Task body (minimal — facts only)
+
+```
+## Task
+
+Target: <absolute path(s)>
+Function / section: <name + approximate line range>
+
+Current state: <1-3 sentence description, or a literal code quote
+if the location is ambiguous>
+
+Problem: <1-2 sentences on the symptom + impact>
+
+Desired behaviour: <numbered steps, concrete; NO prose like "improve
+the error handling" — Codex wanders on vague goals>
+
+Rough shape (if the algorithm is non-obvious):
+<example code block — Codex adapts this to the file's style, so it
+is load-bearing for correctness>
+
+Edge cases to handle: <bullets, by principle not specific example
+where possible — e.g. "version-like strings must not be compared
+lexicographically since multi-digit fields break ASCII order">
+
+Verify: <exact command + cwd>
+```
+
+## Commander responsibilities after Codex returns
+
+Regardless of what Codex self-reports:
+
+1. `git status --short` — only the expected paths modified?
+2. `git diff -- <paths>` — changes make semantic sense? Spot-check
+   for accidental encoding corruption even if Codex claimed to check.
+3. Run verify command locally — sandbox often blocks it on Codex
+   side, and "compiles cleanly" is not the same as "behaves
+   correctly."
+4. For CJK-heavy files: explicitly `grep` for the preserved
+   comments / strings you expect to see unchanged.
+5. Commit with both co-author trailers:
+   ```
+   Co-Authored-By: OpenAI Codex <codex@openai.com>
+   Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+   ```
+
+## Budget model
+
+Per delegation (single-file fix, ~200-line function change):
+- ChatGPT side: 10-15k tokens (one reasoning pass + a few tool calls)
+- Commander side: ~1-2k tokens writing the prompt (preamble reused
+  verbatim is free), plus ~1k tokens reviewing the diff
+
+Net commander savings: ~10× vs doing the full read+write+verify cycle
+yourself. Parallelize independent tasks — the plugin handles fan-out.
+
+Skip delegating if the task-body facts alone exceed ~1k tokens —
+you've paid most of the thinking cost already.
+
+## Known failure modes and mitigations
+
+| Symptom | Mitigation |
+|---|---|
+| Codex interprets `cargo check --quiet` warnings as errors | Preamble's "Verify semantics" block defines `error:` as the only real failure marker |
+| CJK comment mojibakes during apply_patch | Preamble requires self-scan; commander regreps expected Chinese strings after |
+| Codex's sandbox blocks verify with `os error 5` | Preamble allow-lists this; commander re-verifies locally |
+| Lexicographic sort on version-like strings breaks at multi-digit | Call out the principle in task-body edge cases — Codex then picks mtime or semver parse |
+| Codex picks "improvement" that changes caller contract silently | Commander spot-checks behaviour change against known callers via grep |
+
+## Anti-patterns to avoid
+
+- **Prose-only prompts** ("please clean up the error handling"):
+  Codex wanders. Always numbered, always literal.
+- **Single combined "Run cargo check AND run the tests AND..."
+  verify step**: Codex reports the first failure it sees; subsequent
+  signals get lost.
+- **Skipping the commander-side diff review**: Codex's self-report
+  is optimistic by training. Always verify locally.
+- **Delegating while the commander's working directory has unrelated
+  dirty changes**: Codex may touch them. `git status` before and
+  after every delegation.

--- a/ClassNoteAI/docs/sop/release-smoke-test.md
+++ b/ClassNoteAI/docs/sop/release-smoke-test.md
@@ -1,0 +1,179 @@
+# Release 煙霧測試 SOP
+
+驗證 GitHub Actions build 出的 installer 在真實使用者環境下的端到端行為。
+每次推 pre-release tag（`v*-alpha.*` / `v*-rc.*`）後跑一次；stable tag（`v*`）
+推之前必跑一次。
+
+## 目的
+
+把以下一串手動步驟沉澱成照表操課，避免每次都重新回想 CDP 怎麼接、課程怎麼建、import 怎麼觸發。
+
+## 前置條件
+
+| 項目 | 狀態 |
+|---|---|
+| Windows 10/11 x64 + NVIDIA GPU driver ≥ 555 | ✓ 檢查 `nvidia-smi` 顯示 Driver ≥ 555 |
+| 已下載 `ClassNoteAI_{ver}_x64-cuda-setup.exe` 並完成安裝 | ✓ `%LOCALAPPDATA%\ClassNoteAI\classnoteai.exe` 存在 |
+| 測試影片（30–90 min，MP4/MKV/WebM） | 範例：`C:/Users/{user}/我的影片.mp4` |
+| Node.js + `ws` package（repo 目錄下 `npm i` 過） | 為了跑 `scripts/cdp.cjs` |
+
+## 1. 啟動 release，同時開 CDP port
+
+Release 預設不開遠端偵錯 port（production 安全性考量），需要用專用 launcher
+帶 env var 啟動：
+
+```cmd
+cd path\to\repo\ClassNoteAI\src-tauri
+scripts\launch-cuda-release.bat
+```
+
+> 若 9222 被占，`set CNAI_DEV_CDP_PORT=9333` 再跑 bat。
+
+驗證：
+
+```bash
+netstat -ano | grep LISTENING | grep ":9222"
+# 應該看到一行 TCP 127.0.0.1:9222 ... LISTENING
+```
+
+## 2. 透過 CDP 確認 build variant + GPU 可用
+
+從 repo 根目錄：
+
+```bash
+node scripts/cdp.cjs eval \
+  "(async()=>{const i=window.__TAURI_INTERNALS__.invoke;
+    return {variant:await i('get_build_variant'),
+            det:await i('detect_gpu_backends',{preference:null})};})()"
+```
+
+預期：
+
+```json
+{
+  "variant": "cuda",
+  "det": {
+    "cuda": {"gpu_name": "...", "driver_version": "596.21"},
+    "effective": "cuda",
+    "driver_hint": null
+  }
+}
+```
+
+若 `driver_hint` 不是 `null`，代表 driver < 555.85（Windows）/ 555.42（Linux）
+→ 先更新 driver 再測。
+
+> Release 跟 dev 最大差別：`window.__TAURI_INTERNALS__.invoke` 直接存取；dev
+> 模式還有 Vite dev server 所以可以 `import /node_modules/.vite/deps/...`。
+
+## 3. 確認模型都在位
+
+```bash
+ls -la "$USERPROFILE/AppData/Roaming/com.classnoteai/models/whisper/"      # 至少 ggml-base.bin
+ls -la "$USERPROFILE/AppData/Roaming/com.classnoteai/models/translation/m2m100-418M-ct2-int8/model.bin"
+ls -la "$USERPROFILE/AppData/Roaming/com.classnoteai/models/embedding/bge-small-en-v1.5/model.safetensors"
+```
+
+如果 translation 的 `model.bin` 顯示在 `m2m100-418M-ct2-int8/m2m100-418M-ct2-int8/`
+（雙層）而不是外層，`load_translation_model_by_name` 現在會自動 flatten
+（v0.6.0-alpha.1+）。若沒有 self-heal 邏輯的舊版，就 `mv inner/* .. && rmdir inner`。
+
+## 4. 建立測試課程 + lecture
+
+CDP 一行：
+
+```bash
+node scripts/cdp.cjs eval "$(cat <<'EOF'
+(async()=>{
+  const i=window.__TAURI_INTERNALS__.invoke;
+  const now=new Date().toISOString();
+  const userId = 'sk'; // 或你登入的 username
+  const courseId=`smoke-${Date.now()}`;
+  const lectureId=`lec-${Date.now()}`;
+  await i('save_course',{course:{id:courseId,user_id:userId,title:'Smoke Test',description:null,keywords:null,syllabus_info:null,is_deleted:false,created_at:now,updated_at:now},userId});
+  await i('save_lecture',{lecture:{id:lectureId,course_id:courseId,title:'video import 測試',date:now,duration:0,pdf_path:null,audio_path:null,video_path:null,status:'pending',is_deleted:false,created_at:now,updated_at:now},userId});
+  return {courseId,lectureId};
+})()
+EOF
+)"
+```
+
+記下回傳的 `lectureId`——下一步會用。
+
+## 5. 啟動 import pipeline（背景跑）
+
+```bash
+node scripts/cdp.cjs eval "$(cat <<'EOF'
+(async()=>{
+  const i=window.__TAURI_INTERNALS__.invoke;
+  const LECTURE='{{貼上 lectureId}}';
+  const VIDEO='C:/Users/{user}/我的影片.mp4';  // 正斜線
+  window.__smoke={startedAt:Date.now(),progress:[],done:null,err:null};
+  // Release build 的 Vite 模組路徑不可用 — 先把 videoImportService 的
+  // 關鍵 invoke 鏈在這裡手寫，或改回呼叫 Rust side command 直接觸發。
+  // 開發 mode 建議：用 videoImportService；release 建議:invoke 個別 Rust command。
+  return {launched:true};
+})()
+EOF
+)"
+```
+
+實際上 release build 沒有 HMR/Vite，上面 `videoImportService` 動態 import 會失敗。
+**Release 端只能透過 UI 操作**：
+1. 打開 app 的主視窗
+2. 進「課程」→ 選「Smoke Test」→ 點該 lecture
+3. 點「匯入影片」或拖拉 `.mp4` 進 Review mode
+
+> **例外**：如果你只要測 Rust 後端行為，直接 invoke 個別 command（`import_video_for_lecture`, `extract_video_pcm_to_temp`, `transcribe_pcm_file_slice`…）在 CDP 是 OK 的，但不會走 videoImportService 的 orchestration、status 欄位等狀態管理。
+
+## 6. 觀察進度
+
+透過 CDP 讀 window 狀態：
+
+```bash
+node scripts/cdp.cjs eval \
+  "(()=>{const p=window.__smoke||{};return {el:Math.round((Date.now()-p.startedAt)/1000),
+                                            done:!!p.done,err:p.err,
+                                            last:p.progress[p.progress.length-1]};})()"
+```
+
+若在 UI 操作，改看 DOM：
+
+```bash
+node scripts/cdp.cjs text --grep "進度\|轉錄\|翻譯"
+```
+
+## 7. 驗收清單
+
+- [ ] `extracting_audio` → 數秒（ffmpeg PCM 抽取）
+- [ ] `transcribing` → 平均 **~1 秒/chunk**（GPU）；若 > 5 秒/chunk 代表 GPU 沒吃到
+- [ ] `translating` → 跟 transcribing pipeline，多半不成 bottleneck
+- [ ] `indexing` → BGE embedding。**若 Windows CI 版本 candle-cuda 已停用**，預期 CPU ~3 分鐘/70-min 影片；若 GPU ~10 秒
+- [ ] Note Review mode 開啟後每個 section 有 **3 條 bullet**（Layer 1）
+- [ ] Section header 的投影片範圍欄位（若 lecture 有 PDF）
+- [ ] 進「設定 → 雲端 AI 助理」能看到 refine intensity 三檔 + provider 下拉
+- [ ] Settings → 本地轉錄模型 → GPU 偵測面板顯示 cuda ✓，driver_hint = null
+
+## 8. 常見失敗 + 對應
+
+| 症狀 | 可能原因 | 修法 |
+|---|---|---|
+| `CT2 模型文件不存在` | 巢狀目錄（歷史遺留） | 0.6.0-alpha.1+ 自動 heal；更早版本手動 `mv inner/*` |
+| `ggml_cuda_init: failed... driver insufficient` | NVIDIA driver < 555 | 更新 driver（自動提示 banner 會顯示下載連結） |
+| Transcribe 很慢（>5s/chunk） | GPU 沒吃到 | 檢查 `detect_gpu_backends.effective`，若是 cpu → 看 driver/CUDA runtime |
+| UI 停在 `indexing...` 幾分鐘 | CPU BGE（預期，candle-cuda 在 CI 暫時關） | 等完或縮短測試影片長度 |
+| `連接被拒 127.0.0.1:9222` | Release 沒用 launcher 啟動 | 用 `launch-cuda-release.bat`（不是開始選單） |
+
+## 9. 收尾
+
+關掉 app 前建議保留 CDP session（不 kill）讓下次迭代重接。
+刪除測試資料：
+
+```bash
+node scripts/cdp.cjs eval \
+  "(async()=>{const i=window.__TAURI_INTERNALS__.invoke;
+    await i('delete_lecture',{id:'<lectureId>'});
+    return 'deleted';})()"
+```
+
+或直接保留，下個 release 再看 migration 行為是否正常。

--- a/ClassNoteAI/package.json
+++ b/ClassNoteAI/package.json
@@ -1,7 +1,7 @@
 {
   "name": "classnoteai",
   "private": true,
-  "version": "0.6.0-alpha.2",
+  "version": "0.6.0-alpha.3",
   "type": "module",
   "scripts": {
     "dev": "vite --debug",

--- a/ClassNoteAI/package.json
+++ b/ClassNoteAI/package.json
@@ -1,7 +1,7 @@
 {
   "name": "classnoteai",
   "private": true,
-  "version": "0.5.3",
+  "version": "0.6.0-alpha.1",
   "type": "module",
   "scripts": {
     "dev": "vite --debug",

--- a/ClassNoteAI/package.json
+++ b/ClassNoteAI/package.json
@@ -1,7 +1,7 @@
 {
   "name": "classnoteai",
   "private": true,
-  "version": "0.6.0-alpha.1",
+  "version": "0.6.0-alpha.2",
   "type": "module",
   "scripts": {
     "dev": "vite --debug",

--- a/ClassNoteAI/package.json
+++ b/ClassNoteAI/package.json
@@ -1,7 +1,7 @@
 {
   "name": "classnoteai",
   "private": true,
-  "version": "0.6.0-alpha.3",
+  "version": "0.6.0-alpha.4",
   "type": "module",
   "scripts": {
     "dev": "vite --debug",

--- a/ClassNoteAI/src-tauri/Cargo.lock
+++ b/ClassNoteAI/src-tauri/Cargo.lock
@@ -325,17 +325,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "bindgen_cuda"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "282be55fb326843bb67cccceeeaf21c961ef303f60018f9a2ab69494dad8eaf9"
-dependencies = [
- "glob",
- "num_cpus",
- "rayon",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -534,11 +523,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c15b675b80d994b2eadb20a4bbe434eabeb454eac3ee5e2b4cf6f147ee9be091"
 dependencies = [
  "byteorder",
- "candle-kernels",
  "candle-metal-kernels",
  "candle-ug",
- "cudarc 0.19.4",
- "float8 0.6.1",
+ "float8",
  "gemm 0.19.0",
  "half",
  "libm",
@@ -554,15 +541,6 @@ dependencies = [
  "thiserror 2.0.17",
  "yoke 0.8.1",
  "zip 7.2.0",
-]
-
-[[package]]
-name = "candle-kernels"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8455f84bd810047c7c41216683c1020c915a9f8a740b3b0eabdd4fb2fbaa660"
-dependencies = [
- "bindgen_cuda",
 ]
 
 [[package]]
@@ -624,7 +602,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c22d62be69068bf58987a45f690612739d8d2ea1bf508c1b87dc6815a019575d"
 dependencies = [
  "ug",
- "ug-cuda",
  "ug-metal",
 ]
 
@@ -793,7 +770,7 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "classnoteai"
-version = "0.6.0-alpha.1"
+version = "0.6.0-alpha.2"
 dependencies = [
  "anyhow",
  "candle-core",
@@ -825,6 +802,7 @@ dependencies = [
  "tempfile",
  "tokenizers 0.21.4",
  "tokio",
+ "toml 0.8.2",
  "urlencoding",
  "uuid",
  "walkdir",
@@ -1130,27 +1108,6 @@ checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
  "syn 2.0.111",
-]
-
-[[package]]
-name = "cudarc"
-version = "0.17.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf99ab37ee7072d64d906aa2dada9a3422f1d975cdf8c8055a573bc84897ed8"
-dependencies = [
- "half",
- "libloading 0.8.9",
-]
-
-[[package]]
-name = "cudarc"
-version = "0.19.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f071cd6a7b5d51607df76aa2d426aaabc7a74bc6bdb885b8afa63a880572ad9b"
-dependencies = [
- "float8 0.7.0",
- "half",
- "libloading 0.9.0",
 ]
 
 [[package]]
@@ -1773,20 +1730,10 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "719a903cc23e4a89e87962c2a80fdb45cdaad0983a89bd150bb57b4c8571a7d5"
 dependencies = [
- "cudarc 0.19.4",
  "half",
  "num-traits",
  "rand 0.9.2",
  "rand_distr",
-]
-
-[[package]]
-name = "float8"
-version = "0.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2d1f04709a8ac06e8e8042875a3c466cc4832d3c1a18dbcb9dba3c6e83046bc"
-dependencies = [
- "half",
 ]
 
 [[package]]
@@ -6819,19 +6766,6 @@ dependencies = [
  "thiserror 1.0.69",
  "tracing",
  "yoke 0.7.5",
-]
-
-[[package]]
-name = "ug-cuda"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f0a1fa748f26166778c33b8498255ebb7c6bffb472bcc0a72839e07ebb1d9b5"
-dependencies = [
- "cudarc 0.17.8",
- "half",
- "serde",
- "thiserror 1.0.69",
- "ug",
 ]
 
 [[package]]

--- a/ClassNoteAI/src-tauri/Cargo.lock
+++ b/ClassNoteAI/src-tauri/Cargo.lock
@@ -21,6 +21,17 @@ dependencies = [
 
 [[package]]
 name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom 0.2.16",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
+name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
@@ -64,6 +75,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_log-sys"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84521a3cf562bc62942e294181d9eef17eb38ceb8c68677bc49f144e4c3d4f8d"
+
+[[package]]
+name = "android_logger"
+version = "0.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dbb4e440d04be07da1f1bf44fb4495ebd58669372fe0cffa6e48595ac5bd88a3"
+dependencies = [
+ "android_log-sys",
+ "env_filter",
+ "log",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -92,6 +120,12 @@ checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
 dependencies = [
  "derive_arbitrary",
 ]
+
+[[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "ashpd"
@@ -355,6 +389,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty",
+ "radium",
+ "tap",
+ "wyz",
+]
+
+[[package]]
 name = "block"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -401,6 +447,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "borsh"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfd1e3f8955a5d7de9fab72fc8373fade9fb8a703968cb200ae3dc6cf08e185a"
+dependencies = [
+ "borsh-derive",
+ "bytes",
+ "cfg_aliases",
+]
+
+[[package]]
+name = "borsh-derive"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfcfdc083699101d5a7965e49925975f2f55060f94f9a05e7187be95d530ca59"
+dependencies = [
+ "once_cell",
+ "proc-macro-crate 3.4.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "brotli"
 version = "8.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -426,6 +496,40 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
+
+[[package]]
+name = "byte-unit"
+version = "5.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c6d47a4e2961fb8721bcfc54feae6455f2f64e7054f9bc67e875f0e77f4c58d"
+dependencies = [
+ "rust_decimal",
+ "schemars 1.1.0",
+ "serde",
+ "utf8-width",
+]
+
+[[package]]
+name = "bytecheck"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23cdc57ce23ac53c931e88a43d06d070a6fd142f2617be5855eb75efc9beb1c2"
+dependencies = [
+ "bytecheck_derive",
+ "ptr_meta",
+ "simdutf8",
+]
+
+[[package]]
+name = "bytecheck_derive"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3db406d29fbcd95542e92559bed4d8ad92636d1ca8b3b72ede10b4bcc010e659"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "bytemuck"
@@ -781,6 +885,7 @@ dependencies = [
  "dirs 5.0.1",
  "futures-util",
  "hf-hub",
+ "log",
  "ndarray 0.15.6",
  "num_cpus",
  "ort",
@@ -795,6 +900,7 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-fs",
  "tauri-plugin-http",
+ "tauri-plugin-log",
  "tauri-plugin-opener",
  "tauri-plugin-process",
  "tauri-plugin-single-instance",
@@ -1594,6 +1700,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_filter"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+dependencies = [
+ "log",
+ "regex",
+]
+
+[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1684,6 +1800,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
 dependencies = [
  "simd-adler32",
+]
+
+[[package]]
+name = "fern"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4316185f709b23713e41e3195f90edef7fb00c3ed4adc79769cf09cc762a3b29"
+dependencies = [
+ "log",
 ]
 
 [[package]]
@@ -1804,6 +1929,12 @@ name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futf"
@@ -2481,6 +2612,9 @@ name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash 0.7.8",
+]
 
 [[package]]
 name = "hashbrown"
@@ -2488,7 +2622,7 @@ version = "0.14.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5274423e17b7c9fc20b6e7e208532f9b19825d82dfd615708b70edd83df41f1"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
 ]
 
 [[package]]
@@ -3220,6 +3354,9 @@ name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34080505efa8e45a4b816c349525ebe327ceaa8559756f0356cba97ef3bf7432"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "lru-slab"
@@ -3669,6 +3806,15 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -4575,6 +4721,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "33cb294fe86a74cbcf50d4445b37da762029549ebeea341421c7c70370f86cac"
 
 [[package]]
+name = "ptr_meta"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0738ccf7ea06b608c10564b31debd4f5bc5e197fc8bfe088f68ae5ce81e7a4f1"
+dependencies = [
+ "ptr_meta_derive",
+]
+
+[[package]]
+name = "ptr_meta_derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16b845dbfca988fa33db069c0e230574d15a3088f147a87b64c7589eb662c9ac"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "publicsuffix"
 version = "2.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4708,6 +4874,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -4968,6 +5140,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
 
 [[package]]
+name = "rend"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71fe3824f5629716b1589be05dacd749f6aa084c87e00e016714a8cdfccc997c"
+dependencies = [
+ "bytecheck",
+]
+
+[[package]]
 name = "reqwest"
 version = "0.12.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5057,6 +5238,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "rkyv"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2297bf9c81a3f0dc96bc9521370b88f054168c29826a75e89c55ff196e7ed6a1"
+dependencies = [
+ "bitvec",
+ "bytecheck",
+ "bytes",
+ "hashbrown 0.12.3",
+ "ptr_meta",
+ "rend",
+ "rkyv_derive",
+ "seahash",
+ "tinyvec",
+ "uuid",
+]
+
+[[package]]
+name = "rkyv_derive"
+version = "0.7.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "84d7b42d4b8d06048d3ac8db0eb31bcb942cbeb709f0b5f2b2ebde398d3038f5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.31.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5069,6 +5279,23 @@ dependencies = [
  "hashlink",
  "libsqlite3-sys",
  "smallvec",
+]
+
+[[package]]
+name = "rust_decimal"
+version = "1.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2ce901f9a19d251159075a4c37af514c3b8ef99c22e02dd8c19161cf397ee94a"
+dependencies = [
+ "arrayvec",
+ "borsh",
+ "bytes",
+ "num-traits",
+ "rand 0.8.5",
+ "rkyv",
+ "serde",
+ "serde_json",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -5254,6 +5481,12 @@ name = "scratch"
 version = "1.0.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d68f2ec51b097e4c1a75b681a8bec621909b5e91f15bb7b840c4f2f7b01148b2"
+
+[[package]]
+name = "seahash"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
 name = "security-framework"
@@ -5559,6 +5792,12 @@ name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
+
+[[package]]
+name = "simdutf8"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
@@ -5867,6 +6106,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "tap"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
 name = "tar"
 version = "0.4.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6077,6 +6322,28 @@ dependencies = [
  "tokio",
  "url",
  "urlpattern",
+]
+
+[[package]]
+name = "tauri-plugin-log"
+version = "2.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7545bd67f070a4500432c826e2e0682146a1d6712aee22a2786490156b574d93"
+dependencies = [
+ "android_logger",
+ "byte-unit",
+ "fern",
+ "log",
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "swift-rs",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.17",
+ "time",
 ]
 
 [[package]]
@@ -6340,7 +6607,9 @@ checksum = "91e7d9e3bb61134e77bde20dd4825b97c010155709965fedf0f49bb138e52a9d"
 dependencies = [
  "deranged",
  "itoa",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde",
  "time-core",
@@ -6394,7 +6663,7 @@ version = "0.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a620b996116a59e184c2fa2dfd8251ea34a36d0a514758c6f966386bd2e03476"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "aho-corasick",
  "compact_str",
  "dary_heap",
@@ -6428,7 +6697,7 @@ version = "0.22.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b238e22d44a15349529690fb07bd645cf58149a1b1e44d6cb5bd1641ff1a6223"
 dependencies = [
- "ahash",
+ "ahash 0.8.12",
  "aho-corasick",
  "compact_str",
  "dary_heap",
@@ -6960,6 +7229,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf8-width"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1292c0d970b54115d14f2492fe0170adf21d68a1de108eebc51c1df4f346a091"
+
+[[package]]
 name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6976,6 +7251,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
 
 [[package]]
 name = "vcpkg"
@@ -7930,6 +8211,15 @@ dependencies = [
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
+]
+
+[[package]]
+name = "wyz"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
 ]
 
 [[package]]

--- a/ClassNoteAI/src-tauri/Cargo.lock
+++ b/ClassNoteAI/src-tauri/Cargo.lock
@@ -793,7 +793,7 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "classnoteai"
-version = "0.5.3"
+version = "0.6.0-alpha.1"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/ClassNoteAI/src-tauri/Cargo.lock
+++ b/ClassNoteAI/src-tauri/Cargo.lock
@@ -770,7 +770,7 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "classnoteai"
-version = "0.6.0-alpha.2"
+version = "0.6.0-alpha.3"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/ClassNoteAI/src-tauri/Cargo.lock
+++ b/ClassNoteAI/src-tauri/Cargo.lock
@@ -319,6 +319,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "bindgen_cuda"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be55fb326843bb67cccceeeaf21c961ef303f60018f9a2ab69494dad8eaf9"
+dependencies = [
+ "glob",
+ "num_cpus",
+ "rayon",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -347,6 +358,12 @@ checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
 dependencies = [
  "serde_core",
 ]
+
+[[package]]
+name = "block"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0d8c1fef690941d3e7788d328517591fecc684c084084702d6ff1641e993699a"
 
 [[package]]
 name = "block-buffer"
@@ -511,9 +528,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06ccf5ee3532e66868516d9b315f73aec9f34ea1a37ae98514534d458915dbf1"
 dependencies = [
  "byteorder",
+ "candle-kernels",
+ "candle-metal-kernels",
+ "cudarc",
  "gemm 0.17.1",
  "half",
  "memmap2",
+ "metal 0.27.0",
  "num-traits",
  "num_cpus",
  "rand 0.9.2",
@@ -522,8 +543,31 @@ dependencies = [
  "safetensors",
  "thiserror 1.0.69",
  "ug",
+ "ug-cuda",
+ "ug-metal",
  "yoke 0.7.5",
  "zip 1.1.4",
+]
+
+[[package]]
+name = "candle-kernels"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a10885bd902fad1b8518ba2b22369aaed88a3d94e123533ad3ca73db33b1c8ca"
+dependencies = [
+ "bindgen_cuda",
+]
+
+[[package]]
+name = "candle-metal-kernels"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c85c21827c28db94e7112e364abe7e0cf8d2b022c014edf08642be6b94f21e"
+dependencies = [
+ "metal 0.27.0",
+ "once_cell",
+ "thiserror 1.0.69",
+ "tracing",
 ]
 
 [[package]]
@@ -533,7 +577,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be1160c3b63f47d40d91110a3e1e1e566ae38edddbbf492a60b40ffc3bc1ff38"
 dependencies = [
  "candle-core",
+ "candle-metal-kernels",
  "half",
+ "metal 0.27.0",
  "num-traits",
  "rayon",
  "safetensors",
@@ -919,8 +965,19 @@ checksum = "fa95a34622365fa5bbf40b20b75dba8dfa8c94c734aea8ac9a5ca38af14316f1"
 dependencies = [
  "bitflags 2.10.0",
  "core-foundation 0.10.1",
- "core-graphics-types",
+ "core-graphics-types 0.2.0",
  "foreign-types 0.5.0",
+ "libc",
+]
+
+[[package]]
+name = "core-graphics-types"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "45390e6114f68f718cc7a830514a96f903cccd70d02a8f6d9f643ac4ba45afaf"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation 0.9.4",
  "libc",
 ]
 
@@ -1051,6 +1108,16 @@ checksum = "32a2785755761f3ddc1492979ce1e48d2c00d09311c39e4466429188f3dd6501"
 dependencies = [
  "quote",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "cudarc"
+version = "0.13.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "486c221362668c63a1636cfa51463b09574433b39029326cff40864b3ba12b6e"
+dependencies = [
+ "half",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -3189,6 +3256,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "670fdfda89751bc4a84ac13eaa63e205cf0fd22b4c9a5fbfa085b63c1f1d3a30"
 
 [[package]]
+name = "malloc_buf"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62bb907fe88d54d8d9ce32a3cceab4218ed2f6b7d35617cafe9adf84e43919cb"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "markup5ever"
 version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3252,6 +3328,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "metal"
+version = "0.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c43f73953f8cbe511f021b58f18c3ce1c3d1ae13fe953293e13345bf83217f25"
+dependencies = [
+ "bitflags 2.10.0",
+ "block",
+ "core-graphics-types 0.1.3",
+ "foreign-types 0.5.0",
+ "log",
+ "objc",
+ "paste",
+]
+
+[[package]]
+name = "metal"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
+dependencies = [
+ "bitflags 2.10.0",
+ "block",
+ "core-graphics-types 0.1.3",
+ "foreign-types 0.5.0",
+ "log",
+ "objc",
+ "paste",
 ]
 
 [[package]]
@@ -3587,6 +3693,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
+name = "objc"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
+dependencies = [
+ "malloc_buf",
+ "objc_exception",
+]
+
+[[package]]
 name = "objc-sys"
 version = "0.3.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3860,6 +3976,15 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "objc2-javascript-core",
  "objc2-security",
+]
+
+[[package]]
+name = "objc_exception"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -6647,6 +6772,33 @@ dependencies = [
  "thiserror 1.0.69",
  "tracing",
  "yoke 0.7.5",
+]
+
+[[package]]
+name = "ug-cuda"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50758486d7941f8b0a636ba7e29455c07071f41590beac1fd307ec893e8db69a"
+dependencies = [
+ "cudarc",
+ "half",
+ "serde",
+ "thiserror 1.0.69",
+ "ug",
+]
+
+[[package]]
+name = "ug-metal"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a02ddc17bf32f7dcaaf016b6735f7198082b82f122df7b3ca15d8ead5911ccef"
+dependencies = [
+ "half",
+ "metal 0.29.0",
+ "objc",
+ "serde",
+ "thiserror 1.0.69",
+ "ug",
 ]
 
 [[package]]

--- a/ClassNoteAI/src-tauri/Cargo.lock
+++ b/ClassNoteAI/src-tauri/Cargo.lock
@@ -58,6 +58,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -331,18 +337,18 @@ dependencies = [
 
 [[package]]
 name = "bit-set"
-version = "0.5.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+checksum = "08807e080ed7f9d5433fa9b275196cfc35414f66a0c79d864dc51a0d825231a3"
 dependencies = [
  "bit-vec",
 ]
 
 [[package]]
 name = "bit-vec"
-version = "0.6.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
@@ -523,75 +529,80 @@ dependencies = [
 
 [[package]]
 name = "candle-core"
-version = "0.8.4"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "06ccf5ee3532e66868516d9b315f73aec9f34ea1a37ae98514534d458915dbf1"
+checksum = "c15b675b80d994b2eadb20a4bbe434eabeb454eac3ee5e2b4cf6f147ee9be091"
 dependencies = [
  "byteorder",
  "candle-kernels",
  "candle-metal-kernels",
- "cudarc",
- "gemm 0.17.1",
+ "candle-ug",
+ "cudarc 0.19.4",
+ "float8 0.6.1",
+ "gemm 0.19.0",
  "half",
+ "libm",
  "memmap2",
- "metal 0.27.0",
  "num-traits",
  "num_cpus",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
  "rand 0.9.2",
  "rand_distr",
  "rayon",
- "safetensors",
- "thiserror 1.0.69",
- "ug",
- "ug-cuda",
- "ug-metal",
- "yoke 0.7.5",
- "zip 1.1.4",
+ "safetensors 0.7.0",
+ "thiserror 2.0.17",
+ "yoke 0.8.1",
+ "zip 7.2.0",
 ]
 
 [[package]]
 name = "candle-kernels"
-version = "0.8.4"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a10885bd902fad1b8518ba2b22369aaed88a3d94e123533ad3ca73db33b1c8ca"
+checksum = "b8455f84bd810047c7c41216683c1020c915a9f8a740b3b0eabdd4fb2fbaa660"
 dependencies = [
  "bindgen_cuda",
 ]
 
 [[package]]
 name = "candle-metal-kernels"
-version = "0.8.4"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c85c21827c28db94e7112e364abe7e0cf8d2b022c014edf08642be6b94f21e"
+checksum = "2fdfe9d06de16ce49961e49084e5b79a75a9bdf157246e7c7b6328e87a7aa25d"
 dependencies = [
- "metal 0.27.0",
+ "half",
+ "objc2 0.6.3",
+ "objc2-foundation 0.3.2",
+ "objc2-metal 0.3.2",
  "once_cell",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
  "tracing",
 ]
 
 [[package]]
 name = "candle-nn"
-version = "0.8.4"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be1160c3b63f47d40d91110a3e1e1e566ae38edddbbf492a60b40ffc3bc1ff38"
+checksum = "3045fa9e7aef8567d209a27d56b692f60b96f4d0569f4c3011f8ca6715c65e03"
 dependencies = [
  "candle-core",
  "candle-metal-kernels",
  "half",
- "metal 0.27.0",
+ "libc",
  "num-traits",
+ "objc2-metal 0.3.2",
  "rayon",
- "safetensors",
+ "safetensors 0.7.0",
  "serde",
- "thiserror 1.0.69",
+ "thiserror 2.0.17",
 ]
 
 [[package]]
 name = "candle-transformers"
-version = "0.8.4"
+version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94a0900d49f8605e0e7e6693a1f560e6271279de98e5fa369e7abf3aac245020"
+checksum = "b538ec4aa807c416a2ddd3621044888f188827862e2a6fcacba4738e89795d01"
 dependencies = [
  "byteorder",
  "candle-core",
@@ -604,6 +615,17 @@ dependencies = [
  "serde_json",
  "serde_plain",
  "tracing",
+]
+
+[[package]]
+name = "candle-ug"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c22d62be69068bf58987a45f690612739d8d2ea1bf508c1b87dc6815a019575d"
+dependencies = [
+ "ug",
+ "ug-cuda",
+ "ug-metal",
 ]
 
 [[package]]
@@ -1112,12 +1134,23 @@ dependencies = [
 
 [[package]]
 name = "cudarc"
-version = "0.13.9"
+version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "486c221362668c63a1636cfa51463b09574433b39029326cff40864b3ba12b6e"
+checksum = "0bf99ab37ee7072d64d906aa2dada9a3422f1d975cdf8c8055a573bc84897ed8"
 dependencies = [
  "half",
  "libloading 0.8.9",
+]
+
+[[package]]
+name = "cudarc"
+version = "0.19.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f071cd6a7b5d51607df76aa2d426aaabc7a74bc6bdb885b8afa63a880572ad9b"
+dependencies = [
+ "float8 0.7.0",
+ "half",
+ "libloading 0.9.0",
 ]
 
 [[package]]
@@ -1509,16 +1542,6 @@ checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "dyn-stack"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e53799688f5632f364f8fb387488dd05db9fe45db7011be066fc20e7027f8b"
-dependencies = [
- "bytemuck",
- "reborrow",
-]
-
-[[package]]
-name = "dyn-stack"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c4713e43e2886ba72b8271aa66c93d722116acf7a75555cce11dcde84388fe8"
@@ -1682,9 +1705,9 @@ checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fancy-regex"
-version = "0.13.0"
+version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "531e46835a22af56d1e3b66f04844bed63158bc094a628bec1d321d9b4c44bf2"
+checksum = "72cf461f865c862bb7dc573f643dd6a2b6842f7c30b07882b56bd148cc2761b8"
 dependencies = [
  "bit-set",
  "regex-automata",
@@ -1742,6 +1765,28 @@ checksum = "bfe33edd8e85a12a67454e37f8c75e730830d83e313556ab9ebf9ee7fbeb3bfb"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+]
+
+[[package]]
+name = "float8"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "719a903cc23e4a89e87962c2a80fdb45cdaad0983a89bd150bb57b4c8571a7d5"
+dependencies = [
+ "cudarc 0.19.4",
+ "half",
+ "num-traits",
+ "rand 0.9.2",
+ "rand_distr",
+]
+
+[[package]]
+name = "float8"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d1f04709a8ac06e8e8042875a3c466cc4832d3c1a18dbcb9dba3c6e83046bc"
+dependencies = [
+ "half",
 ]
 
 [[package]]
@@ -2018,31 +2063,11 @@ dependencies = [
 
 [[package]]
 name = "gemm"
-version = "0.17.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ab24cc62135b40090e31a76a9b2766a501979f3070fa27f689c27ec04377d32"
-dependencies = [
- "dyn-stack 0.10.0",
- "gemm-c32 0.17.1",
- "gemm-c64 0.17.1",
- "gemm-common 0.17.1",
- "gemm-f16 0.17.1",
- "gemm-f32 0.17.1",
- "gemm-f64 0.17.1",
- "num-complex",
- "num-traits",
- "paste",
- "raw-cpuid 10.7.0",
- "seq-macro",
-]
-
-[[package]]
-name = "gemm"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab96b703d31950f1aeddded248bc95543c9efc7ac9c4a21fda8703a83ee35451"
 dependencies = [
- "dyn-stack 0.13.2",
+ "dyn-stack",
  "gemm-c32 0.18.2",
  "gemm-c64 0.18.2",
  "gemm-common 0.18.2",
@@ -2052,22 +2077,27 @@ dependencies = [
  "num-complex",
  "num-traits",
  "paste",
- "raw-cpuid 11.6.0",
+ "raw-cpuid",
  "seq-macro",
 ]
 
 [[package]]
-name = "gemm-c32"
-version = "0.17.1"
+name = "gemm"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9c030d0b983d1e34a546b86e08f600c11696fde16199f971cd46c12e67512c0"
+checksum = "aa0673db364b12263d103b68337a68fbecc541d6f6b61ba72fe438654709eacb"
 dependencies = [
- "dyn-stack 0.10.0",
- "gemm-common 0.17.1",
+ "dyn-stack",
+ "gemm-c32 0.19.0",
+ "gemm-c64 0.19.0",
+ "gemm-common 0.19.0",
+ "gemm-f16 0.19.0",
+ "gemm-f32 0.19.0",
+ "gemm-f64 0.19.0",
  "num-complex",
  "num-traits",
  "paste",
- "raw-cpuid 10.7.0",
+ "raw-cpuid",
  "seq-macro",
 ]
 
@@ -2077,27 +2107,27 @@ version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6db9fd9f40421d00eea9dd0770045a5603b8d684654816637732463f4073847"
 dependencies = [
- "dyn-stack 0.13.2",
+ "dyn-stack",
  "gemm-common 0.18.2",
  "num-complex",
  "num-traits",
  "paste",
- "raw-cpuid 11.6.0",
+ "raw-cpuid",
  "seq-macro",
 ]
 
 [[package]]
-name = "gemm-c64"
-version = "0.17.1"
+name = "gemm-c32"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbb5f2e79fefb9693d18e1066a557b4546cd334b226beadc68b11a8f9431852a"
+checksum = "086936dbdcb99e37aad81d320f98f670e53c1e55a98bee70573e83f95beb128c"
 dependencies = [
- "dyn-stack 0.10.0",
- "gemm-common 0.17.1",
+ "dyn-stack",
+ "gemm-common 0.19.0",
  "num-complex",
  "num-traits",
  "paste",
- "raw-cpuid 10.7.0",
+ "raw-cpuid",
  "seq-macro",
 ]
 
@@ -2107,33 +2137,28 @@ version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dfcad8a3d35a43758330b635d02edad980c1e143dc2f21e6fd25f9e4eada8edf"
 dependencies = [
- "dyn-stack 0.13.2",
+ "dyn-stack",
  "gemm-common 0.18.2",
  "num-complex",
  "num-traits",
  "paste",
- "raw-cpuid 11.6.0",
+ "raw-cpuid",
  "seq-macro",
 ]
 
 [[package]]
-name = "gemm-common"
-version = "0.17.1"
+name = "gemm-c64"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2e7ea062c987abcd8db95db917b4ffb4ecdfd0668471d8dc54734fdff2354e8"
+checksum = "20c8aeeeec425959bda4d9827664029ba1501a90a0d1e6228e48bef741db3a3f"
 dependencies = [
- "bytemuck",
- "dyn-stack 0.10.0",
- "half",
+ "dyn-stack",
+ "gemm-common 0.19.0",
  "num-complex",
  "num-traits",
- "once_cell",
  "paste",
- "pulp 0.18.22",
- "raw-cpuid 10.7.0",
- "rayon",
+ "raw-cpuid",
  "seq-macro",
- "sysctl 0.5.5",
 ]
 
 [[package]]
@@ -2143,7 +2168,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a352d4a69cbe938b9e2a9cb7a3a63b7e72f9349174a2752a558a8a563510d0f3"
 dependencies = [
  "bytemuck",
- "dyn-stack 0.13.2",
+ "dyn-stack",
  "half",
  "libm",
  "num-complex",
@@ -2151,28 +2176,31 @@ dependencies = [
  "once_cell",
  "paste",
  "pulp 0.21.5",
- "raw-cpuid 11.6.0",
+ "raw-cpuid",
  "rayon",
  "seq-macro",
- "sysctl 0.6.0",
+ "sysctl",
 ]
 
 [[package]]
-name = "gemm-f16"
-version = "0.17.1"
+name = "gemm-common"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ca4c06b9b11952071d317604acb332e924e817bd891bec8dfb494168c7cedd4"
+checksum = "88027625910cc9b1085aaaa1c4bc46bb3a36aad323452b33c25b5e4e7c8e2a3e"
 dependencies = [
- "dyn-stack 0.10.0",
- "gemm-common 0.17.1",
- "gemm-f32 0.17.1",
+ "bytemuck",
+ "dyn-stack",
  "half",
+ "libm",
  "num-complex",
  "num-traits",
+ "once_cell",
  "paste",
- "raw-cpuid 10.7.0",
+ "pulp 0.22.2",
+ "raw-cpuid",
  "rayon",
  "seq-macro",
+ "sysctl",
 ]
 
 [[package]]
@@ -2181,30 +2209,33 @@ version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cff95ae3259432f3c3410eaa919033cd03791d81cebd18018393dc147952e109"
 dependencies = [
- "dyn-stack 0.13.2",
+ "dyn-stack",
  "gemm-common 0.18.2",
  "gemm-f32 0.18.2",
  "half",
  "num-complex",
  "num-traits",
  "paste",
- "raw-cpuid 11.6.0",
+ "raw-cpuid",
  "rayon",
  "seq-macro",
 ]
 
 [[package]]
-name = "gemm-f32"
-version = "0.17.1"
+name = "gemm-f16"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e9a69f51aaefbd9cf12d18faf273d3e982d9d711f60775645ed5c8047b4ae113"
+checksum = "e3df7a55202e6cd6739d82ae3399c8e0c7e1402859b30e4cb780e61525d9486e"
 dependencies = [
- "dyn-stack 0.10.0",
- "gemm-common 0.17.1",
+ "dyn-stack",
+ "gemm-common 0.19.0",
+ "gemm-f32 0.19.0",
+ "half",
  "num-complex",
  "num-traits",
  "paste",
- "raw-cpuid 10.7.0",
+ "raw-cpuid",
+ "rayon",
  "seq-macro",
 ]
 
@@ -2214,27 +2245,27 @@ version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bc8d3d4385393304f407392f754cd2dc4b315d05063f62cf09f47b58de276864"
 dependencies = [
- "dyn-stack 0.13.2",
+ "dyn-stack",
  "gemm-common 0.18.2",
  "num-complex",
  "num-traits",
  "paste",
- "raw-cpuid 11.6.0",
+ "raw-cpuid",
  "seq-macro",
 ]
 
 [[package]]
-name = "gemm-f64"
-version = "0.17.1"
+name = "gemm-f32"
+version = "0.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa397a48544fadf0b81ec8741e5c0fba0043008113f71f2034def1935645d2b0"
+checksum = "02e0b8c9da1fbec6e3e3ab2ce6bc259ef18eb5f6f0d3e4edf54b75f9fd41a81c"
 dependencies = [
- "dyn-stack 0.10.0",
- "gemm-common 0.17.1",
+ "dyn-stack",
+ "gemm-common 0.19.0",
  "num-complex",
  "num-traits",
  "paste",
- "raw-cpuid 10.7.0",
+ "raw-cpuid",
  "seq-macro",
 ]
 
@@ -2244,12 +2275,27 @@ version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "35b2a4f76ce4b8b16eadc11ccf2e083252d8237c1b589558a49b0183545015bd"
 dependencies = [
- "dyn-stack 0.13.2",
+ "dyn-stack",
  "gemm-common 0.18.2",
  "num-complex",
  "num-traits",
  "paste",
- "raw-cpuid 11.6.0",
+ "raw-cpuid",
+ "seq-macro",
+]
+
+[[package]]
+name = "gemm-f64"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "056131e8f2a521bfab322f804ccd652520c79700d81209e9d9275bbdecaadc6a"
+dependencies = [
+ "dyn-stack",
+ "gemm-common 0.19.0",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "raw-cpuid",
  "seq-macro",
 ]
 
@@ -2503,6 +2549,13 @@ name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash",
+ "serde",
+ "serde_core",
+]
 
 [[package]]
 name = "hashlink"
@@ -3332,21 +3385,6 @@ dependencies = [
 
 [[package]]
 name = "metal"
-version = "0.27.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c43f73953f8cbe511f021b58f18c3ce1c3d1ae13fe953293e13345bf83217f25"
-dependencies = [
- "bitflags 2.10.0",
- "block",
- "core-graphics-types 0.1.3",
- "foreign-types 0.5.0",
- "log",
- "objc",
- "paste",
-]
-
-[[package]]
-name = "metal"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ecfd3296f8c56b7c1f6fbac3c71cefa9d78ce009850c45000015f206dc7fa21"
@@ -3699,7 +3737,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "915b1b472bc21c53464d6c8461c9d3af805ba1ef837e1cac254428f4a77177b1"
 dependencies = [
  "malloc_buf",
- "objc_exception",
 ]
 
 [[package]]
@@ -3904,6 +3941,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-metal"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a0125f776a10d00af4152d74616409f0d4a2053a6f57fa5b7d6aa2854ac04794"
+dependencies = [
+ "bitflags 2.10.0",
+ "block2 0.6.2",
+ "dispatch2",
+ "objc2 0.6.3",
+ "objc2-core-foundation",
+ "objc2-foundation 0.3.2",
+]
+
+[[package]]
 name = "objc2-osa-kit"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3925,7 +3976,7 @@ dependencies = [
  "block2 0.5.1",
  "objc2 0.5.2",
  "objc2-foundation 0.2.2",
- "objc2-metal",
+ "objc2-metal 0.2.2",
 ]
 
 [[package]]
@@ -3976,15 +4027,6 @@ dependencies = [
  "objc2-foundation 0.3.2",
  "objc2-javascript-core",
  "objc2-security",
-]
-
-[[package]]
-name = "objc_exception"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad970fb455818ad6cba4c122ad012fae53ae8b4795f86378bce65e4f6bab2ca4"
-dependencies = [
- "cc",
 ]
 
 [[package]]
@@ -4597,18 +4639,6 @@ dependencies = [
 
 [[package]]
 name = "pulp"
-version = "0.18.22"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a0a01a0dc67cf4558d279f0c25b0962bd08fc6dec0137699eae304103e882fe6"
-dependencies = [
- "bytemuck",
- "libm",
- "num-complex",
- "reborrow",
-]
-
-[[package]]
-name = "pulp"
 version = "0.21.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96b86df24f0a7ddd5e4b95c94fc9ed8a98f1ca94d3b01bdce2824097e7835907"
@@ -4620,6 +4650,29 @@ dependencies = [
  "reborrow",
  "version_check",
 ]
+
+[[package]]
+name = "pulp"
+version = "0.22.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e205bb30d5b916c55e584c22201771bcf2bad9aabd5d4127f38387140c38632"
+dependencies = [
+ "bytemuck",
+ "cfg-if",
+ "libm",
+ "num-complex",
+ "paste",
+ "pulp-wasm-simd-flag",
+ "raw-cpuid",
+ "reborrow",
+ "version_check",
+]
+
+[[package]]
+name = "pulp-wasm-simd-flag"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40e24eee682d89fb193496edf918a7f407d30175b2e785fe057e4392dfd182e0"
 
 [[package]]
 name = "quick-xml"
@@ -4827,15 +4880,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16abd0c1b639e9eb4d7c50c0b8100b0d0f849be2349829c740fe8e6eb4816429"
 dependencies = [
  "rand_core 0.5.1",
-]
-
-[[package]]
-name = "raw-cpuid"
-version = "10.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c297679cb867470fa8c9f67dbba74a78d78e3e98d7cf2b08d6d71540f797332"
-dependencies = [
- "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -5162,6 +5206,17 @@ version = "0.4.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44560c11236a6130a46ce36c836a62936dc81ebf8c36a37947423571be0e55b6"
 dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "safetensors"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "675656c1eabb620b921efea4f9199f97fc86e36dd6ffd1fbbe48d0f59a4987f5"
+dependencies = [
+ "hashbrown 0.16.1",
  "serde",
  "serde_json",
 ]
@@ -5763,20 +5818,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
-]
-
-[[package]]
-name = "sysctl"
-version = "0.5.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec7dddc5f0fee506baf8b9fdb989e242f17e4b11c61dfbb0635b705217199eea"
-dependencies = [
- "bitflags 2.10.0",
- "byteorder",
- "enum-as-inner",
- "libc",
- "thiserror 1.0.69",
- "walkdir",
 ]
 
 [[package]]
@@ -6731,6 +6772,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
 name = "typeid"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6755,9 +6802,9 @@ dependencies = [
 
 [[package]]
 name = "ug"
-version = "0.1.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03719c61a91b51541f076dfdba45caacf750b230cefaa4b32d6f5411c3f7f437"
+checksum = "76b761acf8af3494640d826a8609e2265e19778fb43306c7f15379c78c9b05b0"
 dependencies = [
  "gemm 0.18.2",
  "half",
@@ -6767,7 +6814,7 @@ dependencies = [
  "num-traits",
  "num_cpus",
  "rayon",
- "safetensors",
+ "safetensors 0.4.5",
  "serde",
  "thiserror 1.0.69",
  "tracing",
@@ -6776,11 +6823,11 @@ dependencies = [
 
 [[package]]
 name = "ug-cuda"
-version = "0.1.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50758486d7941f8b0a636ba7e29455c07071f41590beac1fd307ec893e8db69a"
+checksum = "9f0a1fa748f26166778c33b8498255ebb7c6bffb472bcc0a72839e07ebb1d9b5"
 dependencies = [
- "cudarc",
+ "cudarc 0.17.8",
  "half",
  "serde",
  "thiserror 1.0.69",
@@ -6789,12 +6836,12 @@ dependencies = [
 
 [[package]]
 name = "ug-metal"
-version = "0.1.0"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a02ddc17bf32f7dcaaf016b6735f7198082b82f122df7b3ca15d8ead5911ccef"
+checksum = "9f7adf545a99a086d362efc739e7cf4317c18cbeda22706000fd434d70ea3d95"
 dependencies = [
  "half",
- "metal 0.29.0",
+ "metal",
  "objc",
  "serde",
  "thiserror 1.0.69",
@@ -8193,21 +8240,6 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "1.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cc23c04387f4da0374be4533ad1208cbb091d5c11d070dfef13676ad6497164"
-dependencies = [
- "arbitrary",
- "crc32fast",
- "crossbeam-utils",
- "displaydoc",
- "indexmap 2.12.1",
- "num_enum",
- "thiserror 1.0.69",
-]
-
-[[package]]
-name = "zip"
 version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
@@ -8216,6 +8248,18 @@ dependencies = [
  "crc32fast",
  "indexmap 2.12.1",
  "memchr",
+]
+
+[[package]]
+name = "zip"
+version = "7.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
+dependencies = [
+ "crc32fast",
+ "indexmap 2.12.1",
+ "memchr",
+ "typed-path",
 ]
 
 [[package]]

--- a/ClassNoteAI/src-tauri/Cargo.lock
+++ b/ClassNoteAI/src-tauri/Cargo.lock
@@ -874,7 +874,7 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "classnoteai"
-version = "0.6.0-alpha.3"
+version = "0.6.0-alpha.4"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/ClassNoteAI/src-tauri/Cargo.lock
+++ b/ClassNoteAI/src-tauri/Cargo.lock
@@ -159,7 +159,7 @@ dependencies = [
  "futures-lite",
  "parking",
  "polling",
- "rustix 1.1.2",
+ "rustix",
  "slab",
  "windows-sys 0.61.2",
 ]
@@ -190,7 +190,7 @@ dependencies = [
  "cfg-if",
  "event-listener",
  "futures-lite",
- "rustix 1.1.2",
+ "rustix",
 ]
 
 [[package]]
@@ -216,7 +216,7 @@ dependencies = [
  "cfg-if",
  "futures-core",
  "futures-io",
- "rustix 1.1.2",
+ "rustix",
  "signal-hook-registry",
  "slab",
  "windows-sys 0.61.2",
@@ -300,25 +300,22 @@ checksum = "55248b47b0caf0546f7988906588779981c43bb1bc9d0c44087278f80cdb44ba"
 
 [[package]]
 name = "bindgen"
-version = "0.69.5"
+version = "0.72.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
 dependencies = [
  "bitflags 2.10.0",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
- "lazy_static",
- "lazycell",
  "log",
  "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
- "rustc-hash 1.1.0",
+ "rustc-hash",
  "shlex",
  "syn 2.0.111",
- "which",
 ]
 
 [[package]]
@@ -2506,15 +2503,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0f0ae375a85536cac3a243e3a9cda80a47910348abdea7e2c22f8ec556d586d"
 
 [[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
 name = "html5ever"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3037,12 +3025,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "libappindicator"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3138,12 +3120,6 @@ checksum = "7f78c730aaa7d0b9336a299029ea49f9ee53b0ed06e9202e8cb7db9bae7b8c82"
 dependencies = [
  "cc",
 ]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -4328,7 +4304,7 @@ dependencies = [
  "concurrent-queue",
  "hermit-abi",
  "pin-project-lite",
- "rustix 1.1.2",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -4549,7 +4525,7 @@ dependencies = [
  "pin-project-lite",
  "quinn-proto",
  "quinn-udp",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls",
  "socket2",
  "thiserror 2.0.17",
@@ -4569,7 +4545,7 @@ dependencies = [
  "lru-slab",
  "rand 0.9.2",
  "ring",
- "rustc-hash 2.1.1",
+ "rustc-hash",
  "rustls",
  "rustls-pki-types",
  "slab",
@@ -4981,12 +4957,6 @@ dependencies = [
 
 [[package]]
 name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
@@ -5002,19 +4972,6 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.10.0",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
-name = "rustix"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
@@ -5022,7 +4979,7 @@ dependencies = [
  "bitflags 2.10.0",
  "errno",
  "libc",
- "linux-raw-sys 0.11.0",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -6198,7 +6155,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.3.4",
  "once_cell",
- "rustix 1.1.2",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -7044,7 +7001,7 @@ checksum = "673a33c33048a5ade91a6b139580fa174e19fb0d23f396dca9fa15f2e1e49b35"
 dependencies = [
  "cc",
  "downcast-rs",
- "rustix 1.1.2",
+ "rustix",
  "scoped-tls",
  "smallvec",
  "wayland-sys",
@@ -7057,7 +7014,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c66a47e840dc20793f2264eb4b3e4ecb4b75d91c0dd4af04b456128e0bdd449d"
 dependencies = [
  "bitflags 2.10.0",
- "rustix 1.1.2",
+ "rustix",
  "wayland-backend",
  "wayland-scanner",
 ]
@@ -7224,36 +7181,26 @@ dependencies = [
 ]
 
 [[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
-]
-
-[[package]]
 name = "whisper-rs"
-version = "0.11.1"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed7a191078e189d96d029244ab1dff159775adec71dc89a222e9bb9d21a7d161"
+checksum = "2088172d00f936c348d6a72f488dc2660ab3f507263a195df308a3c2383229f6"
 dependencies = [
+ "libc",
  "whisper-rs-sys",
 ]
 
 [[package]]
 name = "whisper-rs-sys"
-version = "0.9.0"
+version = "0.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2834f4ca6472b02748c6c282a60cea538f962428f79e685c3205a08efd711336"
+checksum = "6986c0fe081241d391f09b9a071fbcbb59720c3563628c3c829057cf69f2a56f"
 dependencies = [
  "bindgen",
  "cfg-if",
  "cmake",
  "fs_extra",
+ "semver",
 ]
 
 [[package]]
@@ -7880,7 +7827,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix 1.1.2",
+ "rustix",
 ]
 
 [[package]]

--- a/ClassNoteAI/src-tauri/Cargo.lock
+++ b/ClassNoteAI/src-tauri/Cargo.lock
@@ -834,9 +834,9 @@ dependencies = [
 
 [[package]]
 name = "cmake"
-version = "0.1.54"
+version = "0.1.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
 dependencies = [
  "cc",
 ]

--- a/ClassNoteAI/src-tauri/Cargo.toml
+++ b/ClassNoteAI/src-tauri/Cargo.toml
@@ -48,17 +48,25 @@ candle-embed = ["candle-core", "candle-nn", "candle-transformers", "hf-hub"]
 # Each GPU feature fans out to every crate that can benefit. User
 # directive: "GPU 的加速可以用在任何支援 GPU 加速的項目上。只要我們手邊
 # 有 GPU 資源，且執行速度比 CPU 快，就應該盡可能地使用". So:
-#   - whisper-rs: speech-to-text (the headline win).
-#   - candle-core/candle-nn/candle-transformers: BGE-small embedding
-#     for the RAG index. CPU batch on BGE-small is already fast, but
-#     on a 400-chunk lecture the GPU path still halves wall time.
-#   Vulkan doesn't have Candle support yet, so `gpu-vulkan` covers
-#   only the Whisper path.
+#   - whisper-rs              speech-to-text (headline win; 20× on RTX)
+#   - candle-core/nn/transformers   BGE-small embedding for the RAG
+#                             index. Halves index time on a 400-chunk
+#                             lecture.
+#   - ct2rs                   local translation (M2M-100). `cuda-dynamic-
+#                             loading` means the built binary still
+#                             starts on a machine without cudart + just
+#                             falls back to CPU for translation, rather
+#                             than refusing to launch. Important because
+#                             the same binary ships to users without
+#                             NVIDIA drivers.
+# Vulkan/Metal aren't supported by ct2rs (CUDA-only GPU backend). Metal
+# covers whisper + candle; Vulkan covers only whisper.
 gpu-cuda = [
     "whisper-rs/cuda",
     "candle-core/cuda",
     "candle-nn/cuda",
     "candle-transformers/cuda",
+    "ct2rs/cuda-dynamic-loading",
 ]
 gpu-vulkan = ["whisper-rs/vulkan"]
 gpu-metal = [

--- a/ClassNoteAI/src-tauri/Cargo.toml
+++ b/ClassNoteAI/src-tauri/Cargo.toml
@@ -126,14 +126,27 @@ ndarray = "0.15"
 [dev-dependencies]
 tempfile = "3.8"
 
-# macOS-only auto-enable of Whisper's Metal backend. This keeps the
-# default-feature story simple on Windows/Linux (CPU unless the
-# packager opts into gpu-cuda/gpu-vulkan) while giving every macOS
-# build GPU acceleration with zero extra build flags — Metal is
+# macOS-only auto-enable of the Metal backends for every crate that
+# supports it. This keeps the default-feature story simple on
+# Windows/Linux (CPU unless the packager opts into gpu-cuda/gpu-vulkan)
+# while giving every macOS build GPU acceleration across Whisper AND
+# the BGE embedding model with zero extra build flags — Metal is
 # universally available on every Mac since ~2016 so there's no
 # detection story to worry about.
+#
+# Cargo unifies features between the main `[dependencies]` block and
+# these target-specific overrides, so `candle-core` (already declared
+# above as `optional = true`) gets its `metal` feature union'd in
+# when building for macOS.
+#
+# ct2rs has no Metal backend (CUDA-only for GPU), so local translation
+# stays on CPU on macOS. Apple Silicon's NEON + Accelerate framework
+# make CPU CT2 competitive enough that this isn't a priority gap.
 [target.'cfg(target_os = "macos")'.dependencies]
 whisper-rs = { version = "0.16", default-features = false, features = ["metal"] }
+candle-core = { version = "0.8", optional = true, features = ["metal"] }
+candle-nn = { version = "0.8", optional = true, features = ["metal"] }
+candle-transformers = { version = "0.8", optional = true, features = ["metal"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2"

--- a/ClassNoteAI/src-tauri/Cargo.toml
+++ b/ClassNoteAI/src-tauri/Cargo.toml
@@ -97,8 +97,10 @@ tauri = { version = "2", features = ["protocol-asset", "devtools"] }
 tauri-plugin-opener = "2"
 tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
+tauri-plugin-log = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+log = "0.4"
 whisper-rs = { version = "0.16", default-features = false }
 tokio = { version = "1", features = ["full"] }
 anyhow = "1.0"

--- a/ClassNoteAI/src-tauri/Cargo.toml
+++ b/ClassNoteAI/src-tauri/Cargo.toml
@@ -22,6 +22,33 @@ default = ["candle-embed"]
 # Candle embedding - 使用 Candle 框架進行文本 Embedding（預設啟用）
 candle-embed = ["candle-core", "candle-nn", "candle-transformers", "hf-hub"]
 
+# Whisper GPU backends. All three are opt-in and OFF by default — the
+# CPU build stays the baseline, so any regression from a broken
+# backend can't brick the default install. Enable exactly one of
+# these at build time depending on the target platform.
+#
+#   gpu-cuda     NVIDIA CUDA. Requires CUDA Toolkit (~3 GB) present at
+#                build time; at runtime the cudart64_* DLL ships next
+#                to the app (~10–30 MB). On an RTX 4060 Ti,
+#                large-v3-turbo runs ~20× realtime vs ~0.5× on CPU.
+#                Windows + Linux only.
+#   gpu-vulkan   Cross-vendor GPU via Vulkan. Build needs the Vulkan
+#                SDK (~500 MB); runtime uses the Vulkan loader that
+#                ships with every modern GPU driver — no extra DLLs.
+#                Works on NVIDIA, AMD, Intel. Slightly slower than
+#                native CUDA but the broadest GPU coverage.
+#   gpu-metal    Apple Metal. Auto-enabled below via target_os cfg, so
+#                macOS users never need to pass a flag.
+#
+# Build examples:
+#   cargo build                                        # CPU (default)
+#   cargo build --features gpu-cuda                    # Windows + NVIDIA
+#   cargo build --features gpu-vulkan                  # Windows + AMD/Intel or Linux
+#   # (no extra flag on macOS — metal is wired via target-specific dep below)
+gpu-cuda = ["whisper-rs/cuda"]
+gpu-vulkan = ["whisper-rs/vulkan"]
+gpu-metal = ["whisper-rs/metal"]
+
 [dependencies]
 tauri = { version = "2", features = ["protocol-asset", "devtools"] }
 tauri-plugin-opener = "2"
@@ -29,7 +56,7 @@ tauri-plugin-dialog = "2"
 tauri-plugin-fs = "2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-whisper-rs = "0.11"
+whisper-rs = { version = "0.16", default-features = false }
 tokio = { version = "1", features = ["full"] }
 anyhow = "1.0"
 num_cpus = "1.0"
@@ -71,6 +98,15 @@ ndarray = "0.15"
 
 [dev-dependencies]
 tempfile = "3.8"
+
+# macOS-only auto-enable of Whisper's Metal backend. This keeps the
+# default-feature story simple on Windows/Linux (CPU unless the
+# packager opts into gpu-cuda/gpu-vulkan) while giving every macOS
+# build GPU acceleration with zero extra build flags — Metal is
+# universally available on every Mac since ~2016 so there's no
+# detection story to worry about.
+[target.'cfg(target_os = "macos")'.dependencies]
+whisper-rs = { version = "0.16", default-features = false, features = ["metal"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2"

--- a/ClassNoteAI/src-tauri/Cargo.toml
+++ b/ClassNoteAI/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "classnoteai"
-version = "0.5.3"
+version = "0.6.0-alpha.1"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/ClassNoteAI/src-tauri/Cargo.toml
+++ b/ClassNoteAI/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "classnoteai"
-version = "0.6.0-alpha.2"
+version = "0.6.0-alpha.3"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/ClassNoteAI/src-tauri/Cargo.toml
+++ b/ClassNoteAI/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "classnoteai"
-version = "0.6.0-alpha.1"
+version = "0.6.0-alpha.2"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"
@@ -139,6 +139,9 @@ ct2rs = { version = "0.9", features = ["default"] }
 # File system utilities
 walkdir = "2"
 dirs = "5"
+# Tiny TOML parser for `dev_flags.rs` — experimental toggles read
+# before Tauri / SQLite init (so they can't live in the main DB).
+toml = { version = "0.8", default-features = false, features = ["parse", "display"] }
 tauri-plugin-http = "2"
 tauri-plugin-process = "2"
 ort = { version = "2.0.0-rc.9", features = ["load-dynamic"] }

--- a/ClassNoteAI/src-tauri/Cargo.toml
+++ b/ClassNoteAI/src-tauri/Cargo.toml
@@ -89,10 +89,15 @@ anyhow = "1.0"
 num_cpus = "1.0"
 reqwest = { version = "0.12", features = ["stream", "json", "multipart"] }
 futures-util = "0.3"
-# Candle ML framework for embeddings (no protobuf conflict)
-candle-core = { version = "0.8", optional = true }
-candle-nn = { version = "0.8", optional = true }
-candle-transformers = { version = "0.8", optional = true }
+# Candle ML framework for embeddings (no protobuf conflict).
+# Pinned to 0.9: bumped from 0.8 because 0.8's cudarc 0.13 hardcodes
+# a "supported CUDA toolkit" list that rejects 13.x. 0.9 uses cudarc
+# 0.16 which accepts CUDA 13 via the `cuda-version-from-build-system`
+# feature. No source changes needed for the 0.8→0.9 bump — the
+# Module / VarBuilder / tensor APIs we use are unchanged.
+candle-core = { version = "0.9", optional = true }
+candle-nn = { version = "0.9", optional = true }
+candle-transformers = { version = "0.9", optional = true }
 # Hugging Face Hub for model downloads
 hf-hub = { version = "0.3", optional = true }
 # Tokenizer for text preprocessing
@@ -144,9 +149,9 @@ tempfile = "3.8"
 # make CPU CT2 competitive enough that this isn't a priority gap.
 [target.'cfg(target_os = "macos")'.dependencies]
 whisper-rs = { version = "0.16", default-features = false, features = ["metal"] }
-candle-core = { version = "0.8", optional = true, features = ["metal"] }
-candle-nn = { version = "0.8", optional = true, features = ["metal"] }
-candle-transformers = { version = "0.8", optional = true, features = ["metal"] }
+candle-core = { version = "0.9", optional = true, features = ["metal"] }
+candle-nn = { version = "0.9", optional = true, features = ["metal"] }
+candle-transformers = { version = "0.9", optional = true, features = ["metal"] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]
 tauri-plugin-updater = "2"

--- a/ClassNoteAI/src-tauri/Cargo.toml
+++ b/ClassNoteAI/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "classnoteai"
-version = "0.6.0-alpha.3"
+version = "0.6.0-alpha.4"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/ClassNoteAI/src-tauri/Cargo.toml
+++ b/ClassNoteAI/src-tauri/Cargo.toml
@@ -63,9 +63,25 @@ candle-embed = ["candle-core", "candle-nn", "candle-transformers", "hf-hub"]
 # covers whisper + candle; Vulkan covers only whisper.
 gpu-cuda = [
     "whisper-rs/cuda",
-    "candle-core/cuda",
-    "candle-nn/cuda",
-    "candle-transformers/cuda",
+    # candle-core/cuda disabled in the Windows CI build. candle-kernels
+    # 0.9.2 compiles src/moe/moe_wmma.cu through bindgen_cuda 0.1.6's
+    # rayon-parallel nvcc invocation. On a 4-core windows-latest runner
+    # (16GB RAM) the parallel PTXAS processes OOM silently — nvcc
+    # returns exit 1 with empty stdout + stderr. candle 0.10.2 has the
+    # same breakage. Ampere (sm_80+) users would also lose native SASS
+    # if we bumped CUDA_COMPUTE_CAP to paper over the OOM.
+    #
+    # Net effect: BGE embedding stays on CPU in shipped Windows builds.
+    # For a 70-min lecture that's ~3 min of CPU embedding vs. ~10 s on
+    # GPU — noticeable but not blocking. Whisper + CT2 retain full GPU
+    # acceleration (each on a separate crate's CUDA path, neither hits
+    # the moe_wmma.cu compile step).
+    #
+    # When candle 0.11 / bindgen_cuda 0.2 land upstream fixes, or when
+    # we move CI to a larger runner, fold these back in.
+    # "candle-core/cuda",
+    # "candle-nn/cuda",
+    # "candle-transformers/cuda",
     "ct2rs/cuda-dynamic-loading",
 ]
 gpu-vulkan = ["whisper-rs/vulkan"]

--- a/ClassNoteAI/src-tauri/Cargo.toml
+++ b/ClassNoteAI/src-tauri/Cargo.toml
@@ -45,9 +45,28 @@ candle-embed = ["candle-core", "candle-nn", "candle-transformers", "hf-hub"]
 #   cargo build --features gpu-cuda                    # Windows + NVIDIA
 #   cargo build --features gpu-vulkan                  # Windows + AMD/Intel or Linux
 #   # (no extra flag on macOS — metal is wired via target-specific dep below)
-gpu-cuda = ["whisper-rs/cuda"]
+# Each GPU feature fans out to every crate that can benefit. User
+# directive: "GPU 的加速可以用在任何支援 GPU 加速的項目上。只要我們手邊
+# 有 GPU 資源，且執行速度比 CPU 快，就應該盡可能地使用". So:
+#   - whisper-rs: speech-to-text (the headline win).
+#   - candle-core/candle-nn/candle-transformers: BGE-small embedding
+#     for the RAG index. CPU batch on BGE-small is already fast, but
+#     on a 400-chunk lecture the GPU path still halves wall time.
+#   Vulkan doesn't have Candle support yet, so `gpu-vulkan` covers
+#   only the Whisper path.
+gpu-cuda = [
+    "whisper-rs/cuda",
+    "candle-core/cuda",
+    "candle-nn/cuda",
+    "candle-transformers/cuda",
+]
 gpu-vulkan = ["whisper-rs/vulkan"]
-gpu-metal = ["whisper-rs/metal"]
+gpu-metal = [
+    "whisper-rs/metal",
+    "candle-core/metal",
+    "candle-nn/metal",
+    "candle-transformers/metal",
+]
 
 [dependencies]
 tauri = { version = "2", features = ["protocol-asset", "devtools"] }

--- a/ClassNoteAI/src-tauri/resources/cuda/.gitkeep
+++ b/ClassNoteAI/src-tauri/resources/cuda/.gitkeep
@@ -1,0 +1,13 @@
+# This directory is populated by CI when building with gpu-cuda.
+# For non-CUDA builds it stays empty; the tauri.conf.json resources
+# glob matches nothing and bundles nothing.
+#
+# On a CUDA CI run (release-windows.yml with matrix.variant.id == 'cuda')
+# the 'Stage CUDA runtime DLLs' step copies cudart64_12.dll,
+# cublas64_12.dll, cublasLt64_12.dll from $CUDA_PATH/bin into here
+# right before 'npx tauri build'. Tauri's bundler then picks them up
+# via the './resources/cuda/*' glob in tauri.conf.json and drops them
+# next to the exe in the installer.
+#
+# Keep this .gitkeep so the directory exists in a fresh checkout —
+# tauri will refuse to bundle from a non-existent resources path.

--- a/ClassNoteAI/src-tauri/scripts/codex-delegate.sh
+++ b/ClassNoteAI/src-tauri/scripts/codex-delegate.sh
@@ -1,0 +1,201 @@
+#!/usr/bin/env bash
+# codex-delegate.sh — robust wrapper around `codex exec` for commander/worker
+# delegation. Designed for when Claude Code (the commander) hands a well-
+# scoped subtask to Codex (the worker) to save commander-side tokens.
+#
+# Why this exists: plain `codex exec` has reliability issues that kept
+# biting during the v0.6.0 smoke test round:
+#
+#   1. OpenAI backend disconnects mid-run. Codex logs
+#      `Re-connecting... 1/5 ... 5/5` and hangs indefinitely.
+#   2. Silent API hang — codex child process stays alive at 0% CPU
+#      with the HTTP request never returning a byte. No reconnect
+#      lines, no progress, just a dead socket.
+#   3. No wallclock or idle limit. A hung run burns commander polling
+#      budget without producing a diff.
+#
+# This wrapper:
+#   * Hard wallclock timeout (default 900s; --timeout).
+#   * **Idle timeout** (default 120s; --idle-timeout): if the log file
+#     stops growing for N seconds, treat as hang and kill/retry. This
+#     catches the silent-hang case that wallclock misses.
+#   * Heartbeat file at /tmp/codex-heartbeat-<pid>.txt. Injects a
+#     preamble into the prompt telling Codex to write its first step
+#     there, then update it as it progresses. Commander can tail this
+#     externally to observe liveness independent of stdout buffering.
+#   * Retries up to N times (default 2; --retries) on wallclock OR
+#     idle OR reconnect-loop OR non-zero exit.
+#   * Kills orphan `codex.exe` children on retry.
+#   * `model_reasoning_effort=high` via CLI -c override (beats invalid
+#     ~/.codex/config.toml values).
+#   * Dumps last 40 log lines on final failure.
+#
+# Usage:
+#   codex-delegate.sh [--timeout SEC] [--idle-timeout SEC] [--retries N]
+#                     [--prompt-file PATH | PROMPT_STRING]
+#
+# Examples:
+#   codex-delegate.sh "Fix B8 — wrap JSON.parse calls in try/catch"
+#   codex-delegate.sh --timeout 1200 --idle-timeout 180 --retries 3 \
+#       --prompt-file /tmp/big-task.md
+
+set -u
+
+TIMEOUT=900
+IDLE_TIMEOUT=120
+RETRIES=2
+PROMPT=""
+PROMPT_FILE=""
+
+while [ $# -gt 0 ]; do
+    case "$1" in
+        --timeout)       TIMEOUT="$2"; shift 2 ;;
+        --idle-timeout)  IDLE_TIMEOUT="$2"; shift 2 ;;
+        --retries)       RETRIES="$2"; shift 2 ;;
+        --prompt-file)   PROMPT_FILE="$2"; shift 2 ;;
+        --)              shift; PROMPT="$*"; break ;;
+        *)               PROMPT="${PROMPT}${PROMPT:+ }$1"; shift ;;
+    esac
+done
+
+if [ -n "$PROMPT_FILE" ]; then
+    if [ ! -f "$PROMPT_FILE" ]; then
+        echo "[codex-delegate] ERROR: prompt file not found: $PROMPT_FILE" >&2
+        exit 2
+    fi
+    PROMPT=$(cat "$PROMPT_FILE")
+fi
+
+if [ -z "$PROMPT" ]; then
+    echo "Usage: $0 [--timeout SEC] [--idle-timeout SEC] [--retries N] [--prompt-file PATH | PROMPT]" >&2
+    exit 2
+fi
+
+if ! command -v codex >/dev/null 2>&1; then
+    echo "[codex-delegate] ERROR: codex not on PATH (install via npm / scoop)" >&2
+    exit 2
+fi
+
+LOG=$(mktemp -t codex-delegate-XXXXXX.log)
+HEARTBEAT=$(mktemp -t codex-heartbeat-XXXXXX.txt)
+trap 'rm -f "$LOG" "$HEARTBEAT"' EXIT
+
+echo "[codex-delegate] heartbeat: $HEARTBEAT" >&2
+echo "[codex-delegate] log:       $LOG" >&2
+
+kill_orphan_codex() {
+    if command -v taskkill >/dev/null 2>&1; then
+        taskkill //F //IM codex.exe >/dev/null 2>&1 || true
+    else
+        pkill -f "codex exec" 2>/dev/null || true
+    fi
+}
+
+# Prepend a preamble instructing Codex to emit a heartbeat. The path
+# is baked in so we can stat it externally for liveness.
+build_full_prompt() {
+    cat <<PREAMBLE
+BEFORE DOING ANYTHING ELSE: write one line describing your current step
+to the file "$HEARTBEAT" (overwriting prior contents). Update it every
+time you finish reading a file, start an edit, or finish an edit.
+Format: "[HH:MM:SS] <what you just did or are about to do>"
+This heartbeat is how the commander knows you are alive. A stale file
+(no update for 2 minutes) will be treated as a hang and your run will
+be killed.
+
+--- TASK ---
+PREAMBLE
+    printf '%s\n' "$PROMPT"
+}
+
+# Watch the log file's mtime. Kill the codex subprocess group if no
+# growth for IDLE_TIMEOUT seconds. Exit 0 on healthy termination of
+# $target_pid; exit 2 on idle kill.
+watch_idle() {
+    local target_pid="$1"
+    local last_size=0
+    local idle_start
+    idle_start=$(date +%s)
+    while kill -0 "$target_pid" 2>/dev/null; do
+        sleep 10
+        local cur_size
+        cur_size=$(stat -c %s "$LOG" 2>/dev/null || stat -f %z "$LOG" 2>/dev/null || echo 0)
+        local hb_size=0
+        [ -f "$HEARTBEAT" ] && hb_size=$(stat -c %s "$HEARTBEAT" 2>/dev/null || stat -f %z "$HEARTBEAT" 2>/dev/null || echo 0)
+        local combined=$((cur_size + hb_size))
+        if [ "$combined" -gt "$last_size" ]; then
+            last_size=$combined
+            idle_start=$(date +%s)
+            continue
+        fi
+        local idle_elapsed=$(( $(date +%s) - idle_start ))
+        if [ "$idle_elapsed" -ge "$IDLE_TIMEOUT" ]; then
+            echo "[codex-delegate] IDLE ${idle_elapsed}s — killing codex" >&2
+            kill_orphan_codex
+            return 2
+        fi
+    done
+    return 0
+}
+
+run_one_attempt() {
+    local attempt="$1"
+    echo "[codex-delegate] attempt $attempt (wallclock ${TIMEOUT}s, idle ${IDLE_TIMEOUT}s, reasoning=high)" >&2
+    local prompt_tmp
+    prompt_tmp=$(mktemp -t codex-prompt-XXXXXX.txt)
+    build_full_prompt > "$prompt_tmp"
+    : > "$LOG"
+    : > "$HEARTBEAT"
+
+    timeout --kill-after=15 "$TIMEOUT" \
+        codex exec \
+            -c 'model_reasoning_effort="high"' \
+            --skip-git-repo-check \
+            --sandbox workspace-write \
+            "$(cat "$prompt_tmp")" \
+        > "$LOG" 2>&1 &
+    local codex_pid=$!
+
+    watch_idle "$codex_pid" &
+    local watch_pid=$!
+
+    wait "$codex_pid"
+    local rc=$?
+    # Clean up the idle watcher if codex finished naturally.
+    kill "$watch_pid" 2>/dev/null
+    wait "$watch_pid" 2>/dev/null
+    rm -f "$prompt_tmp"
+
+    local reconn_count
+    reconn_count=$(grep -c "Re-connecting\.\.\." "$LOG" 2>/dev/null | head -1)
+    reconn_count=${reconn_count:-0}
+
+    if [ "$rc" -eq 0 ] && [ "$reconn_count" -lt 3 ]; then
+        return 0
+    fi
+
+    case "$rc" in
+        124|137) echo "[codex-delegate] attempt $attempt WALLCLOCK TIMEOUT (rc=$rc) — killing orphans" >&2; kill_orphan_codex ;;
+        143)     echo "[codex-delegate] attempt $attempt IDLE KILLED (rc=$rc)" >&2; kill_orphan_codex ;;
+        *)       echo "[codex-delegate] attempt $attempt failed (rc=$rc, reconnects=$reconn_count)" >&2 ;;
+    esac
+    return 1
+}
+
+overall_start=$(date +%s)
+for attempt in $(seq 1 $((RETRIES + 1))); do
+    if run_one_attempt "$attempt"; then
+        elapsed=$(( $(date +%s) - overall_start ))
+        echo "[codex-delegate] SUCCESS in ${elapsed}s on attempt $attempt" >&2
+        cat "$LOG"
+        exit 0
+    fi
+    [ "$attempt" -le "$RETRIES" ] && sleep 10
+done
+
+echo "[codex-delegate] FAILED after $((RETRIES + 1)) attempts" >&2
+echo "--- last 40 log lines ---" >&2
+tail -40 "$LOG" >&2
+echo "--- last heartbeat ---" >&2
+cat "$HEARTBEAT" >&2 2>/dev/null || echo "(empty)" >&2
+exit 1

--- a/ClassNoteAI/src-tauri/scripts/launch-cuda-release.bat
+++ b/ClassNoteAI/src-tauri/scripts/launch-cuda-release.bat
@@ -1,0 +1,17 @@
+@echo off
+setlocal EnableExtensions
+
+if not defined CNAI_DEV_CDP_PORT set "CNAI_DEV_CDP_PORT=9222"
+set "WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS=--remote-debugging-port=%CNAI_DEV_CDP_PORT%"
+
+set "CNAI_EXE=%LOCALAPPDATA%\ClassNoteAI\classnoteai.exe"
+
+if not exist "%CNAI_EXE%" (
+    echo ERROR: ClassNoteAI not found at "%CNAI_EXE%"
+    exit /b 1
+)
+
+echo Launching: %CNAI_EXE%
+echo CDP port:  %CNAI_DEV_CDP_PORT%
+start "" "%CNAI_EXE%"
+endlocal

--- a/ClassNoteAI/src-tauri/scripts/win-tauri-dev-cuda.bat
+++ b/ClassNoteAI/src-tauri/scripts/win-tauri-dev-cuda.bat
@@ -72,6 +72,19 @@ REM Hopper / Blackwell.
 set "CMAKE_CUDA_ARCHITECTURES=75;80;86;89;90;100"
 set "CT2_CUDA_ARCH_LIST=Turing;Ampere;Ada;Hopper;Blackwell"
 set "GGML_CUDA_ARCHITECTURES=75;80;86;89;90;100"
+REM VS 18 (2026) isn't on CUDA 13's official-supported-compiler list —
+REM CUDA Toolkit's `CUDA 13.2.props` reads CudaToolkitDir from
+REM MSBuild properties (NOT CUDA_PATH), and nvcc rejects MSVC 14.50
+REM without explicit override. Two workarounds combined per NVIDIA's
+REM community guide (gist JoanTerra/ffe18eb5d5752e0f4df7d85c8e61f6b6):
+REM   - set CudaToolkitDir so MSBuild can find it
+REM   - pass -allow-unsupported-compiler via CMAKE_CUDA_FLAGS so nvcc
+REM     skips its host-compiler version check
+REM Trailing backslash is required by the props file's HasTrailingSlash
+REM guard.
+set "CudaToolkitDir=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.2\"
+set "CMAKE_CUDA_FLAGS=-allow-unsupported-compiler"
+set "CMAKE_CUDA_HOST_COMPILER_FLAGS=-allow-unsupported-compiler"
 echo Using CUDA at %CUDA_PATH%
 goto :cuda_ok
 :no_cuda

--- a/ClassNoteAI/src-tauri/scripts/win-tauri-dev-cuda.bat
+++ b/ClassNoteAI/src-tauri/scripts/win-tauri-dev-cuda.bat
@@ -1,0 +1,86 @@
+@echo off
+setlocal EnableExtensions
+
+REM Dev launcher with CUDA backend enabled. Same as win-tauri-dev.bat
+REM plus:
+REM   - CUDA_PATH / PATH pointing at the CUDA 13 Toolkit install
+REM   - NVCC visible so whisper-rs-sys + candle + ct2rs can compile CUDA kernels
+REM   - --features gpu-cuda handed to npx tauri dev
+REM
+REM First build after switching to this script is slow (~30-40 min) because
+REM the native CUDA kernels get built; subsequent rebuilds are fast thanks
+REM to sccache / Rust's incremental.
+
+set "_VS_TAG="
+if not defined VS_VCVARS (
+    if exist "C:\Program Files\Microsoft Visual Studio\18\Community\VC\Auxiliary\Build\vcvars64.bat" (
+        set "VS_VCVARS=C:\Program Files\Microsoft Visual Studio\18\Community\VC\Auxiliary\Build\vcvars64.bat"
+        set "_VS_TAG=18"
+    )
+    if not defined VS_VCVARS if exist "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat" (
+        set "VS_VCVARS=C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
+        set "_VS_TAG=17"
+    )
+)
+if not defined VS_VCVARS (
+    echo ERROR: vcvars64.bat not found.
+    exit /b 1
+)
+call "%VS_VCVARS%" >nul
+
+if exist "%USERPROFILE%\llvm18\bin\libclang.dll" (
+    set "LIBCLANG_PATH=%USERPROFILE%\llvm18\bin"
+)
+
+if "%_VS_TAG%"=="18" (
+    set "CMAKE_GENERATOR=Visual Studio 18 2026"
+) else (
+    set "CMAKE_GENERATOR=Visual Studio 17 2022"
+)
+set "CMAKE_TOOLCHAIN_FILE=%~dp0win-toolchain.cmake"
+
+REM --- CUDA environment ---------------------------------------------------
+REM v13.2 installed via winget. DLLs live under bin\x64\ (not bin\) starting
+REM with CUDA 13. Avoid `if ( ... )` blocks here — setting a variable inside
+REM a paren block and reading it with %CUDA_PATH% in the same block hits
+REM CMD's delayed-expansion trap (prints empty).
+REM
+REM Crucial: CUDA_PATH uses FORWARD slashes. CMake 4.x's deprecated
+REM FindCUDA module (invoked from whisper.cpp's CMakeLists) fails to
+REM parse paths that contain `\P` (from `C:\Program Files`) as an
+REM escape sequence. Forward slashes dodge the issue entirely — CMake
+REM on Windows happily accepts `C:/Program Files/...`, and every
+REM downstream build step that cares (nvcc, the linker, cargo) also
+REM takes them.
+if not exist "C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.2\bin\nvcc.exe" goto :no_cuda
+set "CUDA_PATH=C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v13.2"
+set "CUDA_HOME=%CUDA_PATH%"
+set "CUDA_TOOLKIT_ROOT_DIR=%CUDA_PATH%"
+REM PATH still uses backslashes — Windows shell resolves both, but native
+REM tools (nvcc.exe location lookup) expect system conventions here.
+set "PATH=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.2\bin;C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.2\bin\x64;%PATH%"
+set "INCLUDE=%CUDA_PATH%/include;%INCLUDE%"
+set "LIB=%CUDA_PATH%/lib/x64;%LIB%"
+REM CUDA 13 dropped support for compute capabilities < 7.5 (Maxwell,
+REM Pascal, Volta). Both whisper.cpp and ct2rs's bundled CMakeLists
+REM hardcode arch lists that include compute_53/60/70; nvcc 13.x
+REM rejects those as "Unsupported gpu architecture". Override via
+REM CMAKE_CUDA_ARCHITECTURES (picked up by every cmake-based build)
+REM + CT2_CUDA_ARCH_LIST (ct2rs-specific fallback). Covers the full
+REM consumer GPU range shipped since 2018: Turing / Ampere / Ada /
+REM Hopper / Blackwell.
+set "CMAKE_CUDA_ARCHITECTURES=75;80;86;89;90;100"
+set "CT2_CUDA_ARCH_LIST=Turing;Ampere;Ada;Hopper;Blackwell"
+set "GGML_CUDA_ARCHITECTURES=75;80;86;89;90;100"
+echo Using CUDA at %CUDA_PATH%
+goto :cuda_ok
+:no_cuda
+echo ERROR: CUDA 13.2 not found. Run "winget install Nvidia.CUDA" first.
+exit /b 1
+:cuda_ok
+
+set "PATH=%USERPROFILE%\.cargo\bin;%LIBCLANG_PATH%;%PATH%"
+
+cd /d "%~dp0.."
+npx tauri dev --features gpu-cuda %*
+endlocal

--- a/ClassNoteAI/src-tauri/scripts/win-tauri-dev-cuda.bat
+++ b/ClassNoteAI/src-tauri/scripts/win-tauri-dev-cuda.bat
@@ -70,7 +70,12 @@ REM + CT2_CUDA_ARCH_LIST (ct2rs-specific fallback). Covers the full
 REM consumer GPU range shipped since 2018: Turing / Ampere / Ada /
 REM Hopper / Blackwell.
 set "CMAKE_CUDA_ARCHITECTURES=75;80;86;89;90;100"
-set "CT2_CUDA_ARCH_LIST=Turing;Ampere;Ada;Hopper;Blackwell"
+REM CT2 uses cmake's FindCUDA::cuda_select_nvcc_arch_flags which only
+REM recognises symbolic names up to Ampere (Turing=7.5, Ampere=8.0/8.6).
+REM For newer archs (Ada=8.9, Hopper=9.0, Blackwell=10.0) we pass
+REM numeric compute capabilities. Keeping Turing + Ampere as fallbacks
+REM so a build made on this machine still runs on older NVIDIAs.
+set "CT2_CUDA_ARCH_LIST=Turing;Ampere;7.5;8.0;8.6;8.9;9.0"
 set "GGML_CUDA_ARCHITECTURES=75;80;86;89;90;100"
 REM VS 18 (2026) isn't on CUDA 13's official-supported-compiler list —
 REM CUDA Toolkit's `CUDA 13.2.props` reads CudaToolkitDir from
@@ -85,6 +90,12 @@ REM guard.
 set "CudaToolkitDir=C:\Program Files\NVIDIA GPU Computing Toolkit\CUDA\v13.2\"
 set "CMAKE_CUDA_FLAGS=-allow-unsupported-compiler"
 set "CMAKE_CUDA_HOST_COMPILER_FLAGS=-allow-unsupported-compiler"
+REM ct2rs's CUDA `.cu.obj` files originally built with /MT (static CRT)
+REM via nvcc's Windows defaults, while Rust + whisper-rs use /MD
+REM (dynamic CRT), causing LNK2038 RuntimeLibrary mismatch. Fixed at
+REM the source: vendor/ct2rs/CTranslate2/CMakeLists.txt patched to
+REM unconditionally emit `-Xcompiler=/MD` for CUDA .cu.obj files, so
+REM the whole build agrees on /MD. No RUSTFLAGS override needed.
 echo Using CUDA at %CUDA_PATH%
 goto :cuda_ok
 :no_cuda
@@ -93,6 +104,12 @@ exit /b 1
 :cuda_ok
 
 set "PATH=%USERPROFILE%\.cargo\bin;%LIBCLANG_PATH%;%PATH%"
+
+REM Expose WebView2's Chrome DevTools Protocol on 127.0.0.1:9222 so
+REM scripts/cdp.cjs + scripts/dev-ctl.mjs can inspect the running dev
+REM build (eval JS, tail console, run SQL). Matches win-tauri-dev.bat.
+if not defined CNAI_DEV_CDP_PORT set "CNAI_DEV_CDP_PORT=9222"
+if not "%CNAI_DEV_CDP_PORT%"=="" set "WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS=--remote-debugging-port=%CNAI_DEV_CDP_PORT%"
 
 cd /d "%~dp0.."
 npx tauri dev --features gpu-cuda %*

--- a/ClassNoteAI/src-tauri/src/dev_flags.rs
+++ b/ClassNoteAI/src-tauri/src/dev_flags.rs
@@ -1,0 +1,64 @@
+//! Developer / agent-mode experimental toggles that have to be read
+//! **before** Tauri spins up WebView2. These can't live in the main
+//! SQLite DB because DB init runs inside `tauri::Builder::setup`, far
+//! too late to influence env vars that WebView2 consumes at launch.
+//!
+//! Storage: a minimal `dev-flags.toml` under the app's platform data
+//! dir (same directory as the SQLite db). Missing file / invalid TOML
+//! / missing key all degrade to "flag off" — safe default.
+//!
+//! Write path: the frontend's Settings → experimental → "Remote debug
+//! port" toggle invokes `set_remote_debug_enabled` (command in
+//! `lib.rs`), which updates the TOML. Flag only takes effect on next
+//! app launch; Settings UI shows a "請重啟應用程式" hint after toggling.
+
+use std::path::PathBuf;
+
+/// The only key we currently store. Expand the struct if a second
+/// flag needs pre-WebView2 timing; the file format is cheap to grow.
+#[derive(Debug, Clone, Default, serde::Serialize, serde::Deserialize)]
+pub struct DevFlags {
+    /// When `true`, `main()` sets
+    /// `WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS=--remote-debugging-port={port}`
+    /// so `scripts/cdp.cjs` + third-party agents (Playwright, Claude
+    /// Code, etc.) can drive the installed release the same way
+    /// they drive the dev build.
+    #[serde(default)]
+    pub remote_debug_port_enabled: bool,
+}
+
+/// Resolve the TOML path without depending on Tauri's app handle
+/// (which isn't available at `main()` entry). Matches the Tauri
+/// platform convention — same root the DB ends up under.
+fn flags_file() -> Option<PathBuf> {
+    // `dirs::config_dir()` on Windows → `%APPDATA%`, on macOS →
+    // `~/Library/Application Support`, on Linux → `~/.config`.
+    // Subdir matches the bundle identifier from `tauri.conf.json`.
+    let base = dirs::config_dir()?;
+    Some(base.join("com.classnoteai").join("dev-flags.toml"))
+}
+
+pub fn load() -> DevFlags {
+    let Some(path) = flags_file() else {
+        return DevFlags::default();
+    };
+    let Ok(text) = std::fs::read_to_string(&path) else {
+        return DevFlags::default();
+    };
+    toml::from_str::<DevFlags>(&text).unwrap_or_default()
+}
+
+pub fn save(flags: &DevFlags) -> Result<(), String> {
+    let path = flags_file().ok_or_else(|| "config dir unavailable".to_string())?;
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| format!("mkdir {}: {}", parent.display(), e))?;
+    }
+    let text = toml::to_string_pretty(flags).map_err(|e| format!("toml serialize: {}", e))?;
+    std::fs::write(&path, text).map_err(|e| format!("write {}: {}", path.display(), e))?;
+    Ok(())
+}
+
+/// Cheap read for `main()` — no error propagation, defaults to off.
+pub fn remote_debug_enabled() -> bool {
+    load().remote_debug_port_enabled
+}

--- a/ClassNoteAI/src-tauri/src/diagnostics/mod.rs
+++ b/ClassNoteAI/src-tauri/src/diagnostics/mod.rs
@@ -1,0 +1,125 @@
+use std::fs::{self, File};
+use std::io::Write;
+use std::path::{Path, PathBuf};
+
+use serde::Deserialize;
+use serde_json::{json, Value};
+use zip::write::FileOptions;
+use zip::{CompressionMethod, ZipWriter};
+
+#[derive(Debug, Deserialize)]
+pub struct DiagnosticPackageInput {
+    pub lecture_meta_json: String,
+    pub subtitles_json: String,
+    pub audio_path: Option<String>,
+    pub redacted_log_text: String,
+    pub metadata_json: String,
+}
+
+pub fn build_diagnostic_zip(
+    input: DiagnosticPackageInput,
+    include_audio: bool,
+) -> Result<PathBuf, String> {
+    let downloads_dir = dirs::download_dir().ok_or_else(|| "無法定位下載資料夾".to_string())?;
+    let timestamp = chrono::Utc::now().format("%Y%m%d-%H%M%S").to_string();
+    let zip_path = downloads_dir.join(format!("classnoteai-diagnostic-{}.zip", timestamp));
+
+    let lecture_meta: Value = serde_json::from_str(&input.lecture_meta_json)
+        .map_err(|e| format!("Failed to parse lecture metadata JSON: {}", e))?;
+    let subtitles: Value = serde_json::from_str(&input.subtitles_json)
+        .map_err(|e| format!("Failed to parse subtitles JSON: {}", e))?;
+    let metadata: Value = serde_json::from_str(&input.metadata_json)
+        .map_err(|e| format!("Failed to parse metadata JSON: {}", e))?;
+
+    let transcript_json = serde_json::to_vec_pretty(&json!({
+        "lecture": lecture_meta,
+        "subtitles": subtitles,
+    }))
+    .map_err(|e| format!("Failed to serialize transcript JSON: {}", e))?;
+    let metadata_json = serde_json::to_vec_pretty(&metadata)
+        .map_err(|e| format!("Failed to serialize metadata JSON: {}", e))?;
+
+    let file = File::create(&zip_path)
+        .map_err(|e| format!("Failed to create diagnostic zip {}: {}", zip_path.display(), e))?;
+    let mut zip = ZipWriter::new(file);
+    let options = FileOptions::default().compression_method(CompressionMethod::Deflated);
+
+    zip.start_file("log/classnoteai.log", options)
+        .map_err(|e| format!("Failed to add log file to zip: {}", e))?;
+    zip.write_all(input.redacted_log_text.as_bytes())
+        .map_err(|e| format!("Failed to write log file to zip: {}", e))?;
+
+    zip.start_file("transcript/lecture.json", options)
+        .map_err(|e| format!("Failed to add transcript to zip: {}", e))?;
+    zip.write_all(&transcript_json)
+        .map_err(|e| format!("Failed to write transcript to zip: {}", e))?;
+
+    zip.start_file("metadata.json", options)
+        .map_err(|e| format!("Failed to add metadata to zip: {}", e))?;
+    zip.write_all(&metadata_json)
+        .map_err(|e| format!("Failed to write metadata to zip: {}", e))?;
+
+    let mut included_audio_name: Option<String> = None;
+    if include_audio {
+        if let Some(audio_path) = input.audio_path.as_deref() {
+            let path = Path::new(audio_path);
+            if path.is_file() {
+                let audio_bytes = fs::read(path)
+                    .map_err(|e| format!("Failed to read audio file {}: {}", path.display(), e))?;
+                let filename = path
+                    .file_name()
+                    .map(|name| name.to_string_lossy().into_owned())
+                    .filter(|name| !name.is_empty())
+                    .unwrap_or_else(|| "audio.bin".to_string());
+                zip.start_file(format!("audio/{}", filename), options)
+                    .map_err(|e| format!("Failed to add audio file to zip: {}", e))?;
+                zip.write_all(&audio_bytes)
+                    .map_err(|e| format!("Failed to write audio file to zip: {}", e))?;
+                included_audio_name = Some(filename);
+            }
+        }
+    }
+
+    let generation_time = chrono::Utc::now().to_rfc3339();
+    let readme = build_readme(&generation_time, included_audio_name.as_deref());
+
+    zip.start_file("README.md", options)
+        .map_err(|e| format!("Failed to add README to zip: {}", e))?;
+    zip.write_all(readme.as_bytes())
+        .map_err(|e| format!("Failed to write README to zip: {}", e))?;
+
+    zip.finish()
+        .map_err(|e| format!("Failed to finalize diagnostic zip: {}", e))?;
+
+    Ok(zip_path)
+}
+
+fn build_readme(generation_time: &str, audio_filename: Option<&str>) -> String {
+    let audio_line = match audio_filename {
+        Some(name) => format!("- `audio/{}`：選填的原始音訊檔。", name),
+        None => "- `audio/`：本次匯出未包含音訊，或原始音訊檔已不存在。".to_string(),
+    };
+
+    format!(
+        concat!(
+            "# ClassNoteAI 診斷封包\n\n",
+            "此 ZIP 由 ClassNoteAI 在本機產生，方便回報問題時一次提供必要資料。\n",
+            "程式不會自動上傳這個檔案，是否分享完全由你決定。\n\n",
+            "## 內容\n",
+            "- `log/classnoteai.log`：最近的應用程式日誌，已先做敏感資訊遮罩。\n",
+            "- `transcript/lecture.json`：所選講座的中繼資料與字幕內容。\n",
+            "- `metadata.json`：匯出時的版本、平台與封包摘要資訊。\n",
+            "{audio_line}\n\n",
+            "## 分享方式\n",
+            "1. 先確認內容是否符合你願意分享的範圍。\n",
+            "2. 將整個 ZIP 附加到 issue、Email 或其他支援管道。\n",
+            "3. 若你不想分享音訊，請在匯出時取消勾選包含音訊。\n\n",
+            "## 隱私提醒\n",
+            "- 日誌已做基本遮罩，但仍可能包含課程標題、檔名或錯誤訊息。\n",
+            "- 音訊檔可能包含個人或課堂內容，請自行判斷是否適合提供。\n\n",
+            "生成時間（UTC）：{generation_time}\n"
+        ),
+        audio_line = audio_line,
+        generation_time = generation_time
+    )
+}

--- a/ClassNoteAI/src-tauri/src/embedding/service.rs
+++ b/ClassNoteAI/src-tauri/src/embedding/service.rs
@@ -470,4 +470,147 @@ impl EmbeddingService {
             .map(|c| Self::cosine_similarity(query, c))
             .collect())
     }
+
+    /// For each group of sentences, pick the `top_k` that are most
+    /// representative of the group — the sentences whose embedding is
+    /// closest to the group's centroid. Used by NotesView to turn a
+    /// 5-minute section's raw subtitle soup into a 3-bullet summary
+    /// (the extractive half of Note AI structurization).
+    ///
+    /// Why centroid-nearest and not TextRank / clustering?
+    ///   - Centroid of unit-norm vectors ≈ "average topic of the
+    ///     section" in the embedding space. Sentences near it are the
+    ///     ones that touch the most shared meaning — usually the
+    ///     topic-sentence, the key definition, and the summary line.
+    ///   - One matmul per section on GPU; no iterative graph walk.
+    ///   - No external dependency (wouldn't want to pull textrank-rs
+    ///     just for this).
+    ///
+    /// Picks are returned in **original order**, not similarity order,
+    /// so the resulting bullets still flow as the lecture did — crucial
+    /// for learning material. If a group has fewer sentences than
+    /// `top_k`, the whole group comes back (also in-order).
+    #[cfg(feature = "candle-embed")]
+    pub fn extract_representative_sentences(
+        &mut self,
+        groups: &[Vec<String>],
+        top_k: usize,
+    ) -> Result<Vec<Vec<String>>> {
+        // Short-circuit empty input so the model isn't spun up for
+        // nothing.
+        if groups.is_empty() {
+            return Ok(Vec::new());
+        }
+
+        // Flatten every sentence from every group into one Vec, then
+        // embed in fixed-size chunks. We can't hand the whole lecture
+        // to `generate_embeddings_batch` in one shot because it pads
+        // every row in the batch to the longest sequence — 1296 × 100
+        // tokens × 768 hidden-dim × (activations for 12 BERT layers)
+        // OOMs at ~5 GB on a 70-min lecture. Chunking keeps the
+        // padding horizon small and memory flat.
+        //
+        // Per-group separate passes (the original layout) wasted the
+        // batching win entirely: 14 forward passes at ~90 sentences
+        // each took 52 minutes on CPU. 128 is a pragmatic middle
+        // ground: big enough for BERT to amortise its per-call
+        // overhead, small enough that padding doesn't dominate.
+        //
+        // `group_ranges[i]` records the half-open slice in the flat
+        // buffer owned by group i, so we can pull per-group
+        // embeddings back out with zero copies.
+        const BATCH: usize = 128;
+        let mut flat_sentences: Vec<String> = Vec::new();
+        let mut group_ranges: Vec<(usize, usize)> = Vec::with_capacity(groups.len());
+        for group in groups {
+            let start = flat_sentences.len();
+            for s in group {
+                flat_sentences.push(s.clone());
+            }
+            group_ranges.push((start, flat_sentences.len()));
+        }
+        if flat_sentences.is_empty() {
+            return Ok(groups.iter().map(|_| Vec::new()).collect());
+        }
+
+        let mut all_embs: Vec<Vec<f32>> = Vec::with_capacity(flat_sentences.len());
+        for chunk in flat_sentences.chunks(BATCH) {
+            let chunk_embs = self.generate_embeddings_batch(chunk)?;
+            all_embs.extend(chunk_embs);
+        }
+        let dim = all_embs.first().map(|v| v.len()).unwrap_or(0);
+        if dim == 0 {
+            return Ok(groups.iter().map(|g| g.clone()).collect());
+        }
+
+        let mut out = Vec::with_capacity(groups.len());
+        for (group_idx, group) in groups.iter().enumerate() {
+            let (start, end) = group_ranges[group_idx];
+            let n = end - start;
+            if n == 0 {
+                out.push(Vec::new());
+                continue;
+            }
+            if n <= top_k {
+                out.push(group.clone());
+                continue;
+            }
+
+            // Copy this group's slice of embeddings into an [N, D] tensor.
+            // Allocation is unavoidable (Tensor owns its buffer), but
+            // only once per group instead of a full re-embed.
+            let mut flat = Vec::with_capacity(n * dim);
+            for e in &all_embs[start..end] {
+                flat.extend_from_slice(e);
+            }
+            let mat = Tensor::from_vec(flat, (n, dim), &self.device)?;
+
+            // Centroid = row-wise mean → [D]. BGE outputs are unit-norm,
+            // so the mean of normalised vectors points toward the
+            // dominant cluster direction even when the group is noisy.
+            let centroid = mat.mean(0)?;
+
+            // Normalise the centroid so downstream scores stay in the
+            // familiar cosine-[-1, 1] range. Logging / debugging is
+            // much easier when "0.8 ≈ strong match" still holds.
+            let centroid_norm: f32 = centroid.sqr()?.sum_all()?.sqrt()?.to_scalar()?;
+            let centroid = if centroid_norm > 0.0 {
+                centroid.affine(1.0 / centroid_norm as f64, 0.0)?
+            } else {
+                centroid
+            };
+
+            // [N, D] @ [D, 1] = [N, 1] — cosine against the centroid.
+            let centroid_col = centroid.reshape((dim, 1))?;
+            let sims_tensor = mat.matmul(&centroid_col)?;
+            let sims: Vec<f32> = sims_tensor.squeeze(1)?.to_vec1()?;
+
+            // Pick top_k by score, then re-sort by original position
+            // so the bullets read in the lecture's narrative order.
+            let mut scored: Vec<(usize, f32)> =
+                sims.iter().enumerate().map(|(i, &s)| (i, s)).collect();
+            scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+            scored.truncate(top_k);
+            let mut picked_indices: Vec<usize> = scored.into_iter().map(|(i, _)| i).collect();
+            picked_indices.sort();
+
+            out.push(picked_indices.iter().map(|&i| group[i].clone()).collect());
+        }
+        Ok(out)
+    }
+
+    /// Stub when candle-embed is compiled out — returns the first
+    /// `top_k` sentences of each group so the NotesView UI still has
+    /// something to render.
+    #[cfg(not(feature = "candle-embed"))]
+    pub fn extract_representative_sentences(
+        &mut self,
+        groups: &[Vec<String>],
+        top_k: usize,
+    ) -> Result<Vec<Vec<String>>> {
+        Ok(groups
+            .iter()
+            .map(|g| g.iter().take(top_k).cloned().collect())
+            .collect())
+    }
 }

--- a/ClassNoteAI/src-tauri/src/embedding/service.rs
+++ b/ClassNoteAI/src-tauri/src/embedding/service.rs
@@ -392,4 +392,82 @@ impl EmbeddingService {
             dot_product / (norm_a * norm_b)
         }
     }
+
+    /// Score a query embedding against a batch of chunk embeddings in a
+    /// single matmul on `self.device` (GPU when available, CPU otherwise).
+    /// Returns one similarity per chunk, in the same order.
+    ///
+    /// Replaces the per-chunk JS cosine loop in
+    /// `embeddingStorageService.ts` — for N=500, D=384 that loop used
+    /// ~100 ms on the renderer thread; a single matmul finishes in
+    /// <10 ms on a GPU (and still a few ms on CPU thanks to Candle's
+    /// BLAS backend).
+    ///
+    /// Assumes both the query and every chunk are already L2-normalized,
+    /// which every embedding we generate is — `generate_embedding` and
+    /// `generate_embeddings_batch` both normalize before returning.
+    /// Dot product of unit vectors == cosine, so we skip the denominator
+    /// work the CPU-side `cosine_similarity` has to do.
+    #[cfg(feature = "candle-embed")]
+    pub fn batch_cosine_similarity(
+        &self,
+        query: &[f32],
+        chunks: &[Vec<f32>],
+    ) -> Result<Vec<f32>> {
+        if chunks.is_empty() {
+            return Ok(Vec::new());
+        }
+        let dim = query.len();
+        if dim == 0 {
+            return Err(anyhow!("Query embedding is empty"));
+        }
+        // Filter out any malformed chunks — legacy rows that slipped
+        // past the v0.5.2 dimension migration would explode the matmul.
+        // Record the original index so we can reinsert zero scores for
+        // them afterwards, keeping the returned Vec aligned with the
+        // caller's input.
+        let mut good: Vec<(usize, &[f32])> = Vec::with_capacity(chunks.len());
+        for (i, c) in chunks.iter().enumerate() {
+            if c.len() == dim {
+                good.push((i, c.as_slice()));
+            }
+        }
+        if good.is_empty() {
+            return Ok(vec![0.0; chunks.len()]);
+        }
+
+        let n = good.len();
+        let mut flat = Vec::with_capacity(n * dim);
+        for (_, c) in &good {
+            flat.extend_from_slice(c);
+        }
+
+        let chunk_tensor = Tensor::from_vec(flat, (n, dim), &self.device)?;
+        let query_tensor = Tensor::from_vec(query.to_vec(), (dim, 1), &self.device)?;
+
+        // [N, D] @ [D, 1] = [N, 1] — cosine because inputs are unit norm.
+        let sims_tensor = chunk_tensor.matmul(&query_tensor)?;
+        let sims: Vec<f32> = sims_tensor.squeeze(1)?.to_vec1()?;
+
+        let mut out = vec![0.0f32; chunks.len()];
+        for ((original_idx, _), sim) in good.iter().zip(sims.iter()) {
+            out[*original_idx] = *sim;
+        }
+        Ok(out)
+    }
+
+    /// Stub when candle-embed feature is disabled. Falls back to the
+    /// per-pair CPU cosine so the command still works, just without
+    /// batched GPU acceleration.
+    #[cfg(not(feature = "candle-embed"))]
+    pub fn batch_cosine_similarity(
+        &self,
+        query: &[f32],
+        chunks: &[Vec<f32>],
+    ) -> Result<Vec<f32>> {
+        Ok(chunks
+            .iter()
+            .map(|c| Self::cosine_similarity(query, c))
+            .collect())
+    }
 }

--- a/ClassNoteAI/src-tauri/src/embedding/service.rs
+++ b/ClassNoteAI/src-tauri/src/embedding/service.rs
@@ -62,6 +62,45 @@ impl NomicConfig {
     }
 }
 
+/// Pick the best-available Candle device for BGE embedding. Tries GPU
+/// backends before CPU; any init failure falls back silently. Matches
+/// the ct2rs pattern in `translation::ctranslate2::load_model`.
+///
+/// Important: this is called once, at service construction. The
+/// returned device is kept on the service and used for every tensor
+/// thereafter (model weights + each batch's input_ids). Falling back
+/// to CPU mid-run would require reloading the model, so we only try
+/// the GPU path at startup — if it works there, it works for the
+/// life of the process.
+#[cfg(feature = "candle-embed")]
+fn select_embedding_device() -> Device {
+    #[cfg(feature = "gpu-cuda")]
+    {
+        match Device::new_cuda(0) {
+            Ok(d) => {
+                eprintln!("[Embedding] Using CUDA device 0");
+                return d;
+            }
+            Err(e) => {
+                eprintln!("[Embedding] CUDA init failed ({}), falling back", e);
+            }
+        }
+    }
+    #[cfg(all(target_os = "macos", feature = "gpu-metal"))]
+    {
+        match Device::new_metal(0) {
+            Ok(d) => {
+                eprintln!("[Embedding] Using Metal device 0");
+                return d;
+            }
+            Err(e) => {
+                eprintln!("[Embedding] Metal init failed ({}), falling back", e);
+            }
+        }
+    }
+    Device::Cpu
+}
+
 /// Candle-based Embedding Service
 pub struct EmbeddingService {
     #[cfg(feature = "candle-embed")]
@@ -93,8 +132,15 @@ impl EmbeddingService {
         let tokenizer = Tokenizer::from_file(tokenizer_path)
             .map_err(|e| anyhow!("Failed to load tokenizer: {}", e))?;
 
-        // Use CPU device (Metal support can be added later)
-        let device = Device::Cpu;
+        // Pick the strongest device the host will actually let us use.
+        // Priority: CUDA (gpu-cuda build) → Metal (macOS gpu-metal) →
+        // CPU. An init failure — driver mismatch, missing cudart,
+        // Metal system library missing — silently drops to CPU. BGE
+        // is correctness-critical (the RAG index and the query-time
+        // encoding must agree on the same model output), so a steady
+        // CPU run beats a half-working GPU run. Log to stderr for
+        // post-hoc debugging; nothing reaches the UI.
+        let device = select_embedding_device();
 
         // Load config (支持 nomic 和標準 BERT 格式)
         let config_path = model_path

--- a/ClassNoteAI/src-tauri/src/gpu/mod.rs
+++ b/ClassNoteAI/src-tauri/src/gpu/mod.rs
@@ -155,6 +155,38 @@ pub async fn detect_gpu_backends(preference: Option<String>) -> Result<GpuDetect
     Ok(detect(preference.as_deref()))
 }
 
+/// Which GPU feature set the binary was compiled with. Used by the
+/// updater (frontend) to pick the right artifact URL out of the merged
+/// `latest.json` — a CPU build has no business pulling a CUDA
+/// installer and vice-versa.
+///
+/// Priority of the `cfg` checks matches the CI matrix: exactly one of
+/// the three gpu features should be on in a release build, but if
+/// multiple are somehow on (dev override) we still pick deterministically.
+#[tauri::command]
+pub fn get_build_variant() -> &'static str {
+    #[cfg(feature = "gpu-cuda")]
+    {
+        return "cuda";
+    }
+    #[cfg(all(feature = "gpu-metal", not(feature = "gpu-cuda")))]
+    {
+        return "metal";
+    }
+    #[cfg(all(
+        feature = "gpu-vulkan",
+        not(feature = "gpu-cuda"),
+        not(feature = "gpu-metal")
+    ))]
+    {
+        return "vulkan";
+    }
+    #[cfg(not(any(feature = "gpu-cuda", feature = "gpu-metal", feature = "gpu-vulkan")))]
+    {
+        return "cpu";
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/ClassNoteAI/src-tauri/src/gpu/mod.rs
+++ b/ClassNoteAI/src-tauri/src/gpu/mod.rs
@@ -51,6 +51,95 @@ pub struct GpuDetection {
     /// taking into account what's compiled in (Phase 1: always CPU)
     /// + what was detected here. Phase 2+ will fill this in for real.
     pub effective: String,
+    /// Non-blocking advisory surfaced to the UI when we spot something
+    /// that could stop GPU acceleration from actually kicking in —
+    /// most commonly a too-old NVIDIA driver. Present as a banner with
+    /// a download link; the user can ignore it and keep running on
+    /// CPU. `None` means "nothing to nag about."
+    pub driver_hint: Option<DriverHint>,
+}
+
+/// UI-bound advisory for driver-side GPU issues. Kept structured
+/// (not a single `String`) so the frontend can style severity and
+/// render the download link as a proper button rather than parsing
+/// text.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DriverHint {
+    /// "warning" for actionable mismatches (driver too old),
+    /// "info" for softer suggestions. Frontend picks colour + icon
+    /// off this.
+    pub severity: String,
+    pub title: String,
+    pub message: String,
+    /// URL the "Update driver" CTA opens. NVIDIA's search page is
+    /// stable since 2015 and redirects correctly for every consumer
+    /// GeForce + professional Quadro SKU, so hard-coding is safe.
+    pub action_url: String,
+    pub action_label: String,
+}
+
+/// Minimum NVIDIA driver for the CUDA 12.5 runtime we ship via CI's
+/// Jimver action. Below this, `cudaSetDevice` returns the familiar
+/// "CUDA driver version is insufficient for CUDA runtime version"
+/// error and every downstream load (whisper, ct2rs, candle) falls
+/// back to CPU — still functional, just slow.
+///
+/// Sources: NVIDIA CUDA Toolkit Release Notes 12.5. Windows has a
+/// slightly higher floor than Linux because of WDDM scheduling
+/// changes that landed in the 555-line drivers. When CI moves to
+/// CUDA 12.6+ / 13.x, bump these (and remember to re-sync the
+/// `docs/` note that mentions them).
+const CUDA_MIN_DRIVER_WINDOWS: f32 = 555.85;
+const CUDA_MIN_DRIVER_LINUX: f32 = 555.42;
+
+/// Parse the `"572.83"`-style version string that `nvidia-smi`
+/// prints. Handles the two formats we see in the wild:
+///
+///   - Windows / recent Linux: `"596.21"` — two segments, parses
+///     directly as `f32`.
+///   - Older Linux distros: `"555.42.06"` — three segments, where
+///     the third is a build-number we don't need for threshold
+///     comparison. We take `major.minor` from the first two dots.
+///
+/// Returns `None` on anything that doesn't start with a digit so the
+/// caller treats "unknown driver" as "skip the hint" instead of
+/// nagging about a driver we just can't interpret.
+fn parse_driver_version(s: &str) -> Option<f32> {
+    let trimmed = s.trim();
+    // Direct f32 parse covers the common two-segment case.
+    if let Ok(v) = trimmed.parse::<f32>() {
+        return Some(v);
+    }
+    // Fall back to joining the first two segments and retrying.
+    let mut parts = trimmed.split('.');
+    let major = parts.next()?;
+    let minor = parts.next()?;
+    format!("{}.{}", major, minor).parse::<f32>().ok()
+}
+
+/// Build the advisory banner when a driver is present but below the
+/// CUDA 12.5 floor. Returns `None` when everything's fine.
+fn compute_driver_hint(cuda: &Option<CudaInfo>) -> Option<DriverHint> {
+    let info = cuda.as_ref()?;
+    let parsed = parse_driver_version(&info.driver_version)?;
+    let min = if cfg!(target_os = "windows") {
+        CUDA_MIN_DRIVER_WINDOWS
+    } else {
+        CUDA_MIN_DRIVER_LINUX
+    };
+    if parsed >= min {
+        return None;
+    }
+    Some(DriverHint {
+        severity: "warning".into(),
+        title: "GPU 加速未啟用".into(),
+        message: format!(
+            "偵測到 {}（driver {}），但目前的 NVIDIA driver 版本低於 CUDA 12.5 runtime 所需的 {}。GPU 加速會自動退回 CPU 模式，應用仍可正常使用；若想啟用 GPU，請更新 NVIDIA driver。",
+            info.gpu_name, info.driver_version, min
+        ),
+        action_url: "https://www.nvidia.com/Download/index.aspx".into(),
+        action_label: "前往 NVIDIA 驅動下載".into(),
+    })
 }
 
 fn detect_cuda() -> Option<CudaInfo> {
@@ -140,11 +229,13 @@ pub fn detect(preference: Option<&str>) -> GpuDetection {
     let metal = cfg!(target_os = "macos");
     let vulkan = detect_vulkan();
     let effective = resolve_effective(preference, cuda.is_some(), metal, vulkan);
+    let driver_hint = compute_driver_hint(&cuda);
     GpuDetection {
         cuda,
         metal,
         vulkan,
         effective,
+        driver_hint,
     }
 }
 

--- a/ClassNoteAI/src-tauri/src/gpu/mod.rs
+++ b/ClassNoteAI/src-tauri/src/gpu/mod.rs
@@ -1,0 +1,189 @@
+//! GPU backend detection for Whisper acceleration.
+//!
+//! This module is *detection only* — it answers "what GPU backends
+//! could work on this machine?" without actually loading any of them.
+//! The answer drives two UI surfaces:
+//!
+//!   1. The setup wizard's GPU-check step, which tells the user what
+//!      kind of acceleration they'll get before they finish onboarding.
+//!   2. The Settings → "ASR 加速後端" selector, which shows which
+//!      backends are available as checkmarks and which are greyed out.
+//!
+//! Detection strategies:
+//!   - **CUDA**: probe `nvidia-smi` (shipped with every NVIDIA driver
+//!     ≥ R460) for GPU name + driver version. If the driver is present,
+//!     the runtime cudart/cuBLAS DLLs we'll ship alongside the GPU
+//!     build (Phase 4) will find a GPU to talk to.
+//!   - **Metal**: `cfg(target_os = "macos")`. Every Mac since ~2016
+//!     has Metal; there's no device-level fallback to worry about.
+//!   - **Vulkan**: look for the Vulkan loader — `vulkan-1.dll` on
+//!     Windows, `libvulkan.so.1` on Linux. Every modern GPU driver
+//!     ships it, so this is effectively "does the user have any
+//!     functional GPU driver installed?"
+//!
+//! What we **don't** do:
+//!   - Install CUDA Toolkit. Users don't need it — the runtime DLLs
+//!     we ship (Phase 4) + their existing driver are enough. Toolkit
+//!     is only needed at *build* time, which is handled in CI.
+//!   - Install drivers. Windows Update + GeForce Experience already
+//!     cover 99% of cases, and silent driver installs can trigger
+//!     reboots/kernel changes we shouldn't own.
+
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+use std::process::Command;
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct CudaInfo {
+    /// First GPU name (e.g. "NVIDIA GeForce RTX 4060 Ti"). Multi-GPU
+    /// setups are rare for end users; we surface only the primary.
+    pub gpu_name: String,
+    /// Driver version as reported by `nvidia-smi --query-gpu=driver_version`.
+    pub driver_version: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct GpuDetection {
+    pub cuda: Option<CudaInfo>,
+    pub metal: bool,
+    pub vulkan: bool,
+    /// Which backend will actually run when the user picks `auto`,
+    /// taking into account what's compiled in (Phase 1: always CPU)
+    /// + what was detected here. Phase 2+ will fill this in for real.
+    pub effective: String,
+}
+
+fn detect_cuda() -> Option<CudaInfo> {
+    // `nvidia-smi` is in PATH on every NVIDIA-driver install since
+    // R460. If it's missing, either no NVIDIA driver or the PATH isn't
+    // propagated (rare — system installer adds it).
+    let output = Command::new("nvidia-smi")
+        .args([
+            "--query-gpu=name,driver_version",
+            "--format=csv,noheader",
+        ])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let first_line = stdout.lines().next()?;
+    let mut parts = first_line.split(',').map(|p| p.trim());
+    let name = parts.next()?.to_string();
+    let driver = parts.next()?.to_string();
+    if name.is_empty() {
+        return None;
+    }
+    Some(CudaInfo {
+        gpu_name: name,
+        driver_version: driver,
+    })
+}
+
+fn detect_vulkan() -> bool {
+    // The Vulkan loader ships inside every modern GPU driver. If it's
+    // present on the filesystem, a Vulkan-enabled build will have
+    // something to talk to. We don't try to enumerate physical devices
+    // here — doing so would require linking vulkan-loader into the
+    // detection path, which is exactly what we're trying to avoid at
+    // this stage.
+    if cfg!(target_os = "windows") {
+        // System32 is the guaranteed location for OS-provided loaders.
+        Path::new(r"C:\Windows\System32\vulkan-1.dll").exists()
+    } else if cfg!(target_os = "linux") {
+        Path::new("/usr/lib/x86_64-linux-gnu/libvulkan.so.1").exists()
+            || Path::new("/usr/lib/libvulkan.so.1").exists()
+            || Path::new("/usr/lib64/libvulkan.so.1").exists()
+    } else {
+        // macOS ships MoltenVK via Vulkan SDK, not by default. Not
+        // worth probing — Metal covers it.
+        false
+    }
+}
+
+fn resolve_effective(
+    preference: Option<&str>,
+    cuda: bool,
+    metal: bool,
+    vulkan: bool,
+) -> String {
+    let pref = preference.unwrap_or("auto").to_lowercase();
+    match pref.as_str() {
+        "cuda" if cuda => "cuda".into(),
+        "metal" if metal => "metal".into(),
+        "vulkan" if vulkan => "vulkan".into(),
+        "cpu" => "cpu".into(),
+        _ => {
+            // auto (or invalid / unavailable preference) — priority
+            // order picks the strongest acceleration we actually have.
+            if cuda {
+                "cuda".into()
+            } else if metal {
+                "metal".into()
+            } else if vulkan {
+                "vulkan".into()
+            } else {
+                "cpu".into()
+            }
+        }
+    }
+}
+
+/// Runs all detection probes. Cheap (couple of fork/exec + filesystem
+/// stats) — fine to call on every settings-page open or wizard step.
+///
+/// `preference` is the user's `experimental.asrBackend` value if set;
+/// `None` or `"auto"` picks the best available.
+pub fn detect(preference: Option<&str>) -> GpuDetection {
+    let cuda = detect_cuda();
+    let metal = cfg!(target_os = "macos");
+    let vulkan = detect_vulkan();
+    let effective = resolve_effective(preference, cuda.is_some(), metal, vulkan);
+    GpuDetection {
+        cuda,
+        metal,
+        vulkan,
+        effective,
+    }
+}
+
+// ----- Tauri command wrapper ------------------------------------------------
+
+#[tauri::command]
+pub async fn detect_gpu_backends(preference: Option<String>) -> Result<GpuDetection, String> {
+    Ok(detect(preference.as_deref()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_auto_prefers_cuda_over_vulkan() {
+        let eff = resolve_effective(Some("auto"), true, false, true);
+        assert_eq!(eff, "cuda");
+    }
+
+    #[test]
+    fn resolve_auto_falls_back_to_cpu() {
+        let eff = resolve_effective(Some("auto"), false, false, false);
+        assert_eq!(eff, "cpu");
+    }
+
+    #[test]
+    fn resolve_explicit_preference_falls_back_when_unavailable() {
+        // User picked CUDA but machine has only Vulkan; we quietly fall
+        // back rather than trying to use a backend that isn't there.
+        let eff = resolve_effective(Some("cuda"), false, false, true);
+        assert_eq!(eff, "vulkan");
+    }
+
+    #[test]
+    fn resolve_explicit_cpu_is_honoured_even_with_gpu() {
+        // User opting into CPU (e.g. to conserve GPU for another app)
+        // should be respected.
+        let eff = resolve_effective(Some("cpu"), true, true, true);
+        assert_eq!(eff, "cpu");
+    }
+}

--- a/ClassNoteAI/src-tauri/src/gpu/mod.rs
+++ b/ClassNoteAI/src-tauri/src/gpu/mod.rs
@@ -29,9 +29,9 @@
 //!     cover 99% of cases, and silent driver installs can trigger
 //!     reboots/kernel changes we shouldn't own.
 
+use crate::utils::command::no_window;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
-use std::process::Command;
 
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]
 pub struct CudaInfo {
@@ -146,7 +146,7 @@ fn detect_cuda() -> Option<CudaInfo> {
     // `nvidia-smi` is in PATH on every NVIDIA-driver install since
     // R460. If it's missing, either no NVIDIA driver or the PATH isn't
     // propagated (rare — system installer adds it).
-    let output = Command::new("nvidia-smi")
+    let output = no_window("nvidia-smi")
         .args([
             "--query-gpu=name,driver_version",
             "--format=csv,noheader",

--- a/ClassNoteAI/src-tauri/src/lib.rs
+++ b/ClassNoteAI/src-tauri/src/lib.rs
@@ -30,7 +30,7 @@ pub mod dev_flags;
 
 use embedding::EmbeddingService;
 use log::LevelFilter;
-use tauri::Emitter;
+use tauri::{Emitter, Manager};
 use tauri_plugin_log::{RotationStrategy, Target, TargetKind};
 use tokio::sync::Mutex;
 use whisper::WhisperService; // For window.emit()
@@ -1987,6 +1987,52 @@ async fn close_devtools(app: tauri::AppHandle) -> Result<(), String> {
     Ok(())
 }
 
+#[tauri::command]
+async fn read_recent_log(lines: usize, app_handle: tauri::AppHandle) -> Result<String, String> {
+    use std::fs::File;
+    use std::io::{BufRead, BufReader};
+
+    let log_dir = app_handle
+        .path()
+        .app_log_dir()
+        .map_err(|e| format!("Failed to resolve log dir: {}", e))?;
+    let log_path = log_dir.join("classnoteai.log");
+
+    if !log_path.exists() {
+        return Ok(String::new());
+    }
+
+    let file = File::open(&log_path).map_err(|e| format!("Failed to open log file: {}", e))?;
+    let reader = BufReader::new(file);
+    let all_lines = reader
+        .lines()
+        .collect::<Result<Vec<_>, _>>()
+        .map_err(|e| format!("Failed to read log file: {}", e))?;
+
+    let limit = lines.min(2000);
+    if limit == 0 {
+        return Ok(String::new());
+    }
+
+    let start = all_lines.len().saturating_sub(limit);
+    Ok(all_lines[start..].join("\n"))
+}
+
+#[tauri::command]
+async fn open_log_folder(app_handle: tauri::AppHandle) -> Result<(), String> {
+    use tauri_plugin_opener::OpenerExt;
+
+    let log_dir = app_handle
+        .path()
+        .app_log_dir()
+        .map_err(|e| format!("Failed to resolve log dir: {}", e))?;
+
+    app_handle
+        .opener()
+        .open_path(log_dir.to_string_lossy().to_string(), None::<&str>)
+        .map_err(|e| e.to_string())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // Populate HTTP_PROXY/HTTPS_PROXY from Windows Internet Settings so
@@ -2052,6 +2098,8 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             open_devtools,
             close_devtools,
+            read_recent_log,
+            open_log_folder,
             detect_speech_segments,
             greet,
             load_whisper_model,

--- a/ClassNoteAI/src-tauri/src/lib.rs
+++ b/ClassNoteAI/src-tauri/src/lib.rs
@@ -1894,6 +1894,7 @@ pub fn run() {
             recording::video_import::release_import_whisper,
             recording::video_import::resolve_whisper_model_path,
             gpu::detect_gpu_backends,
+            gpu::get_build_variant,
             list_orphaned_recording_lectures,
         ])
         .run(tauri::generate_context!())

--- a/ClassNoteAI/src-tauri/src/lib.rs
+++ b/ClassNoteAI/src-tauri/src/lib.rs
@@ -22,6 +22,8 @@ mod sync;
 mod oauth;
 // Crash-safe recording — incremental PCM persistence + orphan recovery
 pub mod recording;
+// GPU backend detection (CUDA via nvidia-smi, Metal via cfg, Vulkan via filesystem)
+mod gpu;
 
 use embedding::EmbeddingService;
 use tauri::Emitter;
@@ -1891,6 +1893,7 @@ pub fn run() {
             recording::video_import::delete_temp_pcm,
             recording::video_import::release_import_whisper,
             recording::video_import::resolve_whisper_model_path,
+            gpu::detect_gpu_backends,
             list_orphaned_recording_lectures,
         ])
         .run(tauri::generate_context!())

--- a/ClassNoteAI/src-tauri/src/lib.rs
+++ b/ClassNoteAI/src-tauri/src/lib.rs
@@ -29,7 +29,9 @@ mod gpu;
 pub mod dev_flags;
 
 use embedding::EmbeddingService;
+use log::LevelFilter;
 use tauri::Emitter;
+use tauri_plugin_log::{RotationStrategy, Target, TargetKind};
 use tokio::sync::Mutex;
 use whisper::WhisperService; // For window.emit()
 
@@ -2006,6 +2008,22 @@ pub fn run() {
                 let _ = window.set_focus();
             }
         }))
+        .plugin(
+            tauri_plugin_log::Builder::new()
+                .targets([
+                    Target::new(TargetKind::LogDir {
+                        file_name: Some("classnoteai".into()),
+                    }),
+                    Target::new(TargetKind::Stdout),
+                ])
+                .level(if cfg!(debug_assertions) {
+                    LevelFilter::Info
+                } else {
+                    LevelFilter::Warn
+                })
+                .rotation_strategy(RotationStrategy::KeepSome(5))
+                .build(),
+        )
         .plugin(tauri_plugin_http::init())
         .plugin(tauri_plugin_updater::Builder::new().build())
         .plugin(tauri_plugin_opener::init())

--- a/ClassNoteAI/src-tauri/src/lib.rs
+++ b/ClassNoteAI/src-tauri/src/lib.rs
@@ -16,6 +16,7 @@ mod setup;
 pub mod paths;
 // 統一下載管理模塊
 pub mod downloads;
+pub mod diagnostics;
 // 同步模塊
 mod sync;
 // Localhost OAuth callback listener (for ChatGPT OAuth sign-in)
@@ -2033,6 +2034,15 @@ async fn open_log_folder(app_handle: tauri::AppHandle) -> Result<(), String> {
         .map_err(|e| e.to_string())
 }
 
+#[tauri::command]
+async fn export_diagnostic_package(
+    input: crate::diagnostics::DiagnosticPackageInput,
+    include_audio: bool,
+) -> Result<String, String> {
+    let path = crate::diagnostics::build_diagnostic_zip(input, include_audio)?;
+    Ok(path.to_string_lossy().into_owned())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // Populate HTTP_PROXY/HTTPS_PROXY from Windows Internet Settings so
@@ -2100,6 +2110,7 @@ pub fn run() {
             close_devtools,
             read_recent_log,
             open_log_folder,
+            export_diagnostic_package,
             detect_speech_segments,
             greet,
             load_whisper_model,

--- a/ClassNoteAI/src-tauri/src/lib.rs
+++ b/ClassNoteAI/src-tauri/src/lib.rs
@@ -24,6 +24,9 @@ mod oauth;
 pub mod recording;
 // GPU backend detection (CUDA via nvidia-smi, Metal via cfg, Vulkan via filesystem)
 mod gpu;
+// Pre-WebView2 experimental toggles (remote debug port, etc). Public
+// so `main()` can `remote_debug_enabled()` before Tauri spins up.
+pub mod dev_flags;
 
 use embedding::EmbeddingService;
 use tauri::Emitter;
@@ -511,9 +514,55 @@ async fn load_translation_model_by_name(model_name: String) -> Result<String, St
         return Err(format!("模型目錄不存在: {:?}", model_dir));
     }
 
-    // 檢查 CT2 模型文件 (model.bin)
+    // 檢查 CT2 模型文件 (model.bin).
+    //
+    // Some older app builds / manual extracts left the model files
+    // one directory deeper than expected:
+    //     .../m2m100-418M-ct2-int8/m2m100-418M-ct2-int8/model.bin
+    // instead of the flat layout this command expects:
+    //     .../m2m100-418M-ct2-int8/model.bin
+    // The current downloader strips the top-level dir correctly, so
+    // fresh installs don't hit this — but users migrating from older
+    // versions do, and the error ("CT2 模型文件不存在") is opaque. We
+    // self-heal on first load: if outer model.bin is missing but a
+    // nested `{model_name}/model.bin` exists under the same root,
+    // flatten it by moving every entry up one level. One-shot;
+    // subsequent loads hit the check_path fast path.
     let model_bin_path = model_dir.join("model.bin");
-
+    if !model_bin_path.exists() {
+        let nested_dir = model_dir.join(&model_name);
+        let nested_bin = nested_dir.join("model.bin");
+        if nested_bin.exists() {
+            println!(
+                "[TranslationModel] 偵測到巢狀模型目錄，自動 flatten: {:?} -> {:?}",
+                nested_dir, model_dir
+            );
+            match std::fs::read_dir(&nested_dir) {
+                Ok(entries) => {
+                    for entry in entries.flatten() {
+                        let from = entry.path();
+                        let to = model_dir.join(entry.file_name());
+                        if let Err(e) = std::fs::rename(&from, &to) {
+                            return Err(format!(
+                                "自動 flatten 失敗 ({} → {}): {}",
+                                from.display(),
+                                to.display(),
+                                e
+                            ));
+                        }
+                    }
+                    // Now the inner dir should be empty — remove it.
+                    let _ = std::fs::remove_dir(&nested_dir);
+                }
+                Err(e) => {
+                    return Err(format!(
+                        "讀取巢狀目錄失敗 {:?}: {}",
+                        nested_dir, e
+                    ));
+                }
+            }
+        }
+    }
     if !model_bin_path.exists() {
         return Err(format!("CT2 模型文件不存在: {:?}", model_bin_path));
     }
@@ -1184,6 +1233,25 @@ async fn calculate_similarity(text_a: String, text_b: String) -> Result<f32, Str
     Ok(EmbeddingService::cosine_similarity(&emb_a, &emb_b))
 }
 
+/// Read the current "Remote debug port" experimental toggle.
+/// Returns the persisted flag from `dev-flags.toml`; `false` when
+/// the file doesn't exist or is unreadable.
+#[tauri::command]
+fn get_remote_debug_enabled() -> bool {
+    dev_flags::remote_debug_enabled()
+}
+
+/// Persist the toggle. Frontend Settings shows a "請重啟應用程式"
+/// hint after calling this — the change doesn't take effect until
+/// the next `main()` runs, because WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS
+/// is read at WebView2 process-start time only.
+#[tauri::command]
+fn set_remote_debug_enabled(enabled: bool) -> Result<(), String> {
+    let mut flags = dev_flags::load();
+    flags.remote_debug_port_enabled = enabled;
+    dev_flags::save(&flags)
+}
+
 /// Given N sentence-groups (one per Note section), return `top_k`
 /// representative sentences per group via a GPU-capable centroid
 /// extractor. Empty or small groups are passed through unchanged.
@@ -1654,7 +1722,7 @@ fn try_keynote_conversion(
 
     println!("Executing Keynote conversion...");
 
-    let output = Command::new("osascript")
+    let output = crate::utils::command::no_window("osascript")
         .arg("-e")
         .arg(&script)
         .output()
@@ -1693,7 +1761,7 @@ fn try_pages_conversion(input_path: &str, output_path: &std::path::Path) -> Resu
         output_path.to_string_lossy().replace("\"", "\\\"")
     );
 
-    let output = Command::new("osascript")
+    let output = crate::utils::command::no_window("osascript")
         .arg("-e")
         .arg(&script)
         .output()
@@ -1738,7 +1806,7 @@ fn try_office_mac_conversion(
         output_path.to_string_lossy().replace("\"", "\\\"")
     );
 
-    let output = Command::new("osascript")
+    let output = crate::utils::command::no_window("osascript")
         .arg("-e")
         .arg(&script)
         .output()
@@ -1791,7 +1859,7 @@ fn convert_with_libreoffice(
 
     println!("Using LibreOffice: {}", soffice_cmd);
 
-    let output = Command::new(soffice_cmd)
+    let output = crate::utils::command::no_window(soffice_cmd)
         .arg("--headless")
         .arg("--convert-to")
         .arg("pdf")
@@ -2034,6 +2102,8 @@ pub fn run() {
             semantic_search_lecture,
             semantic_search_course,
             extract_section_highlights,
+            get_remote_debug_enabled,
+            set_remote_debug_enabled,
             download_embedding_model_cmd,
             // 文檔轉換相關
             convert_to_pdf,

--- a/ClassNoteAI/src-tauri/src/lib.rs
+++ b/ClassNoteAI/src-tauri/src/lib.rs
@@ -2029,6 +2029,7 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_fs::init())
+        .manage(oauth::OAuthListenerState::default())
         .setup(|app| {
             // DevTools 現在由前端控制，根據 developerMode 設定
             // 前端可透過 invoke 呼叫開啟
@@ -2064,7 +2065,8 @@ pub fn run() {
             list_available_translation_models,
             load_translation_model_by_name,
             // OAuth callback listener
-            oauth::oauth_listen_for_code,
+            oauth::oauth_bind_port,
+            oauth::oauth_wait_for_code,
             oauth::oauth_cancel,
             // 數據存儲相關
             save_course,

--- a/ClassNoteAI/src-tauri/src/lib.rs
+++ b/ClassNoteAI/src-tauri/src/lib.rs
@@ -1184,6 +1184,28 @@ async fn calculate_similarity(text_a: String, text_b: String) -> Result<f32, Str
     Ok(EmbeddingService::cosine_similarity(&emb_a, &emb_b))
 }
 
+/// Given N sentence-groups (one per Note section), return `top_k`
+/// representative sentences per group via a GPU-capable centroid
+/// extractor. Empty or small groups are passed through unchanged.
+///
+/// This is Layer-1 of Note AI structurization — the extractive pass
+/// that runs automatically on section creation. The opt-in LLM
+/// enrichment (Layer 2) happens through a separate command.
+#[tauri::command]
+async fn extract_section_highlights(
+    sections: Vec<Vec<String>>,
+    top_k: Option<usize>,
+) -> Result<Vec<Vec<String>>, String> {
+    let top_k = top_k.unwrap_or(3).max(1);
+    let mut service_guard = EMBEDDING_SERVICE.lock().await;
+    let service = service_guard
+        .as_mut()
+        .ok_or("Embedding 模型未加載".to_string())?;
+    service
+        .extract_representative_sentences(&sections, top_k)
+        .map_err(|e| format!("section highlight extraction failed: {}", e))
+}
+
 /// Structured search hit returned by `semantic_search_*`. Wraps the
 /// embedding row's metadata (minus the raw embedding vector, which the
 /// frontend doesn't need for display) plus the computed similarity.
@@ -2011,6 +2033,7 @@ pub fn run() {
             calculate_similarity,
             semantic_search_lecture,
             semantic_search_course,
+            extract_section_highlights,
             download_embedding_model_cmd,
             // 文檔轉換相關
             convert_to_pdf,

--- a/ClassNoteAI/src-tauri/src/lib.rs
+++ b/ClassNoteAI/src-tauri/src/lib.rs
@@ -1184,6 +1184,176 @@ async fn calculate_similarity(text_a: String, text_b: String) -> Result<f32, Str
     Ok(EmbeddingService::cosine_similarity(&emb_a, &emb_b))
 }
 
+/// Structured search hit returned by `semantic_search_*`. Wraps the
+/// embedding row's metadata (minus the raw embedding vector, which the
+/// frontend doesn't need for display) plus the computed similarity.
+///
+/// Field names use snake_case to match the existing `BackendEmbeddingRow`
+/// payload — the frontend's `toRecord` helper can then reuse its
+/// existing camelCase mapping.
+#[derive(serde::Serialize, Debug)]
+struct SearchHit {
+    id: String,
+    lecture_id: String,
+    chunk_text: String,
+    source_type: String,
+    position: i64,
+    page_number: Option<i64>,
+    created_at: String,
+    similarity: f32,
+}
+
+/// Apply the same preferred-page boost the old JS path did. Kept as a
+/// tiny helper so the single-lecture and course-wide paths below
+/// don't drift.
+fn boost_for_page(sim: f32, chunk_page: Option<i64>, preferred_page: Option<i64>) -> f32 {
+    match (preferred_page, chunk_page) {
+        (Some(pref), Some(page)) => {
+            let gap = (page - pref).abs();
+            if gap <= 5 {
+                sim + 0.1
+            } else if gap <= 10 {
+                sim + 0.05
+            } else {
+                sim
+            }
+        }
+        _ => sim,
+    }
+}
+
+/// Rank chunks in one lecture by cosine similarity to `query`, with an
+/// optional boost for chunks near `preferred_page` (PDF-slide-aware
+/// RAG). Single Candle matmul on the service's device replaces the
+/// per-chunk JS cosine loop we used to run in the renderer.
+#[tauri::command]
+async fn semantic_search_lecture(
+    lecture_id: String,
+    query: String,
+    top_k: Option<usize>,
+    preferred_page: Option<i64>,
+) -> Result<Vec<SearchHit>, String> {
+    let manager = storage::get_db_manager()
+        .await
+        .map_err(|e| format!("db init: {}", e))?;
+    let db = manager.get_db().map_err(|e| format!("db conn: {}", e))?;
+    let rows = db
+        .get_embeddings_by_lecture(&lecture_id)
+        .map_err(|e| format!("get embeddings: {}", e))?;
+    drop(db);
+
+    if rows.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut service_guard = EMBEDDING_SERVICE.lock().await;
+    let service = service_guard
+        .as_mut()
+        .ok_or("Embedding 模型未加載".to_string())?;
+    let query_emb = service
+        .generate_embedding(&query)
+        .map_err(|e| format!("query embed: {}", e))?;
+    let chunks: Vec<Vec<f32>> = rows.iter().map(|r| r.embedding.clone()).collect();
+    let sims = service
+        .batch_cosine_similarity(&query_emb, &chunks)
+        .map_err(|e| format!("similarity: {}", e))?;
+    drop(service_guard);
+
+    let top_k = top_k.unwrap_or(5);
+    let mut scored: Vec<(usize, f32)> = sims
+        .iter()
+        .enumerate()
+        .map(|(i, &s)| (i, boost_for_page(s, rows[i].page_number, preferred_page)))
+        .collect();
+    scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    scored.truncate(top_k);
+
+    Ok(scored
+        .into_iter()
+        .map(|(i, score)| {
+            let r = &rows[i];
+            SearchHit {
+                id: r.id.clone(),
+                lecture_id: r.lecture_id.clone(),
+                chunk_text: r.chunk_text.clone(),
+                source_type: r.source_type.clone(),
+                position: r.position,
+                page_number: r.page_number,
+                created_at: r.created_at.clone(),
+                similarity: score,
+            }
+        })
+        .collect())
+}
+
+/// Cross-lecture search: union every lecture in a course and rank the
+/// combined chunk pool. One matmul over the union, not per-lecture —
+/// for a typical 10-lecture × 200-chunk course that's 2000 rows, and
+/// the GPU finishes the whole search in a handful of ms.
+#[tauri::command]
+async fn semantic_search_course(
+    course_id: String,
+    user_id: String,
+    query: String,
+    top_k: Option<usize>,
+) -> Result<Vec<SearchHit>, String> {
+    let manager = storage::get_db_manager()
+        .await
+        .map_err(|e| format!("db init: {}", e))?;
+    let db = manager.get_db().map_err(|e| format!("db conn: {}", e))?;
+    let lectures = db
+        .list_lectures_by_course(&course_id, &user_id)
+        .map_err(|e| format!("list lectures: {}", e))?;
+
+    let mut all_rows: Vec<storage::EmbeddingRow> = Vec::new();
+    for lec in &lectures {
+        let rows = db
+            .get_embeddings_by_lecture(&lec.id)
+            .map_err(|e| format!("get embeddings for {}: {}", lec.id, e))?;
+        all_rows.extend(rows);
+    }
+    drop(db);
+
+    if all_rows.is_empty() {
+        return Ok(Vec::new());
+    }
+
+    let mut service_guard = EMBEDDING_SERVICE.lock().await;
+    let service = service_guard
+        .as_mut()
+        .ok_or("Embedding 模型未加載".to_string())?;
+    let query_emb = service
+        .generate_embedding(&query)
+        .map_err(|e| format!("query embed: {}", e))?;
+    let chunks: Vec<Vec<f32>> = all_rows.iter().map(|r| r.embedding.clone()).collect();
+    let sims = service
+        .batch_cosine_similarity(&query_emb, &chunks)
+        .map_err(|e| format!("similarity: {}", e))?;
+    drop(service_guard);
+
+    let top_k = top_k.unwrap_or(5);
+    let mut scored: Vec<(usize, f32)> = sims.iter().enumerate().map(|(i, &s)| (i, s)).collect();
+    scored.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
+    scored.truncate(top_k);
+
+    Ok(scored
+        .into_iter()
+        .map(|(i, score)| {
+            let r = &all_rows[i];
+            SearchHit {
+                id: r.id.clone(),
+                lecture_id: r.lecture_id.clone(),
+                chunk_text: r.chunk_text.clone(),
+                source_type: r.source_type.clone(),
+                position: r.position,
+                page_number: r.page_number,
+                created_at: r.created_at.clone(),
+                similarity: score,
+            }
+        })
+        .collect())
+}
+
 #[cfg(feature = "candle-embed")]
 #[tauri::command]
 async fn download_embedding_model_cmd(
@@ -1839,6 +2009,8 @@ pub fn run() {
             generate_embedding,
             generate_embeddings_batch,
             calculate_similarity,
+            semantic_search_lecture,
+            semantic_search_course,
             download_embedding_model_cmd,
             // 文檔轉換相關
             convert_to_pdf,

--- a/ClassNoteAI/src-tauri/src/main.rs
+++ b/ClassNoteAI/src-tauri/src/main.rs
@@ -2,6 +2,31 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    // Route Rust panics through the `log` crate so they land in the
+    // tauri-plugin-log file at `{APP_DATA}/logs/classnoteai.log`
+    // instead of dying with the process. Without this hook, native
+    // panics leave zero post-mortem trail, which is what made #72
+    // so hard to diagnose before alpha.4.
+    std::panic::set_hook(Box::new(|info| {
+        let payload = info.payload();
+        let msg = payload
+            .downcast_ref::<&str>()
+            .copied()
+            .or_else(|| payload.downcast_ref::<String>().map(String::as_str))
+            .unwrap_or("<non-string panic payload>");
+        if let Some(loc) = info.location() {
+            log::error!(
+                "PANIC at {}:{}:{} — {}",
+                loc.file(),
+                loc.line(),
+                loc.column(),
+                msg
+            );
+        } else {
+            log::error!("PANIC (no location) — {}", msg);
+        }
+    }));
+
     // Developer / agent-mode opt-in: if the user flipped the
     // experimental "Remote debug port" toggle in Settings, we honour
     // it here — BEFORE Tauri fires up WebView2, because

--- a/ClassNoteAI/src-tauri/src/main.rs
+++ b/ClassNoteAI/src-tauri/src/main.rs
@@ -2,5 +2,28 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 
 fn main() {
+    // Developer / agent-mode opt-in: if the user flipped the
+    // experimental "Remote debug port" toggle in Settings, we honour
+    // it here — BEFORE Tauri fires up WebView2, because
+    // WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS is read at WebView2
+    // process-start time. Anything set after `tauri::Builder::run()`
+    // is too late.
+    //
+    // Flag is stored in `%APPDATA%\com.classnoteai\dev-flags.toml`
+    // (not the main SQLite DB, which init runs much later than this
+    // point). Missing / unreadable file means "off" — safe default.
+    // On: opens `127.0.0.1:9222` for Chrome DevTools Protocol,
+    // matching what `win-tauri-dev.bat` already does for dev builds.
+    // Users toggling this get a restart prompt; the flag takes
+    // effect on next launch only.
+    if classnoteai_lib::dev_flags::remote_debug_enabled() {
+        let port = std::env::var("CNAI_DEV_CDP_PORT").unwrap_or_else(|_| "9222".to_string());
+        let args = format!("--remote-debugging-port={}", port);
+        std::env::set_var("WEBVIEW2_ADDITIONAL_BROWSER_ARGUMENTS", &args);
+        eprintln!(
+            "[ClassNoteAI] Remote debug port enabled: http://127.0.0.1:{}",
+            port
+        );
+    }
     classnoteai_lib::run()
 }

--- a/ClassNoteAI/src-tauri/src/oauth.rs
+++ b/ClassNoteAI/src-tauri/src/oauth.rs
@@ -101,9 +101,9 @@ fn try_bind(preferred_port: u16, max_attempts: u16) -> Result<(TcpListener, u16)
 /// or if either command fails.
 #[cfg(target_os = "windows")]
 fn identify_port_holder(port: u16) -> Option<String> {
-    use std::process::Command;
+    use crate::utils::command::no_window;
 
-    let netstat = Command::new("netstat").args(["-ano"]).output().ok()?;
+    let netstat = no_window("netstat").args(["-ano"]).output().ok()?;
     if !netstat.status.success() {
         return None;
     }
@@ -116,7 +116,7 @@ fn identify_port_holder(port: u16) -> Option<String> {
         line.split_whitespace().last()
     })?;
 
-    let tl = Command::new("tasklist")
+    let tl = no_window("tasklist")
         .args(["/FI", &format!("PID eq {}", pid), "/FO", "CSV", "/NH"])
         .output()
         .ok()?;

--- a/ClassNoteAI/src-tauri/src/oauth.rs
+++ b/ClassNoteAI/src-tauri/src/oauth.rs
@@ -1,171 +1,115 @@
 //! Minimal localhost HTTP listener used as an OAuth redirect target.
 //!
-//! Frontend calls `oauth_listen_for_code`, then opens the browser to the
-//! provider's auth URL with `redirect_uri=http://localhost:<port>/auth/callback`.
-//! This function returns when the browser hits that URL, handing back the
-//! full request path so the caller can parse `code` and `state`.
+//! Frontend first calls `oauth_bind_port`, then opens the browser to the
+//! provider's auth URL with `redirect_uri=http://localhost:<port>/auth/callback`,
+//! then calls `oauth_wait_for_code`. The listener is stored in Tauri app state
+//! between those two commands so the redirect URI always matches the port that
+//! Rust actually bound.
 //!
 //! Intentionally NOT a general HTTP server: reads one request, writes one
 //! response, closes the socket. Listener also has a timeout so a
 //! cancelled auth flow doesn't leak a port-bound task.
-//!
-//! v0.5.1: tries a small range of ports starting from the preferred one
-//! so a previous failed sign-in stuck in TIME_WAIT doesn't block a retry.
-//! Returns both the callback path and the port that was actually bound so
-//! the frontend can build the correct redirect_uri.
 
+use std::borrow::Cow;
 use std::io::{BufRead, BufReader, Write};
 use std::net::TcpListener;
+use std::sync::Mutex;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
-use tauri::{AppHandle, Emitter};
-use tokio::task;
+use tauri::State;
 
 /// Cooperative cancel flag for the OAuth listener. Set to `true` via the
-/// `oauth_cancel` command — e.g. when the user closes the browser tab
-/// without completing auth and clicks "Cancel" in the sign-in modal.
-/// Reset on each new `oauth_listen_for_code` invocation.
+/// `oauth_cancel` command when the user aborts sign-in.
+/// Reset on each new `oauth_bind_port` invocation.
 static OAUTH_CANCEL: AtomicBool = AtomicBool::new(false);
 
-/// Event name emitted to the frontend as soon as the listener has bound
-/// a local port. Payload = the `u16` port that was actually bound (may
-/// differ from the preferred port when 1455 is held by another process
-/// — e.g. VS Code, reported in issue #36). The frontend must wait for
-/// this event before opening the browser so the redirect_uri matches
-/// the bound port.
-pub const OAUTH_BOUND_EVENT: &str = "oauth:bound";
+pub struct OAuthListenerState {
+    listener: Mutex<Option<TcpListener>>,
+}
+
+impl Default for OAuthListenerState {
+    fn default() -> Self {
+        Self {
+            listener: Mutex::new(None),
+        }
+    }
+}
 
 const HTML_SUCCESS: &str = "<!DOCTYPE html><html><head><meta charset='utf-8'><title>ClassNoteAI</title><style>body{font-family:system-ui,sans-serif;text-align:center;padding:4rem 1rem;color:#333}h1{font-weight:500}p{color:#666}</style></head><body><h1>\u{2705} Authentication complete</h1><p>You can close this tab and return to ClassNoteAI.</p></body></html>";
 
-/// Result of a successful OAuth callback listen: both the callback
-/// request path and the port the listener actually bound to.
 #[derive(Debug, Clone, serde::Serialize)]
-pub struct OAuthListenResult {
-    pub port: u16,
-    pub path: String,
+pub struct OAuthCallback {
+    pub code: String,
+    pub state: String,
 }
 
-/// Try to bind to `preferred_port`, and if that fails for "address in
-/// use" reasons, walk forward up to `max_attempts` ports. Once bound,
-/// wait up to `timeout_secs` for the first request and return it.
-///
-/// Timeout, bind exhaustion, or other I/O errors return an `Err(String)`
-/// so the frontend can show it in the sign-in modal.
 #[tauri::command]
-pub async fn oauth_listen_for_code(
-    app: AppHandle,
-    port: u16,
-    timeout_secs: u64,
-    max_attempts: Option<u16>,
-) -> Result<OAuthListenResult, String> {
-    // New attempt — clear any pending cancel from a previous aborted flow.
+pub fn oauth_bind_port(
+    state: State<'_, OAuthListenerState>,
+    preferred_port: u16,
+    max_attempts: u16,
+) -> Result<u16, String> {
     OAUTH_CANCEL.store(false, Ordering::SeqCst);
-    let attempts = max_attempts.unwrap_or(16);
-    task::spawn_blocking(move || listen_once(app, port, timeout_secs, attempts))
+
+    let attempts = max_attempts.max(1);
+    let mut guard = state
+        .listener
+        .lock()
+        .map_err(|_| "OAuth listener state poisoned.".to_string())?;
+    guard.take();
+
+    let (listener, bound_port) = try_bind(preferred_port, attempts)?;
+    *guard = Some(listener);
+    Ok(bound_port)
+}
+
+#[tauri::command]
+pub async fn oauth_wait_for_code(
+    state: State<'_, OAuthListenerState>,
+    timeout_secs: u64,
+) -> Result<OAuthCallback, String> {
+    let listener = {
+        let mut guard = state
+            .listener
+            .lock()
+            .map_err(|_| "OAuth listener state poisoned.".to_string())?;
+        guard
+            .take()
+            .ok_or_else(|| "OAuth listener not bound. Start sign-in again.".to_string())?
+    };
+
+    tokio::task::spawn_blocking(move || wait_for_code(listener, timeout_secs))
         .await
         .map_err(|e| format!("spawn_blocking join failed: {}", e))?
 }
 
 /// Ask the currently-running OAuth listener to bail out. Safe to call
-/// even if no listener is active (it just sets a flag).
+/// even if no listener is active.
 #[tauri::command]
-pub fn oauth_cancel() {
+pub fn oauth_cancel(state: State<'_, OAuthListenerState>) {
     OAUTH_CANCEL.store(true, Ordering::SeqCst);
+    if let Ok(mut guard) = state.listener.lock() {
+        guard.take();
+    }
 }
 
 fn try_bind(preferred_port: u16, max_attempts: u16) -> Result<(TcpListener, u16), String> {
-    let mut last_err: Option<std::io::Error> = None;
     for offset in 0..max_attempts {
         let port = preferred_port.saturating_add(offset);
-        match TcpListener::bind(("127.0.0.1", port)) {
-            Ok(listener) => return Ok((listener, port)),
-            Err(e) => {
-                last_err = Some(e);
-            }
+        if let Ok(listener) = TcpListener::bind(("127.0.0.1", port)) {
+            return Ok((listener, port));
         }
     }
-    let detail = last_err.map(|e| e.to_string()).unwrap_or_default();
-    let holder = identify_port_holder(preferred_port)
-        .map(|h| format!(" 佔用者: {}", h))
-        .unwrap_or_default();
+
     Err(format!(
-        "無法綁定 127.0.0.1:{}（ChatGPT 登入必須用這個 port，OAuth server 已固定註冊）。請關閉佔用它的程式後重試。{}（底層錯誤: {}）",
-        preferred_port, holder, detail,
+        "OAuth port range {}-{} all busy, please close other OAuth sessions and retry",
+        preferred_port,
+        preferred_port.saturating_add(max_attempts.saturating_sub(1)),
     ))
 }
 
-/// Best-effort lookup of which process is holding a local TCP port.
-/// Uses `netstat -ano` + `tasklist /FI "PID eq <pid>"` — both are
-/// always present on Windows, so no extra deps. Returns `None` if the
-/// port doesn't appear to be bound (e.g. TIME_WAIT from a previous run)
-/// or if either command fails.
-#[cfg(target_os = "windows")]
-fn identify_port_holder(port: u16) -> Option<String> {
-    use crate::utils::command::no_window;
-
-    let netstat = no_window("netstat").args(["-ano"]).output().ok()?;
-    if !netstat.status.success() {
-        return None;
-    }
-    let text = String::from_utf8_lossy(&netstat.stdout);
-    let needle = format!(":{} ", port);
-    let pid: &str = text.lines().find_map(|line| {
-        if !line.contains(&needle) || !line.contains("LISTENING") {
-            return None;
-        }
-        line.split_whitespace().last()
-    })?;
-
-    let tl = no_window("tasklist")
-        .args(["/FI", &format!("PID eq {}", pid), "/FO", "CSV", "/NH"])
-        .output()
-        .ok()?;
-    if !tl.status.success() {
-        return Some(format!("PID {}", pid));
-    }
-    let out = String::from_utf8_lossy(&tl.stdout);
-    let first = out.lines().next()?;
-    // CSV fields are quoted. First field is the image name.
-    let image = first
-        .split(',')
-        .next()?
-        .trim_matches('"')
-        .to_string();
-    if image.is_empty() {
-        Some(format!("PID {}", pid))
-    } else {
-        Some(format!("{} (PID {})", image, pid))
-    }
-}
-
-#[cfg(not(target_os = "windows"))]
-fn identify_port_holder(_port: u16) -> Option<String> {
-    // lsof-based identification on macOS/Linux could go here. Not wired
-    // up yet because the port-held-by-VS-Code case that motivated this
-    // is Windows-specific (dev extensions using the same port range).
-    None
-}
-
-fn listen_once(
-    app: AppHandle,
-    preferred_port: u16,
-    timeout_secs: u64,
-    max_attempts: u16,
-) -> Result<OAuthListenResult, String> {
-    let (listener, bound_port) = try_bind(preferred_port, max_attempts)?;
-    listener
-        .set_nonblocking(true)
-        .map_err(|e| e.to_string())?;
-
-    // Tell the frontend the actual bound port BEFORE we start waiting for
-    // a request, so it can build the redirect_uri against the right port
-    // and only then open the browser. Without this, a busy preferred port
-    // causes the browser to be sent to e.g. 1455 while the listener is on
-    // 1456 — the callback never reaches us.
-    if let Err(e) = app.emit(OAUTH_BOUND_EVENT, bound_port) {
-        eprintln!("[oauth] failed to emit bound event: {}", e);
-    }
-
+fn wait_for_code(listener: TcpListener, timeout_secs: u64) -> Result<OAuthCallback, String> {
+    listener.set_nonblocking(true).map_err(|e| e.to_string())?;
     let deadline = std::time::Instant::now() + Duration::from_secs(timeout_secs);
 
     loop {
@@ -190,15 +134,12 @@ fn listen_once(
                     .read_line(&mut request_line)
                     .map_err(|e| format!("read request line: {}", e))?;
 
-                // Request line looks like: "GET /auth/callback?... HTTP/1.1"
                 let path = request_line
                     .split_whitespace()
                     .nth(1)
-                    .map(|s| s.to_string())
-                    .ok_or_else(|| "malformed HTTP request line".to_string())?;
+                    .ok_or_else(|| "malformed HTTP request line".to_string())?
+                    .to_string();
 
-                // Drain the rest of the headers so the browser doesn't hang
-                // waiting for a half-read connection. We don't need them.
                 let mut junk = String::new();
                 while reader.read_line(&mut junk).map(|n| n > 2).unwrap_or(false) {
                     junk.clear();
@@ -214,16 +155,48 @@ fn listen_once(
                 let _ = out.write_all(response.as_bytes());
                 let _ = out.flush();
 
-                return Ok(OAuthListenResult {
-                    port: bound_port,
-                    path,
-                });
+                if let Some(error) = extract_query_param(&path, "error")? {
+                    return Err(format!("OAuth error: {}", error));
+                }
+
+                let code = extract_query_param(&path, "code")?
+                    .ok_or_else(|| "OAuth callback missing `code`".to_string())?;
+                let state = extract_query_param(&path, "state")?
+                    .ok_or_else(|| "OAuth callback missing `state`".to_string())?;
+
+                return Ok(OAuthCallback { code, state });
             }
             Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
                 std::thread::sleep(Duration::from_millis(100));
-                continue;
             }
             Err(e) => return Err(format!("accept failed: {}", e)),
         }
     }
+}
+
+fn extract_query_param(path: &str, key: &str) -> Result<Option<String>, String> {
+    let query = match path.split_once('?') {
+        Some((_, query)) => query,
+        None => return Ok(None),
+    };
+
+    for pair in query.split('&') {
+        let (raw_key, raw_value) = match pair.split_once('=') {
+            Some(parts) => parts,
+            None => (pair, ""),
+        };
+        if raw_key != key {
+            continue;
+        }
+
+        let decoded = urlencoding::decode(raw_value)
+            .map_err(|e| format!("decode query param `{}`: {}", key, e))?;
+        return Ok(Some(normalize_query_value(decoded)));
+    }
+
+    Ok(None)
+}
+
+fn normalize_query_value(value: Cow<'_, str>) -> String {
+    value.replace('+', " ")
 }

--- a/ClassNoteAI/src-tauri/src/recording/video_import.rs
+++ b/ClassNoteAI/src-tauri/src/recording/video_import.rs
@@ -142,20 +142,55 @@ fn locate_ffmpeg() -> Result<String, String> {
     #[cfg(target_os = "windows")]
     {
         if let Some(home) = dirs::home_dir() {
-            let winget_path = home.join(
+            let winget_root = home.join(
                 "AppData/Local/Microsoft/WinGet/Packages/\
-                 Gyan.FFmpeg_Microsoft.Winget.Source_8wekyb3d8bbwe/\
-                 ffmpeg-8.0.1-full_build/bin/ffmpeg.exe",
+                 Gyan.FFmpeg_Microsoft.Winget.Source_8wekyb3d8bbwe/",
             );
-            if winget_path.exists() {
-                return Ok(winget_path.to_string_lossy().into_owned());
+            if let Ok(entries) = std::fs::read_dir(&winget_root) {
+                let mut newest_dir: Option<(std::time::SystemTime, PathBuf)> = None;
+                for entry in entries.flatten() {
+                    let path = entry.path();
+                    let Some(name) = path.file_name().and_then(|n| n.to_str()) else {
+                        continue;
+                    };
+                    let matches_full = name.starts_with("ffmpeg-")
+                        && name.ends_with("-full_build")
+                        && name.len() > "ffmpeg-".len() + "-full_build".len();
+                    let matches_essentials = name.starts_with("ffmpeg-")
+                        && name.ends_with("-essentials_build")
+                        && name.len() > "ffmpeg-".len() + "-essentials_build".len();
+                    if !(matches_full || matches_essentials) {
+                        continue;
+                    }
+                    let Ok(metadata) = entry.metadata() else {
+                        continue;
+                    };
+                    if !metadata.is_dir() {
+                        continue;
+                    }
+                    let Ok(modified) = metadata.modified() else {
+                        continue;
+                    };
+                    match &newest_dir {
+                        Some((best_modified, _)) if modified <= *best_modified => {}
+                        _ => newest_dir = Some((modified, path)),
+                    }
+                }
+                if let Some((_, chosen_dir)) = newest_dir {
+                    let winget_path = chosen_dir.join("bin/ffmpeg.exe");
+                    if winget_path.exists() {
+                        return Ok(winget_path.to_string_lossy().into_owned());
+                    }
+                }
             }
         }
     }
 
     Err(
-        "ffmpeg 未安裝或不在 PATH 中。\
-         請從 https://ffmpeg.org/download.html 下載後重新啟動應用程式。"
+        "ffmpeg was not found on PATH or in standard install locations. \
+         Install it from https://ffmpeg.org/download.html and restart the application after installing. \
+         (ffmpeg 未安裝、不在 PATH 中，或不在標準安裝位置。\
+         請從 https://ffmpeg.org/download.html 下載安裝後重新啟動應用程式。)"
             .to_string(),
     )
 }

--- a/ClassNoteAI/src-tauri/src/recording/video_import.rs
+++ b/ClassNoteAI/src-tauri/src/recording/video_import.rs
@@ -18,7 +18,8 @@ use serde::{Deserialize, Serialize};
 use std::fs::File;
 use std::io::{BufWriter, Read, Seek, SeekFrom, Write};
 use std::path::{Path, PathBuf};
-use std::process::{Command, Stdio};
+use crate::utils::command::no_window;
+use std::process::Stdio;
 use tokio::sync::Mutex as TokioMutex;
 
 use crate::whisper::WhisperService;
@@ -48,7 +49,7 @@ pub fn extract_pcm_16k_mono(video_path: &Path) -> Result<Vec<i16>, String> {
 
     let ffmpeg = locate_ffmpeg()?;
 
-    let mut child = Command::new(&ffmpeg)
+    let mut child = no_window(&ffmpeg)
         // Suppress the extremely verbose default banner; keep warnings/errors.
         .args([
             "-hide_banner",
@@ -126,7 +127,7 @@ fn locate_ffmpeg() -> Result<String, String> {
     // Fast path: PATH lookup via `which`-equivalent. `ffmpeg` alone
     // works on every shell that has it resolvable, so we just try to
     // spawn it with `-version` to see if it's there.
-    let probe = Command::new("ffmpeg")
+    let probe = no_window("ffmpeg")
         .arg("-version")
         .stdout(Stdio::null())
         .stderr(Stdio::null())
@@ -271,7 +272,7 @@ fn extract_pcm_to_file(video_path: &Path, pcm_path: &Path) -> Result<u64, String
         .map_err(|e| format!("failed to create pcm file: {}", e))?;
     let mut writer = BufWriter::with_capacity(1024 * 1024, output);
 
-    let mut child = Command::new(&ffmpeg)
+    let mut child = no_window(&ffmpeg)
         .args(["-hide_banner", "-loglevel", "error", "-i"])
         .arg(video_path)
         .args(["-ac", "1", "-ar", "16000", "-f", "s16le", "-y", "-"])

--- a/ClassNoteAI/src-tauri/src/setup/mod.rs
+++ b/ClassNoteAI/src-tauri/src/setup/mod.rs
@@ -83,7 +83,9 @@ pub async fn save_setup_status(complete: bool) -> Result<(), String> {
             "version": env!("CARGO_PKG_VERSION"),
         });
 
-        std::fs::write(&status_file, serde_json::to_string_pretty(&status).unwrap())
+        let payload = serde_json::to_string_pretty(&status)
+            .map_err(|e| format!("Failed to serialize setup status: {}", e))?;
+        std::fs::write(&status_file, payload)
             .map_err(|e| format!("Failed to save setup status: {}", e))?;
     } else {
         // Remove the status file to mark as incomplete

--- a/ClassNoteAI/src-tauri/src/setup/requirements.rs
+++ b/ClassNoteAI/src-tauri/src/setup/requirements.rs
@@ -5,9 +5,9 @@
  * - System: Homebrew, CMake, FFmpeg
  * - Models: Whisper, CTranslate2 translation model
  */
+use crate::utils::command::no_window;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
-use std::process::Command;
 
 /// Requirement category
 #[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
@@ -68,7 +68,7 @@ pub struct Requirement {
 pub fn check_os_version() -> RequirementStatus {
     #[cfg(target_os = "macos")]
     {
-        match Command::new("sw_vers").arg("-productVersion").output() {
+        match no_window("sw_vers").arg("-productVersion").output() {
             Ok(output) => {
                 if output.status.success() {
                     let version = String::from_utf8_lossy(&output.stdout).trim().to_string();
@@ -100,7 +100,7 @@ pub fn check_os_version() -> RequirementStatus {
         // Minimum: Windows 10 1809 (build 17763) — WebView2 baseline.
         const MIN_BUILD: u32 = 17763;
 
-        match Command::new("cmd").args(["/c", "ver"]).output() {
+        match no_window("cmd").args(["/c", "ver"]).output() {
             Ok(output) => {
                 if !output.status.success() {
                     return RequirementStatus::Error(
@@ -166,7 +166,7 @@ pub fn check_os_version() -> RequirementStatus {
 pub fn check_disk_space(required_mb: u64) -> RequirementStatus {
     #[cfg(target_os = "macos")]
     {
-        match Command::new("df").args(["-m", "/"]).output() {
+        match no_window("df").args(["-m", "/"]).output() {
             Ok(output) => {
                 if output.status.success() {
                     let output_str = String::from_utf8_lossy(&output.stdout);
@@ -234,7 +234,7 @@ pub fn check_disk_space(required_mb: u64) -> RequirementStatus {
         // and -File, and cleanly sidesteps any interpretation of
         // backticks / $ / apostrophes that might appear in a Windows
         // path with an unusual username.
-        match Command::new("powershell")
+        match no_window("powershell")
             .args([
                 "-NoProfile",
                 "-NonInteractive",

--- a/ClassNoteAI/src-tauri/src/storage/database.rs
+++ b/ClassNoteAI/src-tauri/src/storage/database.rs
@@ -40,7 +40,31 @@ pub struct Database {
 impl Database {
     /// 初始化數據庫連接
     pub fn new(db_path: &PathBuf) -> SqlResult<Self> {
-        let conn = Connection::open(db_path)?;
+        const MAX_ATTEMPTS: u32 = 3;
+        let mut conn = None;
+        let mut last_error = None;
+        for attempt in 1..=MAX_ATTEMPTS {
+            match Connection::open(db_path) {
+                Ok(opened_conn) => {
+                    conn = Some(opened_conn);
+                    break;
+                }
+                Err(e) => {
+                    eprintln!(
+                        "[Database] open attempt {}/{} failed: {}",
+                        attempt, MAX_ATTEMPTS, e
+                    );
+                    if attempt < MAX_ATTEMPTS {
+                        std::thread::sleep(std::time::Duration::from_millis(500));
+                    }
+                    last_error = Some(e);
+                }
+            };
+        }
+        let conn = match conn {
+            Some(conn) => conn,
+            None => return Err(last_error.expect("database open failed without an error")),
+        };
         let db = Database { conn };
         db.init_tables()?;
         Ok(db)

--- a/ClassNoteAI/src-tauri/src/translation/ctranslate2.rs
+++ b/ClassNoteAI/src-tauri/src/translation/ctranslate2.rs
@@ -9,6 +9,8 @@ use ct2rs::tokenizers::sentencepiece::Tokenizer as SentencePieceTokenizer;
  * needs to be configured with the correct source/target languages via
  * tokenizer_config.json or the source.spm/target.spm files.
  */
+#[cfg(feature = "gpu-cuda")]
+use ct2rs::Device;
 use ct2rs::{BatchType, Config, TranslationOptions, Translator};
 use std::path::Path;
 use std::sync::Arc;
@@ -41,8 +43,30 @@ impl CT2Translator {
             return Err(format!("Model path does not exist: {}", model_path));
         }
 
-        // Create translator with default config
+        // Create translator config. When the binary was compiled with
+        // `gpu-cuda`, we probe for a usable CUDA runtime before asking
+        // ct2rs for a CUDA device — `cuda-dynamic-loading` still works
+        // even if cudart is absent at runtime (falls back to CPU), but
+        // checking up-front keeps the log message honest and avoids
+        // ct2rs's generic error if things go sideways.
+        #[cfg(feature = "gpu-cuda")]
+        let mut config: Config = Default::default();
+        #[cfg(not(feature = "gpu-cuda"))]
         let config: Config = Default::default();
+
+        #[cfg(feature = "gpu-cuda")]
+        {
+            let det = crate::gpu::detect(Some("auto"));
+            if det.cuda.is_some() {
+                config.device = Device::CUDA;
+                println!(
+                    "[CT2] CUDA detected ({}), using Device::CUDA",
+                    det.cuda.as_ref().unwrap().gpu_name
+                );
+            } else {
+                println!("[CT2] No CUDA at runtime — using Device::CPU");
+            }
+        }
 
         // Find SentencePiece model file
         let sp_model_path = Path::new(model_path).join("sentencepiece.bpe.model");

--- a/ClassNoteAI/src-tauri/src/translation/ctranslate2.rs
+++ b/ClassNoteAI/src-tauri/src/translation/ctranslate2.rs
@@ -77,15 +77,44 @@ impl CT2Translator {
             ));
         }
 
-        // Initialize Tokenizer
-        // Note: SentencePieceTokenizer::from_file expects (model_path, vocab_path).
-        // For M2M100, we pass the model path for both as the vocab is typically embedded or handled by the model file.
-        let tokenizer = SentencePieceTokenizer::from_file(&sp_model_path, &sp_model_path)
-            .map_err(|e| format!("Failed to load tokenizer: {}", e))?;
+        // Tokenizer is consumed by `with_tokenizer`, so a CUDA→CPU retry
+        // needs a fresh one. A closure keeps both construction sites in
+        // one place. SentencePieceTokenizer::from_file expects
+        // (model_path, vocab_path); for M2M100 the same file serves both.
+        let make_tokenizer = || {
+            SentencePieceTokenizer::from_file(&sp_model_path, &sp_model_path)
+                .map_err(|e| format!("Failed to load tokenizer: {}", e))
+        };
 
-        // Initialize Translator with tokenizer
-        let translator = Translator::with_tokenizer(&model_path, tokenizer, &config)
-            .map_err(|e| format!("Failed to load CT2 model: {}", e))?;
+        // Try loading with whatever device `config` picked above. If the
+        // first attempt was on CUDA and it blew up (typical causes:
+        // driver < CUDA runtime, cudart DLL missing at runtime even with
+        // `cuda-dynamic-loading`, or a stale kernel cache), retry once
+        // on CPU. We log but don't surface the switch — the product
+        // directive is "use GPU when possible, stay quiet when it
+        // can't." Only fail the command when the CPU attempt also fails.
+        let first_tokenizer = make_tokenizer()?;
+        let first_attempt = Translator::with_tokenizer(&model_path, first_tokenizer, &config);
+
+        let translator = match first_attempt {
+            Ok(t) => t,
+            #[cfg(feature = "gpu-cuda")]
+            Err(e) if matches!(config.device, Device::CUDA) => {
+                println!("[CT2] CUDA load failed ({}), retrying on CPU", e);
+                let mut cpu_config: Config = Default::default();
+                cpu_config.device = Device::CPU;
+                let cpu_tokenizer = make_tokenizer()?;
+                Translator::with_tokenizer(&model_path, cpu_tokenizer, &cpu_config).map_err(
+                    |err| {
+                        format!(
+                            "Failed to load CT2 model: CUDA load errored ({}) and CPU fallback also failed ({})",
+                            e, err
+                        )
+                    },
+                )?
+            }
+            Err(e) => return Err(format!("Failed to load CT2 model: {}", e)),
+        };
 
         self.translator = Some(Arc::new(translator));
         self.model_path = Some(model_path.to_string());

--- a/ClassNoteAI/src-tauri/src/utils/command.rs
+++ b/ClassNoteAI/src-tauri/src/utils/command.rs
@@ -1,0 +1,37 @@
+//! Subprocess helpers that hide the console window on Windows.
+//!
+//! Release binaries run without an attached console, so every
+//! `std::process::Command::new(...)` call on Windows briefly flashes
+//! a cmd window when the child launches — users see a black square
+//! blink every time the app shells out to `nvidia-smi`, `ffmpeg`,
+//! `netstat`, `soffice`, etc. The fix is to pass `CREATE_NO_WINDOW`
+//! (0x08000000) via `CommandExt::creation_flags` on Windows only;
+//! other OSes don't have this behavior and the method isn't available.
+//!
+//! Usage: `utils::command::no_window("nvidia-smi")` returns a
+//! ready-to-configure `Command` with the flag applied (or an
+//! untouched `Command` on non-Windows). Continue with `.args(...)`,
+//! `.output()`, `.spawn()` as usual.
+
+use std::process::Command;
+
+#[cfg(windows)]
+const CREATE_NO_WINDOW: u32 = 0x0800_0000;
+
+/// Construct a `Command` that won't pop a console on Windows.
+pub fn no_window<S: AsRef<std::ffi::OsStr>>(program: S) -> Command {
+    let cmd = Command::new(program);
+    apply_no_window(cmd)
+}
+
+/// Apply the no-window creation flag to an existing `Command`
+/// (useful when the caller built the `Command` with a resolved
+/// path / env / etc. before handing off).
+pub fn apply_no_window(#[allow(unused_mut)] mut cmd: Command) -> Command {
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::CommandExt;
+        cmd.creation_flags(CREATE_NO_WINDOW);
+    }
+    cmd
+}

--- a/ClassNoteAI/src-tauri/src/utils/mod.rs
+++ b/ClassNoteAI/src-tauri/src/utils/mod.rs
@@ -1,2 +1,3 @@
+pub mod command;
 pub mod onnx;
 pub mod sys_proxy;

--- a/ClassNoteAI/src-tauri/src/utils/sys_proxy.rs
+++ b/ClassNoteAI/src-tauri/src/utils/sys_proxy.rs
@@ -68,9 +68,9 @@ pub fn apply_system_proxy_env() {
 
 #[cfg(target_os = "windows")]
 fn read_reg_value(path: &str, name: &str) -> Option<String> {
-    use std::process::Command;
+    use crate::utils::command::no_window;
 
-    let output = Command::new("reg")
+    let output = no_window("reg")
         .args(["query", path, "/v", name])
         .output()
         .ok()?;

--- a/ClassNoteAI/src-tauri/src/whisper/transcribe.rs
+++ b/ClassNoteAI/src-tauri/src/whisper/transcribe.rs
@@ -125,7 +125,8 @@ pub async fn transcribe_audio(
         }
     }
     params.set_suppress_blank(true); // 抑制空白
-    params.set_suppress_non_speech_tokens(true); // 抑制非語音標記
+    // whisper-rs 0.16 renamed `set_suppress_non_speech_tokens` → `set_suppress_nst`.
+    params.set_suppress_nst(true); // 抑制非語音標記
 
     // 設置初始提示（如果提供）
     if let Some(prompt) = initial_prompt {
@@ -189,41 +190,32 @@ pub async fn transcribe_audio(
     let duration_ms = start_time.elapsed().as_millis() as u64;
     println!("[Whisper] 轉錄完成，耗時: {}ms", duration_ms);
 
-    // 獲取轉錄結果
-    let num_segments = state
-        .full_n_segments()
-        .map_err(|e| anyhow::anyhow!("獲取片段數量失敗: {:?}", e))?;
+    // 獲取轉錄結果。whisper-rs 0.16 重構了 segment API：
+    //   - `full_n_segments()` 現在直接回傳 `c_int`（不再是 Result）
+    //   - 用 `get_segment(i) -> Option<WhisperSegment>` 取段落物件
+    //   - 文字: `seg.to_str()`，時間: `seg.start_timestamp()` /
+    //     `seg.end_timestamp()` 皆回傳 centiseconds (i64)
+    let num_segments = state.full_n_segments();
+    let _ = sample_rate; // 單位轉換與 sample_rate 無關（見下）
 
     let mut segments = Vec::new();
     let mut full_text = String::new();
 
     for i in 0..num_segments {
-        let segment_text = state
-            .full_get_segment_text(i)
-            .map_err(|e| anyhow::anyhow!("獲取片段文本失敗: {:?}", e))?;
+        let seg = state
+            .get_segment(i)
+            .ok_or_else(|| anyhow::anyhow!("獲取片段 {} 失敗", i))?;
 
-        let start_timestamp = state
-            .full_get_segment_t0(i)
-            .map_err(|e| anyhow::anyhow!("獲取片段開始時間失敗: {:?}", e))?;
+        let segment_text = seg
+            .to_str_lossy()
+            .map_err(|e| anyhow::anyhow!("獲取片段文本失敗: {:?}", e))?
+            .into_owned();
 
-        let end_timestamp = state
-            .full_get_segment_t1(i)
-            .map_err(|e| anyhow::anyhow!("獲取片段結束時間失敗: {:?}", e))?;
-
-        // whisper.cpp's `full_get_segment_t{0,1}` return values in
-        // **centiseconds** (10 ms units) — not sample indices. The
-        // old code `(t * 1000) / sample_rate` treated them as samples
-        // at 16 kHz, which compressed every segment's timestamp to
-        // ~1/16 of its true value and clumped all subtitles at the
-        // start of each chunk (the user-visible "字幕只有分鐘級別
-        // 精度" symptom).
-        //
-        // `sample_rate` is intentionally dropped from the math here —
-        // the unit conversion is purely t_cs * 10 = t_ms, independent
-        // of the input audio's sample rate.
-        let _ = sample_rate;
-        let start_ms = (start_timestamp * 10) as i64;
-        let end_ms = (end_timestamp * 10) as i64;
+        // Centiseconds → milliseconds: × 10. Independent of sample rate.
+        // Pre-0.6.0 bug here treated these as sample indices and
+        // divided by sample_rate; see commit 05d000b.
+        let start_ms = (seg.start_timestamp() * 10) as i64;
+        let end_ms = (seg.end_timestamp() * 10) as i64;
 
         segments.push(TranscriptionSegment {
             text: segment_text.trim().to_string(),
@@ -234,7 +226,7 @@ pub async fn transcribe_audio(
         if !full_text.is_empty() {
             full_text.push(' ');
         }
-        full_text.push_str(&segment_text.trim());
+        full_text.push_str(segment_text.trim());
     }
 
     // 使用設置的語言

--- a/ClassNoteAI/src-tauri/tauri.conf.json
+++ b/ClassNoteAI/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ClassNoteAI",
-  "version": "0.5.3",
+  "version": "0.6.0-alpha.1",
   "identifier": "com.classnoteai",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/ClassNoteAI/src-tauri/tauri.conf.json
+++ b/ClassNoteAI/src-tauri/tauri.conf.json
@@ -51,7 +51,9 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ],
-    "resources": [],
+    "resources": {
+      "resources/cuda/*": "./"
+    },
     "macOS": {
       "entitlements": null,
       "exceptionDomain": "",

--- a/ClassNoteAI/src-tauri/tauri.conf.json
+++ b/ClassNoteAI/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ClassNoteAI",
-  "version": "0.6.0-alpha.2",
+  "version": "0.6.0-alpha.3",
   "identifier": "com.classnoteai",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/ClassNoteAI/src-tauri/tauri.conf.json
+++ b/ClassNoteAI/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ClassNoteAI",
-  "version": "0.6.0-alpha.1",
+  "version": "0.6.0-alpha.2",
   "identifier": "com.classnoteai",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/ClassNoteAI/src-tauri/tauri.conf.json
+++ b/ClassNoteAI/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ClassNoteAI",
-  "version": "0.6.0-alpha.3",
+  "version": "0.6.0-alpha.4",
   "identifier": "com.classnoteai",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/ClassNoteAI/src-tauri/vendor-patches/ct2rs-cmakelists.patch
+++ b/ClassNoteAI/src-tauri/vendor-patches/ct2rs-cmakelists.patch
@@ -9,3 +9,25 @@
    endif()
    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} /W4 /d2FH4-")
  else()
+@@ -465,11 +465,16 @@
+   include_directories(${CUDA_TOOLKIT_ROOT_DIR}/include)
+
+   add_definitions(-DCT2_WITH_CUDA)
+   if(MSVC)
+-    if(BUILD_SHARED_LIBS)
+-      list(APPEND CUDA_NVCC_FLAGS "-Xcompiler=/MD$<$<CONFIG:Debug>:d>")
+-    else()
+-      list(APPEND CUDA_NVCC_FLAGS "-Xcompiler=/MT$<$<CONFIG:Debug>:d>")
+-    endif()
++    # Force /MD regardless of BUILD_SHARED_LIBS. ct2rs ships as a static
++    # lib into Rust (BUILD_SHARED_LIBS=OFF), but line 90 above pinned
++    # CMAKE_MSVC_RUNTIME_LIBRARY to MultiThreadedDLL (/MD) for the rest
++    # of the C++ compile. The original `if(BUILD_SHARED_LIBS)` branch
++    # here emits /MT for the CUDA `.cu.obj` files only, causing
++    # LNK2038 RuntimeLibrary mismatch against (a) ct2rs's own non-CUDA
++    # code and (b) whisper-rs-sys + Rust stdlib (both /MD). Unifying
++    # on /MD across the whole binary is correct — the linker then has
++    # a single CRT to link.
++    list(APPEND CUDA_NVCC_FLAGS "-Xcompiler=/MD$<$<CONFIG:Debug>:d>")
+   endif()
+   list(APPEND CUDA_NVCC_FLAGS "-std=c++17")

--- a/ClassNoteAI/src/components/AIChatPanel.tsx
+++ b/ClassNoteAI/src/components/AIChatPanel.tsx
@@ -61,7 +61,8 @@ export default function AIChatPanel({
     const [showSessions, setShowSessions] = useState(false);
 
     // 視窗位置和大小
-    const [position, setPosition] = useState({ x: window.innerWidth - DEFAULT_WIDTH - 20, y: 100 });
+    const getDefaultPosition = () => ({ x: window.innerWidth - DEFAULT_WIDTH - 20, y: 100 });
+    const [position, setPosition] = useState(getDefaultPosition);
     const [size, setSize] = useState({ width: DEFAULT_WIDTH, height: DEFAULT_HEIGHT });
 
     const messagesEndRef = useRef<HTMLDivElement>(null);
@@ -156,7 +157,7 @@ export default function AIChatPanel({
             const dy = e.clientY - dragRef.current.startY;
             setPosition({
                 x: Math.max(0, Math.min(window.innerWidth - size.width, dragRef.current.startPosX + dx)),
-                y: Math.max(0, Math.min(window.innerHeight - 100, dragRef.current.startPosY + dy)),
+                y: Math.max(0, Math.min(window.innerHeight - size.height, dragRef.current.startPosY + dy)),
             });
         }
         if (resizeRef.current.isResizing) {
@@ -167,11 +168,15 @@ export default function AIChatPanel({
                 height: Math.max(MIN_HEIGHT, resizeRef.current.startHeight + dy),
             });
         }
-    }, [size.width]);
+    }, [size.height, size.width]);
 
     const handleMouseUp = useCallback(() => {
         dragRef.current.isDragging = false;
         resizeRef.current.isResizing = false;
+    }, []);
+
+    const handleResetPosition = useCallback(() => {
+        setPosition(getDefaultPosition());
     }, []);
 
     useEffect(() => {
@@ -447,6 +452,16 @@ export default function AIChatPanel({
                     >
                         <History className="w-3 h-3" />
                     </button>
+                    {isFloating && (
+                        <button
+                            onClick={handleResetPosition}
+                            aria-label={'\u91cd\u7f6e\u4f4d\u7f6e'}
+                            className="p-1 hover:bg-white/20 rounded transition-colors text-white"
+                            title={'\u91cd\u7f6e\u4f4d\u7f6e'}
+                        >
+                            <Maximize2 className="w-3 h-3" />
+                        </button>
+                    )}
                     {isFloating && (
                         <button
                             onClick={() => setIsMinimized(!isMinimized)}

--- a/ClassNoteAI/src/components/ImportModal.tsx
+++ b/ClassNoteAI/src/components/ImportModal.tsx
@@ -1,6 +1,7 @@
-import { useRef, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { Film, ClipboardPaste, X, Loader2, ArrowLeft } from 'lucide-react';
 import { useTauriFileDrop } from '../hooks/useTauriFileDrop';
+import { storageService } from '../services/storageService';
 
 /**
  * v0.6.0 — unified "匯入" entry point for the Notes view.
@@ -73,6 +74,25 @@ export default function ImportModal({
     const [videoQuality, setVideoQuality] = useState<VideoQuality>('fast');
     const [refineWithAI, setRefineWithAI] = useState(false);
     const modalRef = useRef<HTMLDivElement>(null);
+
+    // Load user's experimental-settings defaults once per mount. The
+    // modal is mounted once and stays resident across opens, so a
+    // single read covers the lifetime. Changing defaults in Settings
+    // only takes effect on the next app load — intentional; we don't
+    // want a settings change to silently overwrite a user's mid-modal
+    // picks if they had it open at the time.
+    useEffect(() => {
+        (async () => {
+            try {
+                const s = await storageService.getAppSettings();
+                const exp = s?.experimental;
+                if (exp?.importSpeed) setVideoQuality(exp.importSpeed as VideoQuality);
+                if (typeof exp?.importAiRefine === 'boolean') setRefineWithAI(exp.importAiRefine);
+            } catch {
+                /* stick with hardcoded defaults */
+            }
+        })();
+    }, []);
 
     // Modal is its own drop zone — takes priority over the NotesView
     // drop zone below it because elementFromPoint returns the topmost

--- a/ClassNoteAI/src/components/NotesView.tsx
+++ b/ClassNoteAI/src/components/NotesView.tsx
@@ -1681,7 +1681,8 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
               const relativeTime = Math.max(0, section.timestamp - baseTime);
               const minutes = Math.floor(relativeTime / 60);
               const seconds = Math.floor(relativeTime % 60);
-              markdown += `*時間戳: ${minutes}:${seconds.toString().padStart(2, '0')}*\n\n`;
+              const centis = Math.floor((relativeTime % 1) * 100);
+              markdown += `*時間戳: ${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}.${centis.toString().padStart(2, '0')}*\n\n`;
             }
           });
         }
@@ -1697,7 +1698,8 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
               const relativeTime = Math.max(0, qa.timestamp - baseTime);
               const minutes = Math.floor(relativeTime / 60);
               const seconds = Math.floor(relativeTime % 60);
-              markdown += `*時間戳: ${minutes}:${seconds.toString().padStart(2, '0')}*\n\n`;
+              const centis = Math.floor((relativeTime % 1) * 100);
+              markdown += `*時間戳: ${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}.${centis.toString().padStart(2, '0')}*\n\n`;
             }
           });
         }
@@ -2236,7 +2238,7 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
                                             onClick={() => handleSeek(relativeTime)}
                                             className="text-xs text-blue-500 hover:text-blue-600 opacity-0 group-hover:opacity-100 transition-opacity"
                                           >
-                                            {Math.floor(relativeTime / 60)}:{Math.floor(relativeTime % 60).toString().padStart(2, '0')}
+                                            {Math.floor(relativeTime / 60).toString().padStart(2, '0')}:{Math.floor(relativeTime % 60).toString().padStart(2, '0')}.{Math.floor((relativeTime % 1) * 100).toString().padStart(2, '0')}
                                           </button>
                                         );
                                       })()}

--- a/ClassNoteAI/src/components/NotesView.tsx
+++ b/ClassNoteAI/src/components/NotesView.tsx
@@ -67,6 +67,65 @@ interface NotesViewProps {
   onBack?: () => void;
 }
 
+type AudioUnavailableState = {
+  message: string;
+  path?: string;
+};
+
+const ABSOLUTE_PATH_PATTERN = /^(?:[A-Za-z]:[\\/]|\\\\|\/)/;
+
+function stripLeadingPathSeparators(value: string): string {
+  return value.replace(/^[\\/]+/, '');
+}
+
+function stripTrailingPathSeparators(value: string): string {
+  return value.replace(/[\\/]+$/, '');
+}
+
+function normalizePathSeparators(value: string): string {
+  return value.replace(/[\\/]+/g, '/');
+}
+
+function joinAudioPath(baseDir: string, childPath: string): string {
+  const separator = baseDir.includes('\\') ? '\\' : '/';
+  const normalizedChild = stripLeadingPathSeparators(childPath).replace(/[\\/]+/g, separator);
+  return `${stripTrailingPathSeparators(baseDir)}${separator}${normalizedChild}`;
+}
+
+function toRelativeAudioPath(audioDir: string, absolutePath: string): string {
+  const normalizedDir = normalizePathSeparators(stripTrailingPathSeparators(audioDir));
+  const normalizedPath = normalizePathSeparators(absolutePath);
+
+  if (normalizedPath.startsWith(`${normalizedDir}/`)) {
+    return normalizedPath.slice(normalizedDir.length + 1);
+  }
+
+  const filename = absolutePath.split(/[\\/]/).pop();
+  return filename && filename.length > 0 ? filename : absolutePath;
+}
+
+async function resolveAudioPath(storedPath: string | null | undefined): Promise<string | null> {
+  if (!storedPath) {
+    return null;
+  }
+
+  const trimmedPath = storedPath.trim();
+  if (!trimmedPath) {
+    return null;
+  }
+
+  const resolvedPath = ABSOLUTE_PATH_PATTERN.test(trimmedPath)
+    ? trimmedPath
+    : joinAudioPath(await invoke<string>('get_audio_dir'), trimmedPath);
+
+  try {
+    await readFile(resolvedPath);
+    return resolvedPath;
+  } catch {
+    return null;
+  }
+}
+
 export default function NotesView({ courseId: propCourseId, lectureId: propLectureId, onBack }: NotesViewProps) {
   const navigate = useNavigate();
   const params = useParams<{ courseId: string; lectureId: string }>();
@@ -239,6 +298,7 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
   const [audioCurrentTime, setAudioCurrentTime] = useState(0);
   const [audioDuration, setAudioDuration] = useState(0);
   const [isPlaying, setIsPlaying] = useState(false);
+  const [audioUnavailable, setAudioUnavailable] = useState<AudioUnavailableState | null>(null);
   // v0.6.0: `audioRef` is now HTMLMediaElement so the same ref can
   // point at either the hidden <audio> (live-recorded lecture) or the
   // visible <video> (imported video lecture). All existing playback
@@ -247,41 +307,89 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
   const audioRef = useRef<HTMLMediaElement>(null);
   const [playbackVolume, setPlaybackVolume] = useState(100); // Output volume for playback
 
+  useEffect(() => {
+    setAudioUnavailable(null);
+  }, [currentLectureData?.id, currentLectureData?.audio_path]);
+
   // Initialize audio when review mode starts or lecture loads
   // Initialize audio when review mode starts or lecture loads
   useEffect(() => {
+    let cancelled = false;
     let objectUrl: string | null = null;
 
     const loadAudio = async () => {
-      if (viewMode === 'review' && currentLectureData?.audio_path && audioRef.current) {
-        try {
-          console.log('[NotesView] Loading audio file:', currentLectureData.audio_path);
-          // Use readFile from plugin-fs to bypass asset protocol issues
-          const data = await readFile(currentLectureData.audio_path);
-          const blob = new Blob([data], { type: 'audio/wav' }); // Default to wav as per recorder
-          objectUrl = URL.createObjectURL(blob);
+      if (viewMode !== 'review' || currentLectureData?.video_path || !audioRef.current) {
+        return;
+      }
 
-          if (audioRef.current) {
-            audioRef.current.src = objectUrl;
-            audioRef.current.load();
-            console.log('[NotesView] Audio loaded via Blob URL');
-          }
-        } catch (error) {
-          console.error('[NotesView] Failed to load audio file:', error);
-          // Fallback to convertFileSrc if readFile fails (e.g. permission error but assuming asset protocol works?)
-          // But since asset URL is failing, better to just log error.
+      const storedAudioPath = currentLectureData?.audio_path?.trim() || null;
+      const clearAudioElement = () => {
+        if (audioRef.current) {
+          audioRef.current.pause();
+          audioRef.current.removeAttribute('src');
+          audioRef.current.load();
         }
+        setIsPlaying(false);
+        setAudioCurrentTime(0);
+        setAudioDuration(0);
+      };
+
+      const resolvedAudioPath = await resolveAudioPath(storedAudioPath);
+      if (cancelled) {
+        return;
+      }
+
+      if (!storedAudioPath) {
+        clearAudioElement();
+        setAudioUnavailable({ message: '此課堂未錄製音檔。' });
+        return;
+      }
+
+      if (!resolvedAudioPath) {
+        clearAudioElement();
+        setAudioUnavailable({
+          message: '音檔遺失，無法播放。',
+          path: storedAudioPath,
+        });
+        return;
+      }
+
+      try {
+        console.log('[NotesView] Loading audio file:', resolvedAudioPath);
+        // Use readFile from plugin-fs to bypass asset protocol issues
+        const data = await readFile(resolvedAudioPath);
+        if (cancelled) {
+          return;
+        }
+
+        const blob = new Blob([data], { type: 'audio/wav' }); // Default to wav as per recorder
+        objectUrl = URL.createObjectURL(blob);
+
+        if (audioRef.current) {
+          audioRef.current.src = objectUrl;
+          audioRef.current.load();
+          setAudioUnavailable(null);
+          console.log('[NotesView] Audio loaded via Blob URL');
+        }
+      } catch (error) {
+        console.error('[NotesView] Failed to load audio file:', error);
+        clearAudioElement();
+        setAudioUnavailable({
+          message: '音檔遺失，無法播放。',
+          path: resolvedAudioPath,
+        });
       }
     };
 
     loadAudio();
 
     return () => {
+      cancelled = true;
       if (objectUrl) {
         URL.revokeObjectURL(objectUrl);
       }
     };
-  }, [viewMode, currentLectureData?.audio_path]);
+  }, [viewMode, currentLectureData?.audio_path, currentLectureData?.video_path]);
 
   const togglePlay = () => {
     if (audioRef.current) {
@@ -1166,7 +1274,7 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
       // keep a stale reference than nuke it to null).
       const updatedLecture = {
         ...currentLectureData,
-        audio_path: audioPath ?? currentLectureData.audio_path,
+        audio_path: audioPath ? toRelativeAudioPath(audioDir, audioPath) : currentLectureData.audio_path,
         status: 'completed' as const,
         updated_at: new Date().toISOString()
       };
@@ -2489,8 +2597,19 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
             </PanelGroup>
 
             {/* Audio Player Bar */}
-            {currentLectureData?.audio_path && (
+            {!currentLectureData?.video_path && (audioUnavailable || currentLectureData?.audio_path) && (
               <div>
+                {audioUnavailable ? (
+                  <div className="border-t border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900 dark:border-amber-800 dark:bg-amber-950/40 dark:text-amber-100">
+                    <p className="font-medium">{audioUnavailable.message}</p>
+                    {audioUnavailable.path && (
+                      <p className="mt-1 break-all font-mono text-xs text-amber-800 dark:text-amber-200">
+                        {audioUnavailable.path}
+                      </p>
+                    )}
+                  </div>
+                ) : (
+                  <>
                 {/* Auto Follow toggle — only shown in Review mode. On
                     enables PDF + subtitle sync to current playback
                     timestamp; off is plain audio playback. */}
@@ -2538,6 +2657,8 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
                   onVolumeChange={setPlaybackVolume}
                   onSkip={(sec) => handleSeek(audioCurrentTime + sec)}
                 />
+                  </>
+                )}
               </div>
             )}
 
@@ -2547,7 +2668,7 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
                 target switches based on `currentLectureData.video_path`
                 — all playback wiring (togglePlay / handleSeek /
                 subtitle sync) is media-type agnostic. */}
-            {!currentLectureData?.video_path && (
+            {!currentLectureData?.video_path && !audioUnavailable && (
               <audio
                 ref={audioRef as React.RefObject<HTMLAudioElement>}
                 onTimeUpdate={handleTimeUpdate}

--- a/ClassNoteAI/src/components/NotesView.tsx
+++ b/ClassNoteAI/src/components/NotesView.tsx
@@ -816,7 +816,10 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
               }
               const text = (sub.text_zh || sub.text_en || '').trim();
               if (text) currentSentences.push(text);
-              if (typeof sub.page_number === 'number') currentPages.push(sub.page_number);
+              // Subtitles don't carry page_number — that field lives on
+              // EmbeddingRow (chunks are page-aware after indexing). Leave
+              // page_range empty for now; a future pass can back-fill from
+              // embeddings once the RAG index has been built.
             }
           } else {
             for (const seg of inMemorySegments) {
@@ -942,6 +945,9 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
                 (a, b) => a.timestamp - b.timestamp,
               );
               const perSectionSentences: string[][] = [];
+              // page_range migration deferred — subtitles don't carry
+              // page_number (see auto-gen path comment). When we add an
+              // embedding-backed back-fill, slot it in here.
               const perSectionPages: number[][] = [];
               for (let i = 0; i < sorted.length; i++) {
                 const start = sorted[i].timestamp;
@@ -955,11 +961,7 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
                     .map((s) => (s.text_zh || s.text_en || '').trim())
                     .filter((t) => t),
                 );
-                perSectionPages.push(
-                  subsInSection
-                    .map((s) => s.page_number)
-                    .filter((p): p is number => typeof p === 'number'),
-                );
+                perSectionPages.push([]);
               }
 
               let bulletsPerSection: string[][] = [];

--- a/ClassNoteAI/src/components/NotesView.tsx
+++ b/ClassNoteAI/src/components/NotesView.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from "react";
+import { useState, useEffect, useRef, useCallback } from "react";
 import { invoke, convertFileSrc } from "@tauri-apps/api/core";
 import { readFile } from "@tauri-apps/plugin-fs";
 import { Download, ArrowLeft, Pencil, Cpu, Loader2, FileText, Mic, MicOff, Pause, Square, Save, BookOpen, FolderOpen, Wand2, Bot, Film } from "lucide-react";
@@ -1061,35 +1061,55 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
   // with subtitles + AI 助教 fully indexed.
   /** Reload subtitles from DB into subtitleService so the Review
    *  mode subtitle panel reflects progressive video-import progress.
-   *  Called from the import progress callback whenever a chunk has
-   *  just been saved — cheap enough (single SQLite query) to rerun
-   *  per chunk for a 70-min lecture (70 chunks). */
-  const reloadSubtitlesFromDb = async (lid: string) => {
+   *
+   *  v0.6.1 perf fix: uses `subtitleService.setSegments` (single
+   *  notify) instead of the old `clear() + addSegment × N` loop
+   *  (N+1 notifies, each triggering a full React re-render of the
+   *  subtitle panel). The import pipeline fires `subtitlesChanged`
+   *  up to 2× per chunk = ~140 refreshes on a 70-chunk lecture;
+   *  with 1000 segments total, the old path racked up ~140k
+   *  unnecessary re-renders.
+   *
+   *  Debounced at the callsite (`scheduleSubtitlesReload`) so
+   *  back-to-back chunks don't even queue redundant DB reads. */
+  const reloadSubtitlesFromDb = useCallback(async (lid: string) => {
     try {
       const subs = await storageService.getSubtitles(lid);
-      subtitleService.clear();
-      subtitleService.setLectureId(lid);
-      for (const sub of subs) {
-        subtitleService.addSegment({
-          id: sub.id,
-          roughText: sub.text_en,
-          roughTranslation: sub.text_zh,
-          displayText: sub.text_en,
-          displayTranslation: sub.text_zh,
-          startTime: sub.timestamp * 1000,
-          endTime: (sub.timestamp + 5) * 1000,
-          source: sub.type === 'fine' ? 'fine' : 'rough',
-          translationSource: sub.text_zh
-            ? (sub.type === 'fine' ? 'fine' : 'rough')
-            : undefined,
-          text: sub.text_en,
-          translatedText: sub.text_zh,
-        });
-      }
+      const segments = subs.map((sub) => ({
+        id: sub.id,
+        roughText: sub.text_en,
+        roughTranslation: sub.text_zh,
+        displayText: sub.text_en,
+        displayTranslation: sub.text_zh,
+        startTime: sub.timestamp * 1000,
+        endTime: (sub.timestamp + 5) * 1000,
+        source: (sub.type === 'fine' ? 'fine' : 'rough') as 'fine' | 'rough',
+        translationSource: (sub.text_zh
+          ? sub.type === 'fine'
+            ? ('fine' as const)
+            : ('rough' as const)
+          : undefined),
+        text: sub.text_en,
+        translatedText: sub.text_zh,
+      }));
+      subtitleService.setSegments(segments, lid);
     } catch (err) {
       console.warn('[NotesView] reloadSubtitlesFromDb failed:', err);
     }
-  };
+  }, []);
+
+  /** Coalesces rapid `subtitlesChanged` events into at most one
+   *  reload per 400 ms. Video import with fast transcribe + parallel
+   *  translate fires reload requests every 100-500 ms; without
+   *  coalescing the DB + React work stacks up and blocks paint. */
+  const reloadTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const scheduleSubtitlesReload = useCallback((lid: string) => {
+    if (reloadTimer.current) return; // already scheduled
+    reloadTimer.current = setTimeout(() => {
+      reloadTimer.current = null;
+      void reloadSubtitlesFromDb(lid);
+    }, 400);
+  }, [reloadSubtitlesFromDb]);
 
   const runVideoImport = async (
     sourcePath: string,
@@ -1116,17 +1136,25 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
             const fresh = await storageService.getLecture(lectureId);
             if (fresh) setCurrentLectureData(fresh);
             setIsImportModalOpen(false);
+            // Video import = the lecture is done recording. Switch to
+            // Notes Review and open the Subtitles/Audio tab, because
+            // the import's streaming caption updates happen there — the
+            // Notes tab is for post-hoc reading and would stay empty
+            // until loadLectureData runs at the end.
             setViewMode('review');
+            setActiveTab('subtitles');
             toastService.success(
               '影片已就緒',
               '可以開始觀看，字幕會隨轉錄逐步填入。',
             );
           }
           // A chunk just persisted new subtitles (or translations).
-          // Reload the in-memory subtitle set so the display updates
-          // without waiting for the whole pipeline to finish.
+          // Schedule a coalesced reload — on a fast transcribe run
+          // (GPU + base model) the pipeline fires this 2-3× per
+          // second, and running it synchronously here would block the
+          // JS thread on DB + re-render before the next chunk emits.
           if (p.subtitlesChanged) {
-            await reloadSubtitlesFromDb(lectureId);
+            scheduleSubtitlesReload(lectureId);
           }
         },
       });

--- a/ClassNoteAI/src/components/NotesView.tsx
+++ b/ClassNoteAI/src/components/NotesView.tsx
@@ -908,6 +908,110 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
             console.log('[NotesView] No sections generated, skipping note creation');
             setSelectedNote(null);
           }
+        } else if (note) {
+          // Existing Note path. v0.6.0 added bullets + page_range to
+          // the Section schema; Notes written before that are missing
+          // both fields and would render as "subtitle-like" walls of
+          // text (the very thing the bullets are meant to replace).
+          // Lazy-migrate on first Review-mode entry: if any section
+          // is missing bullets, rebuild per-section sentence arrays
+          // from the subtitle table, run one extract pass, and patch
+          // the Note in place. Title/content stay untouched so any
+          // user edits to headings or rewritten sections are
+          // preserved.
+          const sectionsMissingBullets = (note.sections || []).some(
+            (s) => !s.bullets || s.bullets.length === 0,
+          );
+          if (sectionsMissingBullets && subtitles.length > 0 && note.sections) {
+            console.log(
+              '[NotesView] Migrating existing Note: adding bullets to',
+              note.sections.filter((s) => !s.bullets || s.bullets.length === 0)
+                .length,
+              'of',
+              note.sections.length,
+              'sections',
+            );
+            setSelectedNote(note); // show the old view immediately while we re-derive
+
+            try {
+              // Re-derive sentence arrays by slicing subtitles into each
+              // section's time window. `section.timestamp` is the start;
+              // the next section's timestamp is the exclusive end.
+              // Sort defensively in case saved ordering drifted.
+              const sorted = [...note.sections].sort(
+                (a, b) => a.timestamp - b.timestamp,
+              );
+              const perSectionSentences: string[][] = [];
+              const perSectionPages: number[][] = [];
+              for (let i = 0; i < sorted.length; i++) {
+                const start = sorted[i].timestamp;
+                const end =
+                  i + 1 < sorted.length ? sorted[i + 1].timestamp : Infinity;
+                const subsInSection = subtitles.filter(
+                  (s) => s.timestamp >= start && s.timestamp < end,
+                );
+                perSectionSentences.push(
+                  subsInSection
+                    .map((s) => (s.text_zh || s.text_en || '').trim())
+                    .filter((t) => t),
+                );
+                perSectionPages.push(
+                  subsInSection
+                    .map((s) => s.page_number)
+                    .filter((p): p is number => typeof p === 'number'),
+                );
+              }
+
+              let bulletsPerSection: string[][] = [];
+              try {
+                bulletsPerSection = await invoke<string[][]>(
+                  'extract_section_highlights',
+                  { sections: perSectionSentences, topK: 3 },
+                );
+              } catch (e) {
+                console.warn(
+                  '[NotesView] Migration bullet extraction failed:',
+                  e,
+                );
+                bulletsPerSection = sorted.map(() => []);
+              }
+
+              const migratedSections = sorted.map((s, i) => {
+                const pages = perSectionPages[i] ?? [];
+                const page_range =
+                  pages.length > 0
+                    ? { min: Math.min(...pages), max: Math.max(...pages) }
+                    : null;
+                return {
+                  ...s,
+                  bullets:
+                    s.bullets && s.bullets.length > 0
+                      ? s.bullets
+                      : bulletsPerSection[i] ?? [],
+                  page_range: s.page_range ?? page_range,
+                };
+              });
+
+              const migratedNote: Note = { ...note, sections: migratedSections };
+              try {
+                await storageService.saveNote(migratedNote);
+                console.log(
+                  '[NotesView] Migration complete, Note resaved with bullets',
+                );
+              } catch (saveErr) {
+                console.warn(
+                  '[NotesView] Note save after migration failed; UI still updated:',
+                  saveErr,
+                );
+              }
+              setSelectedNote(migratedNote);
+            } catch (migErr) {
+              // Leave the existing Note showing — graceful degradation.
+              console.error('[NotesView] Note migration failed:', migErr);
+            }
+          } else {
+            setSelectedNote(note);
+          }
         } else {
           setSelectedNote(note);
         }

--- a/ClassNoteAI/src/components/NotesView.tsx
+++ b/ClassNoteAI/src/components/NotesView.tsx
@@ -772,66 +772,120 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
           console.log('[NotesView] No notes found but subtitles exist. Auto-generating notes...');
 
           const SECTION_DURATION_SEC = 300; // 5 minutes per section
-          const sections: { title: string; content: string; timestamp: number }[] = [];
+
+          // Keep per-section sentence arrays + page tracking alongside
+          // the user-visible section object. The sentence array feeds
+          // `extract_section_highlights` to produce the bullet summary
+          // (Layer 1 of Note AI structurization); page_range gives the
+          // "投影片 3-5" header. Sections without any PDF alignment
+          // simply stay page_range = null.
+          const sectionBuild: Array<{
+            title: string;
+            sentences: string[];
+            timestamp: number;
+            pages: number[];
+          }> = [];
 
           let currentSectionStart = 0;
-          let currentSectionContent: string[] = [];
+          let currentSentences: string[] = [];
+          let currentPages: number[] = [];
           let sectionIndex = 1;
 
-          // Use database subtitles if available, otherwise use in-memory segments
+          const flushSection = () => {
+            if (currentSentences.length === 0) return;
+            sectionBuild.push({
+              title: `Section ${sectionIndex}`,
+              sentences: [...currentSentences],
+              timestamp: currentSectionStart,
+              pages: [...currentPages],
+            });
+            sectionIndex++;
+          };
+
           if (subtitles.length > 0) {
             for (const sub of subtitles) {
               const segTimestamp = sub.timestamp;
-
-              if (segTimestamp - currentSectionStart >= SECTION_DURATION_SEC && currentSectionContent.length > 0) {
-                sections.push({
-                  title: `Section ${sectionIndex}`,
-                  content: currentSectionContent.join(' '),
-                  timestamp: currentSectionStart,
-                });
-                sectionIndex++;
+              if (
+                segTimestamp - currentSectionStart >= SECTION_DURATION_SEC &&
+                currentSentences.length > 0
+              ) {
+                flushSection();
                 currentSectionStart = segTimestamp;
-                currentSectionContent = [];
+                currentSentences = [];
+                currentPages = [];
               }
-
-              const text = sub.text_zh || sub.text_en || '';
-              if (text.trim()) {
-                currentSectionContent.push(text.trim());
-              }
+              const text = (sub.text_zh || sub.text_en || '').trim();
+              if (text) currentSentences.push(text);
+              if (typeof sub.page_number === 'number') currentPages.push(sub.page_number);
             }
           } else {
-            // Use in-memory segments as fallback
             for (const seg of inMemorySegments) {
               const segTimestamp = seg.startTime / 1000;
-
-              if (segTimestamp - currentSectionStart >= SECTION_DURATION_SEC && currentSectionContent.length > 0) {
-                sections.push({
-                  title: `Section ${sectionIndex}`,
-                  content: currentSectionContent.join(' '),
-                  timestamp: currentSectionStart,
-                });
-                sectionIndex++;
+              if (
+                segTimestamp - currentSectionStart >= SECTION_DURATION_SEC &&
+                currentSentences.length > 0
+              ) {
+                flushSection();
                 currentSectionStart = segTimestamp;
-                currentSectionContent = [];
+                currentSentences = [];
+                currentPages = [];
               }
+              const text = (
+                seg.displayTranslation ||
+                seg.roughTranslation ||
+                seg.displayText ||
+                seg.roughText ||
+                ''
+              ).trim();
+              if (text) currentSentences.push(text);
+            }
+          }
+          flushSection();
 
-              const text = seg.displayTranslation || seg.roughTranslation || seg.displayText || seg.roughText || '';
-              if (text.trim()) {
-                currentSectionContent.push(text.trim());
-              }
+          // Compute Layer-1 AI structure: representative bullets per
+          // section via the Rust side's Candle centroid extractor.
+          // Runs on whichever device the embedding service picked —
+          // GPU on a gpu-cuda build with a working driver, CPU
+          // otherwise. One IPC round-trip for the entire lecture.
+          let bulletsPerSection: string[][] = [];
+          if (sectionBuild.length > 0) {
+            try {
+              bulletsPerSection = await invoke<string[][]>(
+                'extract_section_highlights',
+                {
+                  sections: sectionBuild.map((s) => s.sentences),
+                  topK: 3,
+                },
+              );
+              console.log(
+                '[NotesView] Extracted bullets for',
+                bulletsPerSection.length,
+                'sections',
+              );
+            } catch (e) {
+              // Extraction failure shouldn't block note creation —
+              // the section content remains readable even without
+              // bullets. Log once and fall through to empty bullets.
+              console.warn('[NotesView] bullet extraction failed:', e);
+              bulletsPerSection = sectionBuild.map(() => []);
             }
           }
 
-          // Save the last section
-          if (currentSectionContent.length > 0) {
-            sections.push({
-              title: `Section ${sectionIndex}`,
-              content: currentSectionContent.join(' '),
-              timestamp: currentSectionStart,
-            });
-          }
+          const sections = sectionBuild.map((s, i) => {
+            const pages = s.pages.filter((p) => Number.isFinite(p));
+            const page_range =
+              pages.length > 0
+                ? { min: Math.min(...pages), max: Math.max(...pages) }
+                : null;
+            return {
+              title: s.title,
+              content: s.sentences.join(' '),
+              timestamp: s.timestamp,
+              bullets: bulletsPerSection[i] ?? [],
+              page_range,
+            };
+          });
 
-          // Create and save the Note
           if (sections.length > 0) {
             const generatedNote: Note = {
               lecture_id: lecture.id,
@@ -2257,7 +2311,16 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
                                 ) : (
                                   <>
                                     <div className="flex items-center justify-between mb-1">
-                                      <h4 className="font-semibold text-gray-900 dark:text-gray-100">{section.title}</h4>
+                                      <div className="flex items-center gap-2">
+                                        <h4 className="font-semibold text-gray-900 dark:text-gray-100">{section.title}</h4>
+                                        {section.page_range && (
+                                          <span className="text-xs text-gray-500 dark:text-gray-400 px-1.5 py-0.5 rounded bg-gray-100 dark:bg-gray-800">
+                                            {section.page_range.min === section.page_range.max
+                                              ? `投影片 ${section.page_range.min}`
+                                              : `投影片 ${section.page_range.min}–${section.page_range.max}`}
+                                          </span>
+                                        )}
+                                      </div>
                                       {section.timestamp && (() => {
                                         const baseTime = currentLectureData?.created_at ? new Date(currentLectureData.created_at).getTime() / 1000 : section.timestamp;
                                         const relativeTime = Math.max(0, section.timestamp - baseTime);
@@ -2271,7 +2334,29 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
                                         );
                                       })()}
                                     </div>
-                                    <p className="text-gray-600 dark:text-gray-300 text-sm leading-relaxed whitespace-pre-wrap">{section.content}</p>
+                                    {section.bullets && section.bullets.length > 0 ? (
+                                      // Layer-1 structured view: bullets (centroid-extracted
+                                      // representative sentences) above a collapsed raw content.
+                                      // Reading the bullets alone gives the gist; click to
+                                      // expand when the full transcript is wanted.
+                                      <>
+                                        <ul className="list-disc pl-5 space-y-1 text-gray-800 dark:text-gray-200 text-sm leading-relaxed">
+                                          {section.bullets.map((b, bi) => (
+                                            <li key={bi}>{b}</li>
+                                          ))}
+                                        </ul>
+                                        <details className="mt-2 text-xs">
+                                          <summary className="cursor-pointer text-gray-400 hover:text-gray-600 dark:hover:text-gray-300 select-none">
+                                            原始字幕（{section.content.length} 字）
+                                          </summary>
+                                          <p className="text-gray-500 dark:text-gray-400 text-xs leading-relaxed whitespace-pre-wrap mt-1 pl-1">
+                                            {section.content}
+                                          </p>
+                                        </details>
+                                      </>
+                                    ) : (
+                                      <p className="text-gray-600 dark:text-gray-300 text-sm leading-relaxed whitespace-pre-wrap">{section.content}</p>
+                                    )}
                                   </>
                                 )}
                               </div>

--- a/ClassNoteAI/src/components/NotesView.tsx
+++ b/ClassNoteAI/src/components/NotesView.tsx
@@ -138,7 +138,7 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
   // Lookup is a binary search at each time-update so the sync is cheap.
   const [pageTimeline, setPageTimeline] = useState<{ t: number; page: number }[]>([]);
   const [isBuildingTimeline, setIsBuildingTimeline] = useState<boolean>(false);
-  const [lastAutoFollowPage, setLastAutoFollowPage] = useState<number>(0);
+  const lastAutoPageRef = useRef<number | null>(null);
 
   // Note Editing State
   const [isEditingNote, setIsEditingNote] = useState(false);
@@ -540,18 +540,15 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
   }, [autoFollow, viewMode, pdfData, modelLoaded, currentLectureData?.id]);
 
   // Sync PDF to the current playback time when Auto Follow is on.
-  // Debounced via "last page scrolled" so we don't thrash the PDF
-  // viewer on every timeupdate (which fires ~4x/s).
   useEffect(() => {
-    if (!autoFollow) return;
-    if (viewMode !== 'review') return;
-    if (!isPlaying) return;
-    if (pageTimeline.length === 0) return;
+    if (!autoFollow || pageTimeline.length === 0) {
+      lastAutoPageRef.current = null;
+      return;
+    }
 
-    // Binary search for largest timeline entry with t <= currentTime.
     let lo = 0;
     let hi = pageTimeline.length - 1;
-    let best = -1;
+    let best = 0;
     while (lo <= hi) {
       const mid = (lo + hi) >> 1;
       if (pageTimeline[mid].t <= audioCurrentTime) {
@@ -561,14 +558,14 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
         hi = mid - 1;
       }
     }
-    if (best < 0) return;
     const targetPage = pageTimeline[best].page;
-    if (targetPage === lastAutoFollowPage) return;
-    setLastAutoFollowPage(targetPage);
-    if (pdfViewerRef.current) {
-      pdfViewerRef.current.scrollToPage(targetPage);
+    // Manual page turns while autoFollow=true will be overridden on the next timeupdate tick.
+    const viewer = pdfViewerRef.current;
+    if (viewer && lastAutoPageRef.current !== targetPage) {
+      viewer.scrollToPage(targetPage);
+      lastAutoPageRef.current = targetPage;
     }
-  }, [audioCurrentTime, autoFollow, isPlaying, viewMode, pageTimeline, lastAutoFollowPage]);
+  }, [autoFollow, pageTimeline, audioCurrentTime]);
 
   // Assemble the Whisper initial_prompt from three sources:
   //   1. Course context (topic from syllabus)

--- a/ClassNoteAI/src/components/SettingsView.tsx
+++ b/ClassNoteAI/src/components/SettingsView.tsx
@@ -9,6 +9,7 @@ import {
   Database,
   Info,
   ChevronRight,
+  Monitor,
 } from "lucide-react";
 import { AppSettings } from "../types";
 import { getVersion } from "@tauri-apps/api/app";
@@ -25,11 +26,13 @@ import SettingsCloudAI from "./settings/SettingsCloudAI";
 import SettingsAudioSubtitles from "./settings/SettingsAudioSubtitles";
 import SettingsDataManagement from "./settings/SettingsDataManagement";
 import SettingsAboutUpdates from "./settings/SettingsAboutUpdates";
+import SettingsInterface from "./settings/SettingsInterface";
 
 type TabId =
   | "local-transcription"
   | "translation"
   | "cloud-ai"
+  | "interface"
   | "audio-subtitles"
   | "data-management"
   | "about-updates";
@@ -80,6 +83,12 @@ const PRIMARY_NAV: NavItem[] = [
 ];
 
 const SECONDARY_NAV: NavItem[] = [
+  {
+    id: "interface",
+    label: "介面與顯示",
+    icon: Monitor,
+    description: "視窗、面板與佈局",
+  },
   {
     id: "audio-subtitles",
     label: "音訊與字幕",
@@ -260,6 +269,8 @@ export default function SettingsView({}: Props) {
         );
       case "cloud-ai":
         return <SettingsCloudAI />;
+      case "interface":
+        return <SettingsInterface />;
       case "audio-subtitles":
         return (
           <SettingsAudioSubtitles

--- a/ClassNoteAI/src/components/SetupWizard.tsx
+++ b/ClassNoteAI/src/components/SetupWizard.tsx
@@ -16,8 +16,10 @@ import {
     Zap,
     Mic,
     Languages,
-    HardDrive
+    HardDrive,
+    ExternalLink
 } from 'lucide-react';
+import { openUrl } from '@tauri-apps/plugin-opener';
 import { setupService } from '../services/setupService';
 import AIProviderSettings from './AIProviderSettings';
 import {
@@ -46,11 +48,20 @@ type WizardStep =
     | 'installing'
     | 'complete';
 
+interface DriverHint {
+    severity: string;
+    title: string;
+    message: string;
+    action_url: string;
+    action_label: string;
+}
+
 interface GpuDetection {
     cuda: { gpu_name: string; driver_version: string } | null;
     metal: boolean;
     vulkan: boolean;
     effective: string;
+    driver_hint?: DriverHint | null;
 }
 
 type SourceLang = 'auto' | 'en' | 'ja' | 'ko' | 'fr' | 'de' | 'es' | 'zh-TW' | 'zh-CN';
@@ -535,10 +546,94 @@ export default function SetupWizard({ onComplete }: SetupWizardProps) {
                   },
               ]
             : [];
+        const driverHint = gpuDetection?.driver_hint;
         return (
             <div className="setup-step review-step">
                 <h2 className="setup-subtitle">硬體加速偵測</h2>
                 <p className="setup-description">可用的 Whisper 加速後端</p>
+
+                {driverHint && (
+                    // Non-blocking driver-version advisory. Matches the
+                    // banner in LocalModelExperimentalSettings so users
+                    // see the same wording in the wizard + in the live
+                    // settings panel.
+                    <div
+                        style={{
+                            display: 'flex',
+                            gap: '0.75rem',
+                            padding: '0.875rem',
+                            marginBottom: '1rem',
+                            borderRadius: '0.5rem',
+                            background:
+                                driverHint.severity === 'warning'
+                                    ? 'rgba(251, 191, 36, 0.08)'
+                                    : 'rgba(59, 130, 246, 0.08)',
+                            border:
+                                driverHint.severity === 'warning'
+                                    ? '1px solid rgba(251, 191, 36, 0.3)'
+                                    : '1px solid rgba(59, 130, 246, 0.3)',
+                        }}
+                    >
+                        <AlertTriangle
+                            className="w-5 h-5"
+                            style={{
+                                marginTop: '0.125rem',
+                                flexShrink: 0,
+                                color:
+                                    driverHint.severity === 'warning'
+                                        ? '#f59e0b'
+                                        : '#3b82f6',
+                            }}
+                        />
+                        <div style={{ flex: 1, minWidth: 0 }}>
+                            <div
+                                style={{
+                                    fontSize: '0.875rem',
+                                    fontWeight: 600,
+                                    marginBottom: '0.25rem',
+                                    color:
+                                        driverHint.severity === 'warning'
+                                            ? '#d97706'
+                                            : '#2563eb',
+                                }}
+                            >
+                                {driverHint.title}
+                            </div>
+                            <p
+                                style={{
+                                    fontSize: '0.8125rem',
+                                    lineHeight: 1.5,
+                                    color: 'rgba(255,255,255,0.8)',
+                                    margin: 0,
+                                }}
+                            >
+                                {driverHint.message}
+                            </p>
+                            <button
+                                type="button"
+                                onClick={() => {
+                                    void openUrl(driverHint.action_url);
+                                }}
+                                style={{
+                                    marginTop: '0.5rem',
+                                    display: 'inline-flex',
+                                    alignItems: 'center',
+                                    gap: '0.25rem',
+                                    fontSize: '0.8125rem',
+                                    fontWeight: 500,
+                                    color: '#818cf8',
+                                    background: 'transparent',
+                                    border: 'none',
+                                    cursor: 'pointer',
+                                    padding: 0,
+                                }}
+                            >
+                                {driverHint.action_label}
+                                <ExternalLink className="w-3.5 h-3.5" />
+                            </button>
+                        </div>
+                    </div>
+                )}
 
                 <div className="requirements-list">
                     {rows.map((r) => (

--- a/ClassNoteAI/src/components/SetupWizard.tsx
+++ b/ClassNoteAI/src/components/SetupWizard.tsx
@@ -41,9 +41,17 @@ type WizardStep =
     | 'ai-provider'   // v0.5.2: pick GitHub Models vs ChatGPT (or skip)
     | 'ai-config'     // v0.5.2: configure the chosen provider (PAT / OAuth)
     | 'checking'
+    | 'gpu-check'     // v0.6.1: detect NVIDIA/Vulkan/Metal + save preference
     | 'review'
     | 'installing'
     | 'complete';
+
+interface GpuDetection {
+    cuda: { gpu_name: string; driver_version: string } | null;
+    metal: boolean;
+    vulkan: boolean;
+    effective: string;
+}
 
 type SourceLang = 'auto' | 'en' | 'ja' | 'ko' | 'fr' | 'de' | 'es' | 'zh-TW' | 'zh-CN';
 
@@ -68,7 +76,14 @@ export default function SetupWizard({ onComplete }: SetupWizardProps) {
     // wizard container and the "Continue" button got clipped off-screen.
     const [selectedProviderId, setSelectedProviderId] = useState<string | null>(null);
 
-    // Check requirements when entering checking step
+    // v0.6.1: GPU backend detection state for the `gpu-check` step.
+    const [gpuDetection, setGpuDetection] = useState<GpuDetection | null>(null);
+
+    // Check requirements when entering checking step. v0.6.1: after
+    // the env check we insert `gpu-check` so users see their hardware
+    // story (CUDA / Vulkan / Metal / CPU) before committing to a
+    // multi-GB model download — avoids the "why is this so slow?"
+    // surprise post-install.
     const checkRequirements = useCallback(async () => {
         setStep('checking');
         setError(null);
@@ -76,19 +91,57 @@ export default function SetupWizard({ onComplete }: SetupWizardProps) {
         try {
             const setupStatus = await setupService.checkStatus();
             setStatus(setupStatus);
+            // Kick off GPU detection in parallel with the env check so
+            // the gpu-check step has data ready when we transition.
+            // Swallow errors: older binaries missing the command just
+            // skip the GPU step content gracefully.
+            try {
+                const { invoke } = await import('@tauri-apps/api/core');
+                const d = await invoke<GpuDetection>('detect_gpu_backends', {
+                    preference: 'auto',
+                });
+                setGpuDetection(d);
+            } catch {
+                /* detection unavailable — step still renders a CPU fallback notice */
+            }
 
-            // If everything is already installed, skip to complete
+            // If everything is already installed, skip past review
+            // but still show the GPU summary so the user knows what
+            // backend they're on.
             if (setupStatus.is_complete) {
-                await setupService.markComplete();
-                setStep('complete');
+                setStep('gpu-check');
             } else {
-                setStep('review');
+                setStep('gpu-check');
             }
         } catch (err) {
             setError(`環境檢查失敗: ${err}`);
             setStep('review');
         }
     }, []);
+
+    const continueFromGpuCheck = useCallback(async () => {
+        // Persist the auto preference so the ImportModal / settings
+        // both pick it up on first open. User can override in settings.
+        try {
+            const { storageService } = await import('../services/storageService');
+            const existing = (await storageService.getAppSettings()) ?? {} as any;
+            await storageService.saveAppSettings({
+                ...existing,
+                experimental: {
+                    ...(existing.experimental ?? {}),
+                    asrBackend: 'auto',
+                },
+            });
+        } catch {
+            /* non-fatal; settings can be set later */
+        }
+        if (status?.is_complete) {
+            await setupService.markComplete();
+            setStep('complete');
+        } else {
+            setStep('review');
+        }
+    }, [status]);
 
     // Start installation
     const startInstallation = useCallback(async () => {
@@ -453,6 +506,99 @@ export default function SetupWizard({ onComplete }: SetupWizardProps) {
         </div>
     );
 
+    // v0.6.1: GPU-check step. Shows the user what acceleration they'll
+    // get (or not) BEFORE they wait through a ~1 GB model download.
+    // No install action here — we deliberately don't try to
+    // automate CUDA Toolkit installation: users don't need it, they
+    // just need the driver (usually already present from Windows
+    // Update / GeForce Experience). The runtime cudart DLL will ship
+    // inside the GPU-enabled app binary in Phase 4.
+    const renderGpuCheck = () => {
+        const cpuOnly =
+            !gpuDetection ||
+            (!gpuDetection.cuda && !gpuDetection.metal && !gpuDetection.vulkan);
+        return (
+            <div className="setup-step" style={{ maxWidth: '640px', margin: '0 auto' }}>
+                <h2 className="setup-subtitle">硬體加速偵測</h2>
+                <p className="setup-description" style={{ marginBottom: '1rem' }}>
+                    找出這台裝置上可用的 Whisper 加速後端。{cpuOnly ? '未偵測到 GPU，將使用 CPU 運作。' : '好消息：偵測到可加速後端。'}
+                </p>
+
+                {gpuDetection && (
+                    <div
+                        style={{
+                            background: 'var(--bg-subtle, #f8fafc)',
+                            border: '1px solid var(--border-subtle, #e5e7eb)',
+                            borderRadius: '8px',
+                            padding: '1rem',
+                            marginBottom: '1rem',
+                            fontSize: '0.875rem',
+                        }}
+                    >
+                        <div style={{ marginBottom: '0.5rem' }}>
+                            <strong>
+                                {gpuDetection.cuda ? '✓ CUDA (NVIDIA)' : '✗ CUDA (NVIDIA)'}
+                            </strong>
+                            <span style={{ marginLeft: '0.5rem', color: 'var(--text-subtle, #6b7280)' }}>
+                                {gpuDetection.cuda
+                                    ? `${gpuDetection.cuda.gpu_name} · driver ${gpuDetection.cuda.driver_version}`
+                                    : '未偵測到 NVIDIA 驅動'}
+                            </span>
+                        </div>
+                        <div style={{ marginBottom: '0.5rem' }}>
+                            <strong>
+                                {gpuDetection.vulkan ? '✓ Vulkan' : '✗ Vulkan'}
+                            </strong>
+                            <span style={{ marginLeft: '0.5rem', color: 'var(--text-subtle, #6b7280)' }}>
+                                {gpuDetection.vulkan ? 'Vulkan loader 已存在' : '未偵測到 Vulkan runtime'}
+                            </span>
+                        </div>
+                        <div>
+                            <strong>
+                                {gpuDetection.metal ? '✓ Metal' : '✗ Metal'}
+                            </strong>
+                            <span style={{ marginLeft: '0.5rem', color: 'var(--text-subtle, #6b7280)' }}>
+                                {gpuDetection.metal ? '原生支援' : '不適用此系統'}
+                            </span>
+                        </div>
+                    </div>
+                )}
+
+                <div
+                    style={{
+                        background: cpuOnly ? '#fef3c7' : '#d1fae5',
+                        color: cpuOnly ? '#92400e' : '#065f46',
+                        border: `1px solid ${cpuOnly ? '#fcd34d' : '#6ee7b7'}`,
+                        borderRadius: '8px',
+                        padding: '0.75rem 1rem',
+                        marginBottom: '1rem',
+                        fontSize: '0.85rem',
+                        lineHeight: '1.5',
+                    }}
+                >
+                    {cpuOnly ? (
+                        <>
+                            目前將以 CPU 模式運作。轉錄 1 小時影片約需 30-60 分鐘（large 模型）或 5-10 分鐘（base 模型，可在設定調整）。
+                        </>
+                    ) : (
+                        <>
+                            你不需要額外安裝 CUDA Toolkit。發布版內建必要的 runtime DLL；目前的 dev build 尚未包含 GPU backend，但偏好已經記錄，等 GPU build 上線後會自動啟用。
+                        </>
+                    )}
+                </div>
+
+                <div style={{ display: 'flex', justifyContent: 'flex-end' }}>
+                    <button
+                        className="btn-primary"
+                        onClick={continueFromGpuCheck}
+                    >
+                        繼續 <ArrowRight className="w-5 h-5" />
+                    </button>
+                </div>
+            </div>
+        );
+    };
+
     // Render review step
     const renderReview = () => {
         if (!status) return null;
@@ -686,6 +832,7 @@ export default function SetupWizard({ onComplete }: SetupWizardProps) {
                 {step === 'ai-provider' && renderAIProvider()}
                 {step === 'ai-config' && renderAIConfig()}
                 {step === 'checking' && renderChecking()}
+                {step === 'gpu-check' && renderGpuCheck()}
                 {step === 'review' && renderReview()}
                 {step === 'installing' && renderInstalling()}
                 {step === 'complete' && renderComplete()}

--- a/ClassNoteAI/src/components/SetupWizard.tsx
+++ b/ClassNoteAI/src/components/SetupWizard.tsx
@@ -506,85 +506,59 @@ export default function SetupWizard({ onComplete }: SetupWizardProps) {
         </div>
     );
 
-    // v0.6.1: GPU-check step. Shows the user what acceleration they'll
-    // get (or not) BEFORE they wait through a ~1 GB model download.
-    // No install action here — we deliberately don't try to
-    // automate CUDA Toolkit installation: users don't need it, they
-    // just need the driver (usually already present from Windows
-    // Update / GeForce Experience). The runtime cudart DLL will ship
-    // inside the GPU-enabled app binary in Phase 4.
+    // v0.6.1: GPU-check step. Reuses the same `requirements-list` /
+    // `requirement-item` classes as the env-check step for visual
+    // consistency with the rest of the wizard (dark translucent cards
+    // on the gradient background). Previously used ad-hoc white
+    // cards that looked out of place.
     const renderGpuCheck = () => {
-        const cpuOnly =
-            !gpuDetection ||
-            (!gpuDetection.cuda && !gpuDetection.metal && !gpuDetection.vulkan);
+        const rows: { ok: boolean; label: string; detail: string }[] = gpuDetection
+            ? [
+                  {
+                      ok: !!gpuDetection.cuda,
+                      label: 'CUDA (NVIDIA)',
+                      detail: gpuDetection.cuda
+                          ? `${gpuDetection.cuda.gpu_name} · driver ${gpuDetection.cuda.driver_version}`
+                          : '未偵測到 NVIDIA 驅動',
+                  },
+                  {
+                      ok: gpuDetection.vulkan,
+                      label: 'Vulkan',
+                      detail: gpuDetection.vulkan
+                          ? 'Vulkan loader 已存在'
+                          : '未偵測到 Vulkan runtime',
+                  },
+                  {
+                      ok: gpuDetection.metal,
+                      label: 'Metal (macOS)',
+                      detail: gpuDetection.metal ? '原生支援' : '不適用此系統',
+                  },
+              ]
+            : [];
         return (
-            <div className="setup-step" style={{ maxWidth: '640px', margin: '0 auto' }}>
+            <div className="setup-step review-step">
                 <h2 className="setup-subtitle">硬體加速偵測</h2>
-                <p className="setup-description" style={{ marginBottom: '1rem' }}>
-                    找出這台裝置上可用的 Whisper 加速後端。{cpuOnly ? '未偵測到 GPU，將使用 CPU 運作。' : '好消息：偵測到可加速後端。'}
-                </p>
+                <p className="setup-description">可用的 Whisper 加速後端</p>
 
-                {gpuDetection && (
-                    <div
-                        style={{
-                            background: 'var(--bg-subtle, #f8fafc)',
-                            border: '1px solid var(--border-subtle, #e5e7eb)',
-                            borderRadius: '8px',
-                            padding: '1rem',
-                            marginBottom: '1rem',
-                            fontSize: '0.875rem',
-                        }}
-                    >
-                        <div style={{ marginBottom: '0.5rem' }}>
-                            <strong>
-                                {gpuDetection.cuda ? '✓ CUDA (NVIDIA)' : '✗ CUDA (NVIDIA)'}
-                            </strong>
-                            <span style={{ marginLeft: '0.5rem', color: 'var(--text-subtle, #6b7280)' }}>
-                                {gpuDetection.cuda
-                                    ? `${gpuDetection.cuda.gpu_name} · driver ${gpuDetection.cuda.driver_version}`
-                                    : '未偵測到 NVIDIA 驅動'}
-                            </span>
+                <div className="requirements-list">
+                    {rows.map((r) => (
+                        <div
+                            key={r.label}
+                            className={`requirement-item ${r.ok ? 'installed' : 'missing'}`}
+                        >
+                            <div className="requirement-info">
+                                {r.ok ? (
+                                    <CheckCircle className="w-5 h-5" style={{ color: '#22c55e' }} />
+                                ) : (
+                                    <XCircle className="w-5 h-5" style={{ color: 'rgba(255,255,255,0.3)' }} />
+                                )}
+                                <div className="requirement-details">
+                                    <span className="requirement-name">{r.label}</span>
+                                    <span className="requirement-desc">{r.detail}</span>
+                                </div>
+                            </div>
                         </div>
-                        <div style={{ marginBottom: '0.5rem' }}>
-                            <strong>
-                                {gpuDetection.vulkan ? '✓ Vulkan' : '✗ Vulkan'}
-                            </strong>
-                            <span style={{ marginLeft: '0.5rem', color: 'var(--text-subtle, #6b7280)' }}>
-                                {gpuDetection.vulkan ? 'Vulkan loader 已存在' : '未偵測到 Vulkan runtime'}
-                            </span>
-                        </div>
-                        <div>
-                            <strong>
-                                {gpuDetection.metal ? '✓ Metal' : '✗ Metal'}
-                            </strong>
-                            <span style={{ marginLeft: '0.5rem', color: 'var(--text-subtle, #6b7280)' }}>
-                                {gpuDetection.metal ? '原生支援' : '不適用此系統'}
-                            </span>
-                        </div>
-                    </div>
-                )}
-
-                <div
-                    style={{
-                        background: cpuOnly ? '#fef3c7' : '#d1fae5',
-                        color: cpuOnly ? '#92400e' : '#065f46',
-                        border: `1px solid ${cpuOnly ? '#fcd34d' : '#6ee7b7'}`,
-                        borderRadius: '8px',
-                        padding: '0.75rem 1rem',
-                        marginBottom: '1rem',
-                        fontSize: '0.85rem',
-                        lineHeight: '1.5',
-                    }}
-                >
-                    {cpuOnly ? (
-                        <>
-                            目前將以 CPU 模式運作。轉錄 1 小時影片約需 30-60 分鐘（large 模型）或 5-10 分鐘（base 模型，可在設定調整）。
-                        </>
-                    ) : (
-                        <>
-                            你不需要額外安裝 CUDA Toolkit。發布版內建必要的 runtime DLL；目前的 dev build 尚未包含 GPU backend，但偏好已經記錄，等 GPU build 上線後會自動啟用。
-                        </>
-                    )}
+                    ))}
                 </div>
 
                 <div style={{ display: 'flex', justifyContent: 'flex-end' }}>

--- a/ClassNoteAI/src/components/SubtitleDisplay.tsx
+++ b/ClassNoteAI/src/components/SubtitleDisplay.tsx
@@ -122,9 +122,21 @@ export default function SubtitleDisplay({ onSeek, currentTime, baseTime }: Subti
                   : segment.startTime;
             const relativeMs = Math.max(0, segment.startTime - refEpochMs);
 
+            // MM:SS.cc — centiseconds precision. Whisper.cpp's native
+            // timing grid is 10 ms (centiseconds) so two digits after
+            // the decimal fully reflect what the model actually knows;
+            // showing a third millisecond digit would just be `0` all
+            // the time. Live-recording segments store Date.now() so
+            // they can theoretically be ms-precise, but rounding down
+            // to centiseconds for display keeps the format uniform
+            // between both paths.
             const minutes = Math.floor(relativeMs / 60000);
             const seconds = Math.floor((relativeMs % 60000) / 1000);
-            const timeString = `${minutes.toString().padStart(2, '0')}:${seconds.toString().padStart(2, '0')}`;
+            const centis = Math.floor((relativeMs % 1000) / 10);
+            const timeString =
+                `${minutes.toString().padStart(2, '0')}:` +
+                `${seconds.toString().padStart(2, '0')}.` +
+                `${centis.toString().padStart(2, '0')}`;
 
             const isActive = index === activeIdx;
 

--- a/ClassNoteAI/src/components/settings/CloudAIExperimentalSettings.tsx
+++ b/ClassNoteAI/src/components/settings/CloudAIExperimentalSettings.tsx
@@ -1,0 +1,89 @@
+import { useEffect, useState } from 'react';
+import { FlaskConical, Sparkles } from 'lucide-react';
+import { storageService } from '../../services/storageService';
+
+/**
+ * v0.6.1: experimental / opt-in defaults that belong to the **雲端
+ * AI 助理** category — anything that spends cloud-LLM tokens. Lives
+ * under Settings → 雲端 AI 助理.
+ *
+ *   - importAiRefine   run LLM fine-refinement after rough transcribe
+ *                      for newly-imported videos. Off by default.
+ *
+ * ASR backend + fast/standard model live in
+ * LocalModelExperimentalSettings under 本地轉錄模型 because they
+ * only touch the local Whisper pipeline.
+ */
+export default function CloudAIExperimentalSettings() {
+    const [refine, setRefine] = useState<boolean>(false);
+    const [loaded, setLoaded] = useState(false);
+    const [savedAt, setSavedAt] = useState<number | null>(null);
+
+    useEffect(() => {
+        (async () => {
+            try {
+                const s = await storageService.getAppSettings();
+                if (typeof s?.experimental?.importAiRefine === 'boolean') {
+                    setRefine(s.experimental.importAiRefine);
+                }
+            } finally {
+                setLoaded(true);
+            }
+        })();
+    }, []);
+
+    const handleChange = async (next: boolean) => {
+        setRefine(next);
+        try {
+            const existing = await storageService.getAppSettings();
+            if (!existing) return;
+            await storageService.saveAppSettings({
+                ...existing,
+                experimental: {
+                    ...(existing.experimental ?? {}),
+                    importAiRefine: next,
+                },
+            });
+            setSavedAt(Date.now());
+        } catch (err) {
+            console.error('[CloudAIExperimental] save failed:', err);
+        }
+    };
+
+    if (!loaded) return null;
+
+    return (
+        <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-slate-900/50 p-4">
+            <div className="flex items-center gap-2 mb-3">
+                <FlaskConical className="w-4 h-4 text-gray-500" />
+                <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                    實驗性功能
+                </span>
+                {savedAt && Date.now() - savedAt < 2000 && (
+                    <span className="text-[10px] text-green-600 dark:text-green-400">已保存</span>
+                )}
+            </div>
+
+            <label className="flex items-start gap-2 text-sm">
+                <input
+                    type="checkbox"
+                    checked={refine}
+                    onChange={(e) => handleChange(e.target.checked)}
+                    className="mt-1 accent-indigo-500"
+                />
+                <span>
+                    <span className="flex items-center gap-1.5 font-medium text-gray-700 dark:text-gray-300">
+                        <Sparkles className="w-4 h-4 text-purple-500" />
+                        匯入後自動執行 AI 精修字幕
+                    </span>
+                    <span className="block text-[11px] text-gray-500 dark:text-gray-400 mt-0.5">
+                        粗翻譯完成後請 LLM 修正 ASR 錯誤 + 自然中文。
+                        <span className="text-amber-600 dark:text-amber-500">
+                            1 小時影片 ≈ 130k tokens（GPT-4o ≈ $1、Claude Sonnet ≈ $1.5、GitHub Models 免費但可能撞 rate limit）
+                        </span>。預設關閉。
+                    </span>
+                </span>
+            </label>
+        </div>
+    );
+}

--- a/ClassNoteAI/src/components/settings/CloudAIExperimentalSettings.tsx
+++ b/ClassNoteAI/src/components/settings/CloudAIExperimentalSettings.tsx
@@ -1,21 +1,46 @@
 import { useEffect, useState } from 'react';
-import { FlaskConical, Sparkles } from 'lucide-react';
+import { FlaskConical, Sparkles, Zap, Gauge } from 'lucide-react';
 import { storageService } from '../../services/storageService';
 
+type Intensity = 'off' | 'light' | 'deep';
+type Provider =
+    | 'auto'
+    | 'chatgpt-oauth'
+    | 'github-models'
+    | 'ollama'
+    | 'gemini'
+    | 'groq'
+    | 'mistral'
+    | 'openrouter'
+    | 'user-key';
+
 /**
- * v0.6.1: experimental / opt-in defaults that belong to the **雲端
- * AI 助理** category — anything that spends cloud-LLM tokens. Lives
- * under Settings → 雲端 AI 助理.
+ * v0.6.0-alpha.1: cloud-AI settings. Splits the old single "匯入後自動
+ * AI 精修" checkbox into an intensity selector + provider pin so users
+ * can pick their tradeoff between cost and quality explicitly.
  *
- *   - importAiRefine   run LLM fine-refinement after rough transcribe
- *                      for newly-imported videos. Off by default.
+ * Why the split:
+ *   - a full per-subtitle refinement on a 70-min lecture was 1296 LLM
+ *     calls × ~200 tokens ≈ 260k tokens, blowing free tiers after 2-3
+ *     lectures. Batched per 5-min section cuts that to 14 calls ≈
+ *     15k-50k tokens depending on intensity.
+ *   - primary user segments are Copilot Pro subscribers (GitHub
+ *     OAuth → Models) and ChatGPT Plus subscribers (Codex-style
+ *     OAuth → Plus subscription quota). Both flows are already in
+ *     the codebase (`llm/providers/chatgpt-oauth.ts`, `github-
+ *     models.ts`) — the refine path just picks from those same
+ *     configured providers.
+ *   - free-tier options (Gemini, Groq, Mistral, local Ollama) are
+ *     shown for users with neither subscription or when a user
+ *     wants to keep their paid quota for other tasks.
  *
  * ASR backend + fast/standard model live in
  * LocalModelExperimentalSettings under 本地轉錄模型 because they
  * only touch the local Whisper pipeline.
  */
 export default function CloudAIExperimentalSettings() {
-    const [refine, setRefine] = useState<boolean>(false);
+    const [intensity, setIntensity] = useState<Intensity>('off');
+    const [provider, setProvider] = useState<Provider>('auto');
     const [loaded, setLoaded] = useState(false);
     const [savedAt, setSavedAt] = useState<number | null>(null);
 
@@ -23,17 +48,23 @@ export default function CloudAIExperimentalSettings() {
         (async () => {
             try {
                 const s = await storageService.getAppSettings();
-                if (typeof s?.experimental?.importAiRefine === 'boolean') {
-                    setRefine(s.experimental.importAiRefine);
+                const exp = s?.experimental;
+                if (exp?.refineIntensity) {
+                    setIntensity(exp.refineIntensity);
+                } else if (typeof exp?.importAiRefine === 'boolean') {
+                    // Legacy boolean → intensity mapping. Old true = deep
+                    // so existing users don't silently lose quality after
+                    // the upgrade.
+                    setIntensity(exp.importAiRefine ? 'deep' : 'off');
                 }
+                if (exp?.refineProvider) setProvider(exp.refineProvider);
             } finally {
                 setLoaded(true);
             }
         })();
     }, []);
 
-    const handleChange = async (next: boolean) => {
-        setRefine(next);
+    const patch = async (changes: Partial<{ refineIntensity: Intensity; refineProvider: Provider }>) => {
         try {
             const existing = await storageService.getAppSettings();
             if (!existing) return;
@@ -41,7 +72,11 @@ export default function CloudAIExperimentalSettings() {
                 ...existing,
                 experimental: {
                     ...(existing.experimental ?? {}),
-                    importAiRefine: next,
+                    ...changes,
+                    // Drop the legacy boolean — `refineIntensity`
+                    // supersedes it. Keeping both would let them
+                    // drift.
+                    importAiRefine: undefined,
                 },
             });
             setSavedAt(Date.now());
@@ -64,26 +99,94 @@ export default function CloudAIExperimentalSettings() {
                 )}
             </div>
 
-            <label className="flex items-start gap-2 text-sm">
-                <input
-                    type="checkbox"
-                    checked={refine}
-                    onChange={(e) => handleChange(e.target.checked)}
-                    className="mt-1 accent-indigo-500"
-                />
-                <span>
-                    <span className="flex items-center gap-1.5 font-medium text-gray-700 dark:text-gray-300">
+            <div className="space-y-4">
+                {/* Intensity selector */}
+                <div>
+                    <label className="flex items-center gap-1.5 text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">
                         <Sparkles className="w-4 h-4 text-purple-500" />
-                        匯入後自動執行 AI 精修字幕
-                    </span>
-                    <span className="block text-[11px] text-gray-500 dark:text-gray-400 mt-0.5">
-                        粗翻譯完成後請 LLM 修正 ASR 錯誤 + 自然中文。
-                        <span className="text-amber-600 dark:text-amber-500">
-                            1 小時影片 ≈ 130k tokens（GPT-4o ≈ $1、Claude Sonnet ≈ $1.5、GitHub Models 免費但可能撞 rate limit）
-                        </span>。預設關閉。
-                    </span>
-                </span>
-            </label>
+                        AI 精修字幕強度
+                    </label>
+                    <p className="text-[11px] text-gray-500 dark:text-gray-400 mb-2">
+                        粗翻譯由本機 CT2 完成後，選擇是否請雲端 LLM 再潤飾。
+                        批次以 5 分鐘為一段（70 分鐘講堂 ≈ 14 次 LLM 呼叫）。
+                    </p>
+                    <div className="flex gap-2">
+                        {(
+                            [
+                                { id: 'off' as const, label: '關', hint: '不呼叫 LLM' },
+                                { id: 'light' as const, label: '輕量', hint: '~15k tokens / 小時' },
+                                { id: 'deep' as const, label: '深度', hint: '~50k tokens / 小時' },
+                            ]
+                        ).map((opt) => (
+                            <button
+                                key={opt.id}
+                                onClick={() => {
+                                    setIntensity(opt.id);
+                                    void patch({ refineIntensity: opt.id });
+                                }}
+                                className={`flex-1 text-xs px-3 py-2 rounded-md border transition-colors ${
+                                    intensity === opt.id
+                                        ? 'border-indigo-300 bg-indigo-50 text-indigo-700 dark:border-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300'
+                                        : 'border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-slate-800/50'
+                                }`}
+                            >
+                                <div className="font-medium">{opt.label}</div>
+                                <div className="text-[10px] opacity-75 mt-0.5">{opt.hint}</div>
+                            </button>
+                        ))}
+                    </div>
+                    {intensity !== 'off' && (
+                        <p className="text-[11px] text-gray-500 dark:text-gray-400 mt-2">
+                            {intensity === 'light' ? (
+                                <>
+                                    <Gauge className="w-3 h-3 inline mr-1 text-emerald-500" />
+                                    使用 mid-tier 模型（GPT-4o-mini / Haiku / Gemini Flash）。
+                                    修語法、術語；保留原意。適合日常使用。
+                                </>
+                            ) : (
+                                <>
+                                    <Zap className="w-3 h-3 inline mr-1 text-amber-500" />
+                                    使用 upper-mid / frontier 模型（Mistral Large 2 /
+                                    Claude Sonnet）。跨 section 保持術語一致、整段重寫可讀性。
+                                    token 花費較高，免費層可能撞限額。
+                                </>
+                            )}
+                        </p>
+                    )}
+                </div>
+
+                {/* Provider pick (only meaningful if intensity != off) */}
+                {intensity !== 'off' && (
+                    <div>
+                        <label className="flex items-center gap-1.5 text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">
+                            LLM 提供者
+                        </label>
+                        <p className="text-[11px] text-gray-500 dark:text-gray-400 mb-2">
+                            依序嘗試你已登入的 provider；任一 rate-limit 就自動換下一個。
+                            想固定一個就選下拉；選「自動」則依下列優先順序。
+                        </p>
+                        <select
+                            value={provider}
+                            onChange={(e) => {
+                                const v = e.target.value as Provider;
+                                setProvider(v);
+                                void patch({ refineProvider: v });
+                            }}
+                            className="w-full text-sm px-2 py-1.5 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-gray-100"
+                        >
+                            <option value="auto">自動（ChatGPT OAuth → Copilot OAuth → 本機 → 免費 API → 使用者金鑰）</option>
+                            <option value="chatgpt-oauth">ChatGPT Plus（已登入）— 用你的訂閱額度</option>
+                            <option value="github-models">GitHub Models（Copilot 已登入）— 用你的 Copilot 額度</option>
+                            <option value="ollama">本機 Ollama — 無限，需 GPU ≥ 12 GB VRAM</option>
+                            <option value="gemini">Google Gemini 2.5 Flash — 免費 500 req/day</option>
+                            <option value="groq">Groq Llama 3.3 70B — 免費 14.4k req/day、速度最快</option>
+                            <option value="mistral">Mistral La Plateforme Experiment — 免費 1B token/月</option>
+                            <option value="openrouter">OpenRouter 免費模型 — 50 req/day</option>
+                            <option value="user-key">使用者貼的 API 金鑰（在 AI 提供者頁設定）</option>
+                        </select>
+                    </div>
+                )}
+            </div>
         </div>
     );
 }

--- a/ClassNoteAI/src/components/settings/ExperimentalSettings.tsx
+++ b/ClassNoteAI/src/components/settings/ExperimentalSettings.tsx
@@ -1,9 +1,17 @@
 import { useEffect, useState } from 'react';
-import { FlaskConical, Zap, Sparkles, Cpu } from 'lucide-react';
+import { FlaskConical, Zap, Sparkles, Cpu, CheckCircle2, XCircle } from 'lucide-react';
+import { invoke } from '@tauri-apps/api/core';
 import { storageService } from '../../services/storageService';
 
 type Speed = 'fast' | 'standard';
 type Backend = 'auto' | 'cuda' | 'metal' | 'vulkan' | 'cpu';
+
+interface GpuDetection {
+    cuda: { gpu_name: string; driver_version: string } | null;
+    metal: boolean;
+    vulkan: boolean;
+    effective: string;
+}
 
 /**
  * v0.6.1 experimental / opt-in defaults for the video-import pipeline.
@@ -21,6 +29,7 @@ export default function ExperimentalSettings() {
     const [speed, setSpeed] = useState<Speed>('fast');
     const [refine, setRefine] = useState<boolean>(false);
     const [backend, setBackend] = useState<Backend>('auto');
+    const [detection, setDetection] = useState<GpuDetection | null>(null);
     const [loaded, setLoaded] = useState(false);
     const [savedAt, setSavedAt] = useState<number | null>(null);
 
@@ -32,6 +41,17 @@ export default function ExperimentalSettings() {
                 if (exp?.importSpeed) setSpeed(exp.importSpeed);
                 if (typeof exp?.importAiRefine === 'boolean') setRefine(exp.importAiRefine);
                 if (exp?.asrBackend) setBackend(exp.asrBackend);
+                // Kick off GPU detection in parallel — runs a couple of
+                // fork/exec + filesystem stats, ~10 ms. Safe to re-run
+                // per settings-page-open since it's pure inspection.
+                try {
+                    const d = await invoke<GpuDetection>('detect_gpu_backends', {
+                        preference: exp?.asrBackend ?? 'auto',
+                    });
+                    setDetection(d);
+                } catch {
+                    /* older binary without the command — leave null */
+                }
             } finally {
                 setLoaded(true);
             }
@@ -131,17 +151,56 @@ export default function ExperimentalSettings() {
                     </label>
                 </div>
 
-                {/* GPU backend selector — Phase 1 stub */}
+                {/* GPU backend selector — Phase 2: detection live,
+                    execution pending Phase 4 (GPU-enabled build). */}
                 <div>
                     <label className="flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">
                         <Cpu className="w-4 h-4 text-blue-500" />
                         ASR 加速後端
-                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400 font-normal">
-                            尚未啟用
-                        </span>
                     </label>
+
+                    {/* Live detection readout — builds the right mental
+                        model: "your machine CAN do CUDA, but the app
+                        build you have right now doesn't include it." */}
+                    {detection && (
+                        <div className="mb-2 p-2.5 rounded-md bg-white dark:bg-slate-900/50 border border-gray-200 dark:border-gray-700 space-y-1">
+                            <DetRow
+                                ok={!!detection.cuda}
+                                label="CUDA (NVIDIA)"
+                                detail={
+                                    detection.cuda
+                                        ? `${detection.cuda.gpu_name} · driver ${detection.cuda.driver_version}`
+                                        : '未偵測到 NVIDIA 驅動'
+                                }
+                            />
+                            <DetRow
+                                ok={detection.metal}
+                                label="Metal (macOS)"
+                                detail={detection.metal ? '原生支援' : '不適用此系統'}
+                            />
+                            <DetRow
+                                ok={detection.vulkan}
+                                label="Vulkan"
+                                detail={
+                                    detection.vulkan
+                                        ? 'Vulkan loader 已存在'
+                                        : '未偵測到 Vulkan runtime'
+                                }
+                            />
+                            <div className="text-[11px] text-gray-500 dark:text-gray-400 pt-1 border-t border-gray-100 dark:border-gray-800 mt-1">
+                                目前版本使用：
+                                <span className="font-mono font-medium text-gray-700 dark:text-gray-300 ml-1">
+                                    CPU
+                                </span>
+                                <span className="ml-2 text-amber-600 dark:text-amber-500">
+                                    （GPU build 需等 Phase 4 的發布版，會內建 cudart DLL 自動啟用。你不需要自行安裝 CUDA Toolkit。）
+                                </span>
+                            </div>
+                        </div>
+                    )}
+
                     <p className="text-[11px] text-gray-500 dark:text-gray-400 mb-2">
-                        選擇 Whisper 轉錄使用的後端。目前版本所有 build 都是 CPU，GPU 支援會在之後的版本啟用（需要 CUDA Toolkit 或 Vulkan SDK 打包）。現在設定值只會儲存，不會生效。
+                        設定你偏好的後端。等 GPU build 就緒後，這個選項會被 Whisper 實際採用；目前先儲存你的偏好。
                     </p>
                     <select
                         value={backend}
@@ -152,14 +211,40 @@ export default function ExperimentalSettings() {
                         }}
                         className="text-sm px-2 py-1 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-gray-100"
                     >
-                        <option value="auto">自動（偵測可用 GPU，否則 CPU）</option>
-                        <option value="cuda">CUDA（NVIDIA）</option>
-                        <option value="metal">Metal（macOS）</option>
-                        <option value="vulkan">Vulkan（跨廠牌）</option>
+                        <option value="auto">自動（優先用最快的可用後端）</option>
+                        <option value="cuda" disabled={!detection?.cuda}>
+                            CUDA（NVIDIA）
+                            {detection && !detection.cuda ? ' — 未偵測' : ''}
+                        </option>
+                        <option value="metal" disabled={!detection?.metal}>
+                            Metal（macOS）
+                            {detection && !detection.metal ? ' — 不適用' : ''}
+                        </option>
+                        <option value="vulkan" disabled={!detection?.vulkan}>
+                            Vulkan（跨廠牌）
+                            {detection && !detection.vulkan ? ' — 未偵測' : ''}
+                        </option>
                         <option value="cpu">強制 CPU</option>
                     </select>
                 </div>
             </div>
+        </div>
+    );
+}
+
+/** Small status row inside the GPU detection readout. */
+function DetRow({ ok, label, detail }: { ok: boolean; label: string; detail: string }) {
+    return (
+        <div className="flex items-start gap-2 text-[11px]">
+            {ok ? (
+                <CheckCircle2 className="w-3.5 h-3.5 text-green-500 mt-0.5 flex-shrink-0" />
+            ) : (
+                <XCircle className="w-3.5 h-3.5 text-gray-400 mt-0.5 flex-shrink-0" />
+            )}
+            <span className={ok ? 'text-gray-700 dark:text-gray-300' : 'text-gray-400 dark:text-gray-500'}>
+                <span className="font-medium">{label}</span>
+                <span className="ml-1">— {detail}</span>
+            </span>
         </div>
     );
 }

--- a/ClassNoteAI/src/components/settings/ExperimentalSettings.tsx
+++ b/ClassNoteAI/src/components/settings/ExperimentalSettings.tsx
@@ -1,0 +1,165 @@
+import { useEffect, useState } from 'react';
+import { FlaskConical, Zap, Sparkles, Cpu } from 'lucide-react';
+import { storageService } from '../../services/storageService';
+
+type Speed = 'fast' | 'standard';
+type Backend = 'auto' | 'cuda' | 'metal' | 'vulkan' | 'cpu';
+
+/**
+ * v0.6.1 experimental / opt-in defaults for the video-import pipeline.
+ * Previously the user had to pick speed + AI-refine from the
+ * ImportModal every single time; those selectors now fall back to the
+ * values here so users with a consistent workflow (always fast, always
+ * refine, etc.) can set-and-forget.
+ *
+ * Also the staging area for upcoming toggles — GPU backend selector
+ * lives here but is display-only in Phase 1 since the build doesn't
+ * link any GPU features yet. When Phase 2+ lands the runtime detector,
+ * this same control will flip to active without further UI work.
+ */
+export default function ExperimentalSettings() {
+    const [speed, setSpeed] = useState<Speed>('fast');
+    const [refine, setRefine] = useState<boolean>(false);
+    const [backend, setBackend] = useState<Backend>('auto');
+    const [loaded, setLoaded] = useState(false);
+    const [savedAt, setSavedAt] = useState<number | null>(null);
+
+    useEffect(() => {
+        (async () => {
+            try {
+                const s = await storageService.getAppSettings();
+                const exp = s?.experimental;
+                if (exp?.importSpeed) setSpeed(exp.importSpeed);
+                if (typeof exp?.importAiRefine === 'boolean') setRefine(exp.importAiRefine);
+                if (exp?.asrBackend) setBackend(exp.asrBackend);
+            } finally {
+                setLoaded(true);
+            }
+        })();
+    }, []);
+
+    const save = async (next: {
+        importSpeed?: Speed;
+        importAiRefine?: boolean;
+        asrBackend?: Backend;
+    }) => {
+        try {
+            const existing = await storageService.getAppSettings();
+            if (!existing) return;
+            await storageService.saveAppSettings({
+                ...existing,
+                experimental: { ...(existing.experimental ?? {}), ...next },
+            });
+            setSavedAt(Date.now());
+        } catch (err) {
+            console.error('[ExperimentalSettings] save failed:', err);
+        }
+    };
+
+    if (!loaded) return null;
+
+    return (
+        <div className="rounded-lg border border-gray-200 dark:border-gray-700 bg-gray-50 dark:bg-slate-900/50 p-4">
+            <div className="flex items-center gap-2 mb-3">
+                <FlaskConical className="w-4 h-4 text-gray-500" />
+                <span className="text-sm font-medium text-gray-700 dark:text-gray-300">
+                    實驗性功能
+                </span>
+                {savedAt && Date.now() - savedAt < 2000 && (
+                    <span className="text-[10px] text-green-600 dark:text-green-400">已保存</span>
+                )}
+            </div>
+            <p className="text-xs text-gray-500 dark:text-gray-400 mb-4">
+                匯入影片時的預設行為。每次匯入還是可以在對話框裡臨時覆蓋這些設定。
+            </p>
+
+            <div className="space-y-4">
+                {/* Import speed default */}
+                <div>
+                    <label className="flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">
+                        <Zap className="w-4 h-4 text-amber-500" />
+                        匯入轉錄速度預設
+                    </label>
+                    <p className="text-[11px] text-gray-500 dark:text-gray-400 mb-2">
+                        快速 = 使用 base 模型（每小時影片約 5-10 分鐘）。
+                        標準 = 使用主設定的 Whisper 模型（通常較慢但精度高）。
+                    </p>
+                    <div className="flex gap-2">
+                        {(['fast', 'standard'] as Speed[]).map((v) => (
+                            <button
+                                key={v}
+                                onClick={() => {
+                                    setSpeed(v);
+                                    void save({ importSpeed: v });
+                                }}
+                                className={`text-xs px-3 py-1.5 rounded-md border transition-colors ${
+                                    speed === v
+                                        ? 'border-indigo-300 bg-indigo-50 text-indigo-700 dark:border-indigo-700 dark:bg-indigo-900/30 dark:text-indigo-300'
+                                        : 'border-gray-200 dark:border-gray-700 text-gray-700 dark:text-gray-300 hover:bg-gray-100 dark:hover:bg-slate-800/50'
+                                }`}
+                            >
+                                {v === 'fast' ? '快速 (base)' : '標準'}
+                            </button>
+                        ))}
+                    </div>
+                </div>
+
+                {/* AI refine default */}
+                <div>
+                    <label className="flex items-start gap-2 text-sm">
+                        <input
+                            type="checkbox"
+                            checked={refine}
+                            onChange={(e) => {
+                                setRefine(e.target.checked);
+                                void save({ importAiRefine: e.target.checked });
+                            }}
+                            className="mt-1 accent-indigo-500"
+                        />
+                        <span>
+                            <span className="flex items-center gap-1.5 font-medium text-gray-700 dark:text-gray-300">
+                                <Sparkles className="w-4 h-4 text-purple-500" />
+                                匯入後自動執行 AI 精修字幕
+                            </span>
+                            <span className="block text-[11px] text-gray-500 dark:text-gray-400 mt-0.5">
+                                粗翻譯完成後請 LLM 修正 ASR 錯誤 + 自然中文。
+                                <span className="text-amber-600 dark:text-amber-500">
+                                    預估 1 小時影片 ≈ 130k tokens（GPT-4o ≈ $1、Claude Sonnet ≈ $1.5、GitHub Models 免費但可能撞 rate limit）
+                                </span>。預設關閉。
+                            </span>
+                        </span>
+                    </label>
+                </div>
+
+                {/* GPU backend selector — Phase 1 stub */}
+                <div>
+                    <label className="flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">
+                        <Cpu className="w-4 h-4 text-blue-500" />
+                        ASR 加速後端
+                        <span className="text-[10px] px-1.5 py-0.5 rounded bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400 font-normal">
+                            尚未啟用
+                        </span>
+                    </label>
+                    <p className="text-[11px] text-gray-500 dark:text-gray-400 mb-2">
+                        選擇 Whisper 轉錄使用的後端。目前版本所有 build 都是 CPU，GPU 支援會在之後的版本啟用（需要 CUDA Toolkit 或 Vulkan SDK 打包）。現在設定值只會儲存，不會生效。
+                    </p>
+                    <select
+                        value={backend}
+                        onChange={(e) => {
+                            const v = e.target.value as Backend;
+                            setBackend(v);
+                            void save({ asrBackend: v });
+                        }}
+                        className="text-sm px-2 py-1 rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-gray-100"
+                    >
+                        <option value="auto">自動（偵測可用 GPU，否則 CPU）</option>
+                        <option value="cuda">CUDA（NVIDIA）</option>
+                        <option value="metal">Metal（macOS）</option>
+                        <option value="vulkan">Vulkan（跨廠牌）</option>
+                        <option value="cpu">強制 CPU</option>
+                    </select>
+                </div>
+            </div>
+        </div>
+    );
+}

--- a/ClassNoteAI/src/components/settings/LocalModelExperimentalSettings.tsx
+++ b/ClassNoteAI/src/components/settings/LocalModelExperimentalSettings.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { FlaskConical, Zap, Cpu, CheckCircle2, XCircle, AlertTriangle, ExternalLink } from 'lucide-react';
+import { FlaskConical, Zap, Cpu, CheckCircle2, XCircle, AlertTriangle, ExternalLink, Terminal } from 'lucide-react';
 import { invoke } from '@tauri-apps/api/core';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import { storageService } from '../../services/storageService';
@@ -41,6 +41,13 @@ export default function LocalModelExperimentalSettings() {
     const [detection, setDetection] = useState<GpuDetection | null>(null);
     const [loaded, setLoaded] = useState(false);
     const [savedAt, setSavedAt] = useState<number | null>(null);
+    // v0.6.0-alpha.2: opt-in remote debug port. Read straight from a
+    // Rust-managed TOML flag (not AppSettings) because the flag is
+    // consumed by main() *before* Tauri/SQLite come up — the UI
+    // here just reflects + toggles it. Restart required to take
+    // effect: we render a "待重啟" badge after toggling.
+    const [cdpOn, setCdpOn] = useState<boolean>(false);
+    const [cdpChangedAt, setCdpChangedAt] = useState<number | null>(null);
 
     useEffect(() => {
         (async () => {
@@ -56,6 +63,12 @@ export default function LocalModelExperimentalSettings() {
                     setDetection(d);
                 } catch {
                     /* older binary — leave null */
+                }
+                try {
+                    const cdp = await invoke<boolean>('get_remote_debug_enabled');
+                    setCdpOn(cdp);
+                } catch {
+                    /* older binary without the command — default off */
                 }
             } finally {
                 setLoaded(true);
@@ -225,6 +238,51 @@ export default function LocalModelExperimentalSettings() {
                         </option>
                         <option value="cpu">強制 CPU</option>
                     </select>
+                </div>
+
+                {/* Remote debug port — developer / agent mode */}
+                <div className="pt-3 border-t border-gray-200 dark:border-gray-700">
+                    <label className="flex items-start gap-2 text-sm">
+                        <input
+                            type="checkbox"
+                            checked={cdpOn}
+                            onChange={async (e) => {
+                                const next = e.target.checked;
+                                setCdpOn(next);
+                                try {
+                                    await invoke('set_remote_debug_enabled', { enabled: next });
+                                    setCdpChangedAt(Date.now());
+                                } catch (err) {
+                                    console.error('[DevFlags] save failed:', err);
+                                    setCdpOn(!next); // revert
+                                }
+                            }}
+                            className="mt-1 accent-indigo-500"
+                        />
+                        <span>
+                            <span className="flex items-center gap-1.5 font-medium text-gray-700 dark:text-gray-300">
+                                <Terminal className="w-4 h-4 text-slate-500" />
+                                開啟遠端除錯 / Agent port
+                                {cdpChangedAt && Date.now() - cdpChangedAt < 10000 && (
+                                    <span className="text-[10px] text-amber-600 dark:text-amber-400 ml-1">
+                                        請重啟應用程式以生效
+                                    </span>
+                                )}
+                            </span>
+                            <span className="block text-[11px] text-gray-500 dark:text-gray-400 mt-0.5 leading-relaxed">
+                                在 <code className="text-[10px]">127.0.0.1:9222</code> 開啟
+                                Chrome DevTools Protocol，方便自動化測試腳本（
+                                <code className="text-[10px]">scripts/cdp.cjs</code>、Playwright、
+                                AI Agent 等）連進來操作應用程式。
+                                <span className="text-amber-600 dark:text-amber-500">
+                                    注意：
+                                </span>
+                                任何能連到 localhost 的程式都能讀寫你的資料，
+                                正式使用時請關掉。
+                                變更需下次啟動才生效。
+                            </span>
+                        </span>
+                    </label>
                 </div>
             </div>
         </div>

--- a/ClassNoteAI/src/components/settings/LocalModelExperimentalSettings.tsx
+++ b/ClassNoteAI/src/components/settings/LocalModelExperimentalSettings.tsx
@@ -1,16 +1,26 @@
 import { useEffect, useState } from 'react';
-import { FlaskConical, Zap, Cpu, CheckCircle2, XCircle } from 'lucide-react';
+import { FlaskConical, Zap, Cpu, CheckCircle2, XCircle, AlertTriangle, ExternalLink } from 'lucide-react';
 import { invoke } from '@tauri-apps/api/core';
+import { openUrl } from '@tauri-apps/plugin-opener';
 import { storageService } from '../../services/storageService';
 
 type Speed = 'fast' | 'standard';
 type Backend = 'auto' | 'cuda' | 'metal' | 'vulkan' | 'cpu';
+
+interface DriverHint {
+    severity: string;
+    title: string;
+    message: string;
+    action_url: string;
+    action_label: string;
+}
 
 interface GpuDetection {
     cuda: { gpu_name: string; driver_version: string } | null;
     metal: boolean;
     vulkan: boolean;
     effective: string;
+    driver_hint?: DriverHint | null;
 }
 
 /**
@@ -121,6 +131,51 @@ export default function LocalModelExperimentalSettings() {
                     <p className="text-[11px] text-gray-500 dark:text-gray-400 mb-2">
                         套用到所有支援 GPU 的本地模型：Whisper 轉錄、BGE 向量索引、CT2 本地翻譯。
                     </p>
+
+                    {detection?.driver_hint && (
+                        // Non-blocking advisory for driver mismatch. Shown
+                        // when we see a GPU but the driver is older than
+                        // our shipped CUDA runtime needs. Rust side fills
+                        // in the exact version numbers + download URL.
+                        <div
+                            className={`mb-2 p-3 rounded-md border flex gap-2.5 ${
+                                detection.driver_hint.severity === 'warning'
+                                    ? 'bg-amber-50 dark:bg-amber-900/10 border-amber-200 dark:border-amber-900/40'
+                                    : 'bg-blue-50 dark:bg-blue-900/10 border-blue-200 dark:border-blue-900/40'
+                            }`}
+                        >
+                            <AlertTriangle
+                                className={`w-4 h-4 mt-0.5 flex-shrink-0 ${
+                                    detection.driver_hint.severity === 'warning'
+                                        ? 'text-amber-500'
+                                        : 'text-blue-500'
+                                }`}
+                            />
+                            <div className="flex-1 min-w-0">
+                                <div
+                                    className={`text-xs font-semibold mb-1 ${
+                                        detection.driver_hint.severity === 'warning'
+                                            ? 'text-amber-800 dark:text-amber-300'
+                                            : 'text-blue-800 dark:text-blue-300'
+                                    }`}
+                                >
+                                    {detection.driver_hint.title}
+                                </div>
+                                <p className="text-[11px] text-gray-700 dark:text-gray-300 leading-relaxed">
+                                    {detection.driver_hint.message}
+                                </p>
+                                <button
+                                    onClick={() => {
+                                        void openUrl(detection.driver_hint!.action_url);
+                                    }}
+                                    className="mt-2 inline-flex items-center gap-1 text-[11px] font-medium text-indigo-600 dark:text-indigo-400 hover:text-indigo-700 dark:hover:text-indigo-300"
+                                >
+                                    {detection.driver_hint.action_label}
+                                    <ExternalLink className="w-3 h-3" />
+                                </button>
+                            </div>
+                        </div>
+                    )}
 
                     {detection && (
                         <div className="mb-2 p-2.5 rounded-md bg-white dark:bg-slate-900/50 border border-gray-200 dark:border-gray-700 space-y-1">

--- a/ClassNoteAI/src/components/settings/LocalModelExperimentalSettings.tsx
+++ b/ClassNoteAI/src/components/settings/LocalModelExperimentalSettings.tsx
@@ -1,5 +1,5 @@
 import { useEffect, useState } from 'react';
-import { FlaskConical, Zap, Sparkles, Cpu, CheckCircle2, XCircle } from 'lucide-react';
+import { FlaskConical, Zap, Cpu, CheckCircle2, XCircle } from 'lucide-react';
 import { invoke } from '@tauri-apps/api/core';
 import { storageService } from '../../services/storageService';
 
@@ -14,20 +14,19 @@ interface GpuDetection {
 }
 
 /**
- * v0.6.1 experimental / opt-in defaults for the video-import pipeline.
- * Previously the user had to pick speed + AI-refine from the
- * ImportModal every single time; those selectors now fall back to the
- * values here so users with a consistent workflow (always fast, always
- * refine, etc.) can set-and-forget.
+ * v0.6.1: experimental / opt-in defaults that belong to the **本地
+ * 轉錄模型** category — anything that tunes how the local Whisper
+ * pipeline runs. Lives under Settings → 本地轉錄模型.
  *
- * Also the staging area for upcoming toggles — GPU backend selector
- * lives here but is display-only in Phase 1 since the build doesn't
- * link any GPU features yet. When Phase 2+ lands the runtime detector,
- * this same control will flip to active without further UI work.
+ *   - importSpeed      which Whisper model variant powers bulk video
+ *                      imports (base vs the user's main model)
+ *   - asrBackend + GPU readout   CPU / CUDA / Metal / Vulkan preference
+ *
+ * LLM-backed fine refinement lives in CloudAIExperimentalSettings
+ * because it hits a cloud API, not the local model.
  */
-export default function ExperimentalSettings() {
+export default function LocalModelExperimentalSettings() {
     const [speed, setSpeed] = useState<Speed>('fast');
-    const [refine, setRefine] = useState<boolean>(false);
     const [backend, setBackend] = useState<Backend>('auto');
     const [detection, setDetection] = useState<GpuDetection | null>(null);
     const [loaded, setLoaded] = useState(false);
@@ -39,18 +38,14 @@ export default function ExperimentalSettings() {
                 const s = await storageService.getAppSettings();
                 const exp = s?.experimental;
                 if (exp?.importSpeed) setSpeed(exp.importSpeed);
-                if (typeof exp?.importAiRefine === 'boolean') setRefine(exp.importAiRefine);
                 if (exp?.asrBackend) setBackend(exp.asrBackend);
-                // Kick off GPU detection in parallel — runs a couple of
-                // fork/exec + filesystem stats, ~10 ms. Safe to re-run
-                // per settings-page-open since it's pure inspection.
                 try {
                     const d = await invoke<GpuDetection>('detect_gpu_backends', {
                         preference: exp?.asrBackend ?? 'auto',
                     });
                     setDetection(d);
                 } catch {
-                    /* older binary without the command — leave null */
+                    /* older binary — leave null */
                 }
             } finally {
                 setLoaded(true);
@@ -58,21 +53,17 @@ export default function ExperimentalSettings() {
         })();
     }, []);
 
-    const save = async (next: {
-        importSpeed?: Speed;
-        importAiRefine?: boolean;
-        asrBackend?: Backend;
-    }) => {
+    const save = async (patch: Partial<{ importSpeed: Speed; asrBackend: Backend }>) => {
         try {
             const existing = await storageService.getAppSettings();
             if (!existing) return;
             await storageService.saveAppSettings({
                 ...existing,
-                experimental: { ...(existing.experimental ?? {}), ...next },
+                experimental: { ...(existing.experimental ?? {}), ...patch },
             });
             setSavedAt(Date.now());
         } catch (err) {
-            console.error('[ExperimentalSettings] save failed:', err);
+            console.error('[LocalModelExperimental] save failed:', err);
         }
     };
 
@@ -89,9 +80,6 @@ export default function ExperimentalSettings() {
                     <span className="text-[10px] text-green-600 dark:text-green-400">已保存</span>
                 )}
             </div>
-            <p className="text-xs text-gray-500 dark:text-gray-400 mb-4">
-                匯入影片時的預設行為。每次匯入還是可以在對話框裡臨時覆蓋這些設定。
-            </p>
 
             <div className="space-y-4">
                 {/* Import speed default */}
@@ -101,8 +89,8 @@ export default function ExperimentalSettings() {
                         匯入轉錄速度預設
                     </label>
                     <p className="text-[11px] text-gray-500 dark:text-gray-400 mb-2">
-                        快速 = 使用 base 模型（每小時影片約 5-10 分鐘）。
-                        標準 = 使用主設定的 Whisper 模型（通常較慢但精度高）。
+                        快速 = base 模型（約 5-10 分鐘/小時影片）。
+                        標準 = 主設定的 Whisper 模型（通常較慢但精度高）。
                     </p>
                     <div className="flex gap-2">
                         {(['fast', 'standard'] as Speed[]).map((v) => (
@@ -124,44 +112,13 @@ export default function ExperimentalSettings() {
                     </div>
                 </div>
 
-                {/* AI refine default */}
-                <div>
-                    <label className="flex items-start gap-2 text-sm">
-                        <input
-                            type="checkbox"
-                            checked={refine}
-                            onChange={(e) => {
-                                setRefine(e.target.checked);
-                                void save({ importAiRefine: e.target.checked });
-                            }}
-                            className="mt-1 accent-indigo-500"
-                        />
-                        <span>
-                            <span className="flex items-center gap-1.5 font-medium text-gray-700 dark:text-gray-300">
-                                <Sparkles className="w-4 h-4 text-purple-500" />
-                                匯入後自動執行 AI 精修字幕
-                            </span>
-                            <span className="block text-[11px] text-gray-500 dark:text-gray-400 mt-0.5">
-                                粗翻譯完成後請 LLM 修正 ASR 錯誤 + 自然中文。
-                                <span className="text-amber-600 dark:text-amber-500">
-                                    預估 1 小時影片 ≈ 130k tokens（GPT-4o ≈ $1、Claude Sonnet ≈ $1.5、GitHub Models 免費但可能撞 rate limit）
-                                </span>。預設關閉。
-                            </span>
-                        </span>
-                    </label>
-                </div>
-
-                {/* GPU backend selector — Phase 2: detection live,
-                    execution pending Phase 4 (GPU-enabled build). */}
+                {/* GPU backend selector + detection readout */}
                 <div>
                     <label className="flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">
                         <Cpu className="w-4 h-4 text-blue-500" />
                         ASR 加速後端
                     </label>
 
-                    {/* Live detection readout — builds the right mental
-                        model: "your machine CAN do CUDA, but the app
-                        build you have right now doesn't include it." */}
                     {detection && (
                         <div className="mb-2 p-2.5 rounded-md bg-white dark:bg-slate-900/50 border border-gray-200 dark:border-gray-700 space-y-1">
                             <DetRow
@@ -181,27 +138,11 @@ export default function ExperimentalSettings() {
                             <DetRow
                                 ok={detection.vulkan}
                                 label="Vulkan"
-                                detail={
-                                    detection.vulkan
-                                        ? 'Vulkan loader 已存在'
-                                        : '未偵測到 Vulkan runtime'
-                                }
+                                detail={detection.vulkan ? 'Vulkan loader 已存在' : '未偵測到 Vulkan runtime'}
                             />
-                            <div className="text-[11px] text-gray-500 dark:text-gray-400 pt-1 border-t border-gray-100 dark:border-gray-800 mt-1">
-                                目前版本使用：
-                                <span className="font-mono font-medium text-gray-700 dark:text-gray-300 ml-1">
-                                    CPU
-                                </span>
-                                <span className="ml-2 text-amber-600 dark:text-amber-500">
-                                    （GPU build 需等 Phase 4 的發布版，會內建 cudart DLL 自動啟用。你不需要自行安裝 CUDA Toolkit。）
-                                </span>
-                            </div>
                         </div>
                     )}
 
-                    <p className="text-[11px] text-gray-500 dark:text-gray-400 mb-2">
-                        設定你偏好的後端。等 GPU build 就緒後，這個選項會被 Whisper 實際採用；目前先儲存你的偏好。
-                    </p>
                     <select
                         value={backend}
                         onChange={(e) => {
@@ -232,7 +173,6 @@ export default function ExperimentalSettings() {
     );
 }
 
-/** Small status row inside the GPU detection readout. */
 function DetRow({ ok, label, detail }: { ok: boolean; label: string; detail: string }) {
     return (
         <div className="flex items-start gap-2 text-[11px]">

--- a/ClassNoteAI/src/components/settings/LocalModelExperimentalSettings.tsx
+++ b/ClassNoteAI/src/components/settings/LocalModelExperimentalSettings.tsx
@@ -116,8 +116,11 @@ export default function LocalModelExperimentalSettings() {
                 <div>
                     <label className="flex items-center gap-2 text-sm font-medium text-gray-700 dark:text-gray-300 mb-1.5">
                         <Cpu className="w-4 h-4 text-blue-500" />
-                        ASR 加速後端
+                        GPU 加速後端
                     </label>
+                    <p className="text-[11px] text-gray-500 dark:text-gray-400 mb-2">
+                        套用到所有支援 GPU 的本地模型：Whisper 轉錄、BGE 向量索引、CT2 本地翻譯。
+                    </p>
 
                     {detection && (
                         <div className="mb-2 p-2.5 rounded-md bg-white dark:bg-slate-900/50 border border-gray-200 dark:border-gray-700 space-y-1">

--- a/ClassNoteAI/src/components/settings/SettingsAboutUpdates.tsx
+++ b/ClassNoteAI/src/components/settings/SettingsAboutUpdates.tsx
@@ -1,4 +1,6 @@
 import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { openUrl } from "@tauri-apps/plugin-opener";
 import {
   Info,
   RefreshCw,
@@ -7,11 +9,19 @@ import {
   Cpu,
   RotateCcw,
   FlaskConical,
+  Copy,
+  FolderOpen,
+  Bug,
 } from "lucide-react";
 import { Card } from "./shared";
 import { setupService } from "../../services/setupService";
+import { storageService } from "../../services/storageService";
 import { toastService } from "../../services/toastService";
 import { confirmService } from "../../services/confirmService";
+import {
+  redactLogContent,
+  buildGithubIssueUrl,
+} from "../../services/logDiagnostics";
 import type { ReleaseChannel } from "../../services/updateService";
 
 interface Props {
@@ -28,6 +38,9 @@ export default function SettingsAboutUpdates({ appVersion }: Props) {
   const [isDownloading, setIsDownloading] = useState(false);
   const [downloadProgress, setDownloadProgress] = useState(0);
   const [channel, setChannel] = useState<ReleaseChannel>("stable");
+  const [logPreview, setLogPreview] = useState<string | null>(null);
+  const [logHits, setLogHits] = useState<Record<string, number>>({});
+  const [hasGithubProvider, setHasGithubProvider] = useState(true);
 
   // Load the user's current channel selection on mount. Default to
   // stable on any failure — see getReleaseChannel() for the same
@@ -41,6 +54,34 @@ export default function SettingsAboutUpdates({ appVersion }: Props) {
         if (!cancelled) setChannel(current);
       } catch (e) {
         console.warn("[SettingsAboutUpdates] Failed to read release channel:", e);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const settings = await storageService.getAppSettings();
+        const canReadLocalStorage = typeof window !== "undefined" &&
+          typeof window.localStorage !== "undefined";
+        const storedPat = canReadLocalStorage
+          ? window.localStorage.getItem("llm.github-models.pat")
+          : null;
+        const configured = typeof storedPat === "string"
+          ? storedPat.trim().length > 0
+          : !canReadLocalStorage
+          ? true
+          : settings?.experimental?.refineProvider === "github-models"
+          ? true
+          : false;
+        if (!cancelled) setHasGithubProvider(configured);
+      } catch (e) {
+        console.warn("[SettingsAboutUpdates] Failed to inspect GitHub Models state:", e);
+        if (!cancelled) setHasGithubProvider(true);
       }
     })();
     return () => {
@@ -114,9 +155,60 @@ export default function SettingsAboutUpdates({ appVersion }: Props) {
     }
   };
 
+  const handleCopyLog = async () => {
+    try {
+      const raw = await invoke<string>("read_recent_log", { lines: 500 });
+      const { redacted, hits } = redactLogContent(raw);
+      setLogPreview(redacted);
+      setLogHits(hits);
+    } catch (e) {
+      toastService.error(
+        "無法讀取診斷 log",
+        e instanceof Error ? e.message : String(e),
+      );
+    }
+  };
+
+  const handleOpenLogFolder = async () => {
+    try {
+      await invoke("open_log_folder");
+    } catch (e) {
+      toastService.error(
+        "無法開啟 log 資料夾",
+        e instanceof Error ? e.message : String(e),
+      );
+    }
+  };
+
+  const handleGithubIssue = async () => {
+    if (logPreview === null) return;
+    try {
+      await openUrl(buildGithubIssueUrl(logPreview, appVersion));
+    } catch (e) {
+      toastService.error(
+        "無法開啟 GitHub issue 頁面",
+        e instanceof Error ? e.message : String(e),
+      );
+    }
+  };
+
+  const handleConfirmCopyToClipboard = async () => {
+    if (logPreview === null) return;
+    try {
+      await navigator.clipboard.writeText(logPreview);
+      toastService.success("診斷 log 已複製");
+      setLogPreview(null);
+      setLogHits({});
+    } catch (e) {
+      toastService.error(
+        "無法複製診斷 log",
+        e instanceof Error ? e.message : String(e),
+      );
+    }
+  };
+
   const handleOpenDevTools = async () => {
     try {
-      const { invoke } = await import("@tauri-apps/api/core");
       await invoke("open_devtools");
     } catch (e) {
       console.error("Failed to open devtools:", e);
@@ -153,6 +245,8 @@ export default function SettingsAboutUpdates({ appVersion }: Props) {
 
   const isWindows = typeof navigator !== "undefined" &&
     navigator.userAgent.includes("Windows");
+  const redactionEntries = Object.entries(logHits).filter(([, count]) => count > 0);
+  const totalRedactions = redactionEntries.reduce((sum, [, count]) => sum + count, 0);
 
   return (
     <div className="space-y-6 animate-in fade-in duration-300">
@@ -290,6 +384,84 @@ export default function SettingsAboutUpdates({ appVersion }: Props) {
               {updateError}
             </div>
           )}
+
+        </div>
+      </Card>
+
+      <Card
+        title="診斷 log"
+        icon={<Info className="w-5 h-5 text-slate-500" />}
+      >
+        <div className="space-y-4">
+          <p className="text-sm text-gray-500 dark:text-gray-400">
+            預覽最近 500 行 app log，先在前端做敏感資訊遮罩，再決定是否複製或回報。
+          </p>
+          <div className="grid grid-cols-1 gap-2 sm:grid-cols-2">
+            <button
+              onClick={handleCopyLog}
+              className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-slate-700 hover:bg-slate-800 text-white rounded-lg transition-colors"
+            >
+              <Copy className="w-4 h-4" />
+              預覽並複製 log
+            </button>
+            <button
+              onClick={handleOpenLogFolder}
+              className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-white dark:bg-slate-800 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-slate-700 rounded-lg transition-colors"
+            >
+              <FolderOpen className="w-4 h-4" />
+              開啟 log 資料夾
+            </button>
+          </div>
+
+            {logPreview !== null && (
+              <div className="p-4 rounded-lg bg-gray-50 dark:bg-gray-900/50 border border-gray-200 dark:border-gray-700 space-y-3">
+                <div className="text-sm text-gray-700 dark:text-gray-300">
+                  <div className="font-medium">Redaction summary</div>
+                  <div className="text-xs text-gray-500 dark:text-gray-400 mt-1">
+                    {redactionEntries.length > 0
+                      ? `已遮罩 ${totalRedactions} 項：${redactionEntries
+                          .map(([label, count]) => `${label} ×${count}`)
+                          .join(", ")}`
+                      : "未偵測到需要遮罩的內容。"}
+                  </div>
+                </div>
+
+                <textarea
+                  readOnly
+                  value={logPreview}
+                  rows={12}
+                  className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-slate-950 px-3 py-2 text-xs font-mono text-gray-800 dark:text-gray-100"
+                />
+
+                <div className="grid grid-cols-1 gap-2 sm:grid-cols-3">
+                  <button
+                    onClick={handleConfirmCopyToClipboard}
+                    className="w-full flex items-center justify-center gap-2 px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white rounded-lg transition-colors"
+                  >
+                    <Copy className="w-4 h-4" />
+                    複製到剪貼簿
+                  </button>
+                  {hasGithubProvider && (
+                    <button
+                      onClick={handleGithubIssue}
+                      className="w-full flex items-center justify-center gap-2 px-4 py-2 bg-white dark:bg-slate-800 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-slate-700 rounded-lg transition-colors"
+                    >
+                      <Bug className="w-4 h-4" />
+                      GitHub issue
+                    </button>
+                  )}
+                  <button
+                    onClick={() => {
+                      setLogPreview(null);
+                      setLogHits({});
+                    }}
+                    className="w-full flex items-center justify-center gap-2 px-4 py-2 bg-white dark:bg-slate-800 border border-gray-300 dark:border-gray-600 text-gray-700 dark:text-gray-200 hover:bg-gray-50 dark:hover:bg-slate-700 rounded-lg transition-colors"
+                  >
+                    取消
+                  </button>
+                </div>
+              </div>
+            )}
         </div>
       </Card>
 

--- a/ClassNoteAI/src/components/settings/SettingsAboutUpdates.tsx
+++ b/ClassNoteAI/src/components/settings/SettingsAboutUpdates.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import {
   Info,
   RefreshCw,
@@ -6,11 +6,13 @@ import {
   CheckCircle,
   Cpu,
   RotateCcw,
+  FlaskConical,
 } from "lucide-react";
 import { Card } from "./shared";
 import { setupService } from "../../services/setupService";
 import { toastService } from "../../services/toastService";
 import { confirmService } from "../../services/confirmService";
+import type { ReleaseChannel } from "../../services/updateService";
 
 interface Props {
   appVersion: string;
@@ -25,6 +27,47 @@ export default function SettingsAboutUpdates({ appVersion }: Props) {
   const [updateError, setUpdateError] = useState<string | null>(null);
   const [isDownloading, setIsDownloading] = useState(false);
   const [downloadProgress, setDownloadProgress] = useState(0);
+  const [channel, setChannel] = useState<ReleaseChannel>("stable");
+
+  // Load the user's current channel selection on mount. Default to
+  // stable on any failure — see getReleaseChannel() for the same
+  // defensive stance on the service side.
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const { updateService } = await import("../../services/updateService");
+        const current = await updateService.getReleaseChannel();
+        if (!cancelled) setChannel(current);
+      } catch (e) {
+        console.warn("[SettingsAboutUpdates] Failed to read release channel:", e);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const handleChannelChange = async (next: ReleaseChannel) => {
+    const prev = channel;
+    setChannel(next);
+    // Clear any prior check result — the new channel might see a
+    // different "available" answer, and showing the stale one is
+    // misleading.
+    setUpdateInfo(null);
+    setUpdateError(null);
+    try {
+      const { updateService } = await import("../../services/updateService");
+      await updateService.setReleaseChannel(next);
+    } catch (e) {
+      console.error("[SettingsAboutUpdates] Failed to save channel:", e);
+      setChannel(prev);
+      toastService.error(
+        "無法儲存更新通道設定",
+        e instanceof Error ? e.message : String(e),
+      );
+    }
+  };
 
   const handleCheckUpdate = async () => {
     setIsCheckingUpdate(true);
@@ -123,7 +166,39 @@ export default function SettingsAboutUpdates({ appVersion }: Props) {
             <span className="font-mono">{appVersion}</span>
           </div>
 
-          <div className="border-t border-gray-200 dark:border-gray-700 pt-4">
+          <div className="border-t border-gray-200 dark:border-gray-700 pt-4 space-y-2">
+            <div className="flex items-center justify-between gap-3">
+              <div className="flex items-center gap-2">
+                <FlaskConical className="w-4 h-4 text-gray-500 dark:text-gray-400" />
+                <label
+                  htmlFor="release-channel"
+                  className="text-sm text-gray-700 dark:text-gray-300"
+                >
+                  更新通道
+                </label>
+              </div>
+              <select
+                id="release-channel"
+                value={channel}
+                onChange={(e) => handleChannelChange(e.target.value as ReleaseChannel)}
+                disabled={isCheckingUpdate || isDownloading}
+                className="text-sm px-2 py-1 rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-slate-800 text-gray-900 dark:text-gray-100 disabled:opacity-50"
+              >
+                <option value="stable">穩定版 (Stable)</option>
+                <option value="beta">Beta (公開測試版)</option>
+                <option value="alpha">Alpha (開發測試版)</option>
+              </select>
+            </div>
+            {channel !== "stable" && (
+              <p className="text-xs text-amber-700 dark:text-amber-400">
+                {channel === "alpha"
+                  ? "Alpha 版本可能包含未穩定功能，安裝時會開啟安裝程式請你手動完成。"
+                  : "Beta 版本功能接近正式版但仍在測試中，安裝時會開啟安裝程式請你手動完成。"}
+              </p>
+            )}
+          </div>
+
+          <div>
             <button
               onClick={handleCheckUpdate}
               disabled={isCheckingUpdate || isDownloading}
@@ -177,7 +252,7 @@ export default function SettingsAboutUpdates({ appVersion }: Props) {
                     )}
                   </button>
 
-                  {!isWindows && (
+                  {!isWindows && channel === "stable" && (
                     <>
                       <div className="relative flex py-1 items-center">
                         <div className="flex-grow border-t border-gray-200 dark:border-gray-700"></div>

--- a/ClassNoteAI/src/components/settings/SettingsAboutUpdates.tsx
+++ b/ClassNoteAI/src/components/settings/SettingsAboutUpdates.tsx
@@ -12,6 +12,7 @@ import {
   Copy,
   FolderOpen,
   Bug,
+  Package,
 } from "lucide-react";
 import { Card } from "./shared";
 import { setupService } from "../../services/setupService";
@@ -23,6 +24,7 @@ import {
   buildGithubIssueUrl,
 } from "../../services/logDiagnostics";
 import type { ReleaseChannel } from "../../services/updateService";
+import type { Lecture } from "../../types";
 
 interface Props {
   appVersion: string;
@@ -39,6 +41,10 @@ export default function SettingsAboutUpdates({ appVersion }: Props) {
   const [downloadProgress, setDownloadProgress] = useState(0);
   const [channel, setChannel] = useState<ReleaseChannel>("stable");
   const [logPreview, setLogPreview] = useState<string | null>(null);
+  const [isExporting, setIsExporting] = useState(false);
+  const [exportIncludeAudio, setExportIncludeAudio] = useState(false);
+  const [lectures, setLectures] = useState<Lecture[]>([]);
+  const [selectedLectureId, setSelectedLectureId] = useState<string>("");
   const [logHits, setLogHits] = useState<Record<string, number>>({});
   const [hasGithubProvider, setHasGithubProvider] = useState(true);
 
@@ -82,6 +88,31 @@ export default function SettingsAboutUpdates({ appVersion }: Props) {
       } catch (e) {
         console.warn("[SettingsAboutUpdates] Failed to inspect GitHub Models state:", e);
         if (!cancelled) setHasGithubProvider(true);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const list = await storageService.listLectures();
+        const sorted = [...list].sort(
+          (a, b) => new Date(b.created_at).getTime() - new Date(a.created_at).getTime(),
+        );
+        if (cancelled) return;
+        setLectures(sorted);
+        setSelectedLectureId((current) => {
+          if (current && sorted.some((lecture) => lecture.id === current)) {
+            return current;
+          }
+          return sorted[0]?.id ?? "";
+        });
+      } catch (e) {
+        console.warn("[SettingsAboutUpdates] Failed to load lectures:", e);
       }
     })();
     return () => {
@@ -177,6 +208,36 @@ export default function SettingsAboutUpdates({ appVersion }: Props) {
         "無法開啟 log 資料夾",
         e instanceof Error ? e.message : String(e),
       );
+    }
+  };
+
+  const handleExportPackage = async () => {
+    if (!selectedLectureId) {
+      toastService.error("請先選擇要匯出的講座");
+      return;
+    }
+
+    setIsExporting(true);
+    try {
+      const buildVariant = await invoke<string>("get_build_variant").catch(() => "cpu");
+      const { exportDiagnosticPackage, revealZipInFileManager } = await import(
+        "../../services/diagnosticsService"
+      );
+      const zipPath = await exportDiagnosticPackage({
+        lectureId: selectedLectureId,
+        includeAudio: exportIncludeAudio,
+        appVersion,
+        buildVariant,
+      });
+      toastService.success("診斷封包已匯出到下載資料夾");
+      await revealZipInFileManager(zipPath);
+    } catch (e) {
+      toastService.error(
+        "匯出診斷封包失敗",
+        e instanceof Error ? e.message : String(e),
+      );
+    } finally {
+      setIsExporting(false);
     }
   };
 
@@ -413,7 +474,56 @@ export default function SettingsAboutUpdates({ appVersion }: Props) {
             </button>
           </div>
 
-            {logPreview !== null && (
+          <div className="border-t border-gray-200 dark:border-gray-700 pt-4 space-y-3">
+            <div className="space-y-1">
+              <div className="flex items-center gap-2 text-sm font-medium text-gray-800 dark:text-gray-100">
+                <Package className="w-4 h-4 text-violet-500" />
+                <span>匯出完整診斷封包</span>
+              </div>
+              <p className="text-sm text-gray-500 dark:text-gray-400">
+                會將講座資料、字幕、已遮罩的 log 與中繼資料打包成 ZIP 存到下載資料夾，可選擇是否附帶音訊；不會自動上傳。
+              </p>
+            </div>
+
+            <select
+              value={selectedLectureId}
+              onChange={(e) => setSelectedLectureId(e.target.value)}
+              disabled={isExporting || lectures.length === 0}
+              className="w-full rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-slate-800 px-3 py-2 text-sm text-gray-900 dark:text-gray-100 disabled:opacity-50"
+            >
+              {lectures.length === 0 ? (
+                <option value="">目前沒有可匯出的講座</option>
+              ) : (
+                lectures.map((lecture) => (
+                  <option key={lecture.id} value={lecture.id}>
+                    {lecture.title} · {new Date(lecture.created_at).toLocaleString()}
+                  </option>
+                ))
+              )}
+            </select>
+
+            <label className="flex items-center gap-2 text-sm text-gray-700 dark:text-gray-300">
+              <input
+                type="checkbox"
+                checked={exportIncludeAudio}
+                onChange={(e) => setExportIncludeAudio(e.target.checked)}
+                disabled={isExporting}
+                className="h-4 w-4 rounded border-gray-300 text-violet-600 focus:ring-violet-500"
+              />
+              包含原始音訊檔（若存在）
+            </label>
+
+            <button
+              onClick={handleExportPackage}
+              disabled={isExporting || !selectedLectureId}
+              className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-violet-600 hover:bg-violet-700 disabled:bg-gray-400 text-white rounded-lg transition-colors"
+            >
+              <Package className="w-4 h-4" />
+              {isExporting ? "正在匯出診斷封包..." : "匯出診斷封包 ZIP"}
+            </button>
+          </div>
+
+          {logPreview !== null && (
               <div className="p-4 rounded-lg bg-gray-50 dark:bg-gray-900/50 border border-gray-200 dark:border-gray-700 space-y-3">
                 <div className="text-sm text-gray-700 dark:text-gray-300">
                   <div className="font-medium">Redaction summary</div>

--- a/ClassNoteAI/src/components/settings/SettingsCloudAI.tsx
+++ b/ClassNoteAI/src/components/settings/SettingsCloudAI.tsx
@@ -3,10 +3,11 @@ import AIProviderSettings from "../AIProviderSettings";
 import { Card } from "./shared";
 import UsageSummary from "./UsageSummary";
 import OcrSettings from "./OcrSettings";
-import AiTutorDisplaySettings from "./AiTutorDisplaySettings";
-import VideoLayoutSettings from "./VideoLayoutSettings";
-import ExperimentalSettings from "./ExperimentalSettings";
+import CloudAIExperimentalSettings from "./CloudAIExperimentalSettings";
 
+// v0.6.1: trimmed to cloud-LLM-only concerns. Layout / UI-display
+// settings moved to Settings → 介面與顯示; local-model / GPU toggles
+// moved to Settings → 本地轉錄模型.
 export default function SettingsCloudAI() {
   return (
     <div className="space-y-6 animate-in fade-in duration-300">
@@ -18,9 +19,7 @@ export default function SettingsCloudAI() {
         <div className="space-y-4">
           <AIProviderSettings />
           <OcrSettings />
-          <AiTutorDisplaySettings />
-          <VideoLayoutSettings />
-          <ExperimentalSettings />
+          <CloudAIExperimentalSettings />
           <UsageSummary />
         </div>
       </Card>

--- a/ClassNoteAI/src/components/settings/SettingsCloudAI.tsx
+++ b/ClassNoteAI/src/components/settings/SettingsCloudAI.tsx
@@ -5,6 +5,7 @@ import UsageSummary from "./UsageSummary";
 import OcrSettings from "./OcrSettings";
 import AiTutorDisplaySettings from "./AiTutorDisplaySettings";
 import VideoLayoutSettings from "./VideoLayoutSettings";
+import ExperimentalSettings from "./ExperimentalSettings";
 
 export default function SettingsCloudAI() {
   return (
@@ -19,6 +20,7 @@ export default function SettingsCloudAI() {
           <OcrSettings />
           <AiTutorDisplaySettings />
           <VideoLayoutSettings />
+          <ExperimentalSettings />
           <UsageSummary />
         </div>
       </Card>

--- a/ClassNoteAI/src/components/settings/SettingsInterface.tsx
+++ b/ClassNoteAI/src/components/settings/SettingsInterface.tsx
@@ -1,0 +1,34 @@
+import { Monitor } from "lucide-react";
+import { Card } from "./shared";
+import AiTutorDisplaySettings from "./AiTutorDisplaySettings";
+import VideoLayoutSettings from "./VideoLayoutSettings";
+
+/**
+ * v0.6.1: 介面與顯示 tab — houses layout / panel-arrangement settings
+ * that aren't tied to a specific data-source category. Previously
+ * these (AI-tutor display mode, video+PDF layout) were crammed into
+ * the 雲端 AI 助理 card even though only one of them is cloud-related.
+ * Split out into its own tab under 其他 so each tab's subject matter
+ * matches its content.
+ *
+ * Content belongs here when the toggle is purely about "where on screen"
+ * or "which layout"; user-visible behaviour that hits a specific
+ * subsystem (local Whisper, cloud LLM, translation) lives in that
+ * subsystem's own tab.
+ */
+export default function SettingsInterface() {
+    return (
+        <div className="space-y-6 animate-in fade-in duration-300">
+            <Card
+                title="介面與顯示"
+                icon={<Monitor className="w-5 h-5 text-slate-500" />}
+                subtitle="視窗、面板與輔助介面的排版方式。"
+            >
+                <div className="space-y-4">
+                    <AiTutorDisplaySettings />
+                    <VideoLayoutSettings />
+                </div>
+            </Card>
+        </div>
+    );
+}

--- a/ClassNoteAI/src/components/settings/SettingsLocalTranscription.tsx
+++ b/ClassNoteAI/src/components/settings/SettingsLocalTranscription.tsx
@@ -1,6 +1,7 @@
 import { Mic } from "lucide-react";
 import WhisperModelManager from "../WhisperModelManager";
 import { Card } from "./shared";
+import LocalModelExperimentalSettings from "./LocalModelExperimentalSettings";
 
 export default function SettingsLocalTranscription() {
   return (
@@ -10,7 +11,10 @@ export default function SettingsLocalTranscription() {
         icon={<Mic className="w-5 h-5 text-blue-500" />}
         subtitle="全程離線、無額外費用。模型檔案只下載一次。"
       >
-        <WhisperModelManager />
+        <div className="space-y-4">
+          <WhisperModelManager />
+          <LocalModelExperimentalSettings />
+        </div>
       </Card>
     </div>
   );

--- a/ClassNoteAI/src/services/diagnosticsService.ts
+++ b/ClassNoteAI/src/services/diagnosticsService.ts
@@ -1,0 +1,100 @@
+import { invoke } from "@tauri-apps/api/core";
+import { openUrl } from "@tauri-apps/plugin-opener";
+import { storageService } from "./storageService";
+import { redactLogContent } from "./logDiagnostics";
+
+const ABSOLUTE_PATH_PATTERN = /^(?:[A-Za-z]:[\\/]|\\\\|\/)/;
+
+interface DiagnosticPackageInput {
+  lecture_meta_json: string;
+  subtitles_json: string;
+  audio_path: string | null;
+  redacted_log_text: string;
+  metadata_json: string;
+}
+
+export interface DiagnosticExportOptions {
+  lectureId: string;
+  includeAudio: boolean;
+  appVersion: string;
+  buildVariant: string;
+}
+
+function joinPath(baseDir: string, childPath: string, separator: string): string {
+  const normalizedBase = baseDir.replace(/[\\/]+$/, "");
+  const normalizedChild = childPath.replace(/^[\\/]+/, "").replace(/[\\/]+/g, separator);
+  return `${normalizedBase}${separator}${normalizedChild}`;
+}
+
+export async function exportDiagnosticPackage(
+  opts: DiagnosticExportOptions,
+): Promise<string> {
+  const lecture = await storageService.getLecture(opts.lectureId);
+  if (!lecture) {
+    throw new Error(`Lecture not found: ${opts.lectureId}`);
+  }
+
+  const subtitles = await storageService.getSubtitles(opts.lectureId);
+  const audioPath = opts.includeAudio
+    ? await resolveAudioPath(lecture.audio_path)
+    : null;
+
+  const rawLog = await invoke<string>("read_recent_log", { lines: 2000 });
+  const { redacted } = redactLogContent(rawLog);
+  const metadata = {
+    app_version: opts.appVersion,
+    build_variant: opts.buildVariant,
+    os: navigator.userAgent,
+    exported_at: new Date().toISOString(),
+    lecture_id: opts.lectureId,
+    has_audio: audioPath !== null,
+  };
+
+  const input: DiagnosticPackageInput = {
+    lecture_meta_json: JSON.stringify(lecture),
+    subtitles_json: JSON.stringify(subtitles),
+    audio_path: audioPath,
+    redacted_log_text: redacted,
+    metadata_json: JSON.stringify(metadata),
+  };
+
+  return await invoke<string>("export_diagnostic_package", {
+    input,
+    includeAudio: opts.includeAudio,
+  });
+}
+
+export async function resolveAudioPath(
+  stored: string | null | undefined,
+): Promise<string | null> {
+  if (!stored) {
+    return null;
+  }
+
+  const trimmed = stored.trim();
+  if (!trimmed) {
+    return null;
+  }
+
+  const [{ readFile }, { sep }] = await Promise.all([
+    import("@tauri-apps/plugin-fs"),
+    import("@tauri-apps/api/path"),
+  ]);
+  const audioDir = await invoke<string>("get_audio_dir");
+  const candidate = ABSOLUTE_PATH_PATTERN.test(trimmed)
+    ? trimmed
+    : joinPath(audioDir, trimmed, sep());
+
+  try {
+    await readFile(candidate);
+    return candidate;
+  } catch {
+    return null;
+  }
+}
+
+export async function revealZipInFileManager(zipPath: string): Promise<void> {
+  const lastSeparator = Math.max(zipPath.lastIndexOf("/"), zipPath.lastIndexOf("\\"));
+  const parent = lastSeparator > 0 ? zipPath.slice(0, lastSeparator) : zipPath;
+  await openUrl(parent);
+}

--- a/ClassNoteAI/src/services/embeddingStorageService.ts
+++ b/ClassNoteAI/src/services/embeddingStorageService.ts
@@ -11,8 +11,7 @@
  */
 
 import { invoke } from '@tauri-apps/api/core';
-import { generateLocalEmbedding } from './embeddingService';
-import { storageService } from './storageService';
+import { authService } from './authService';
 import { TextChunk } from './chunkingService';
 
 export interface EmbeddingRecord {
@@ -71,18 +70,36 @@ function toBackend(r: EmbeddingRecord) {
     };
 }
 
-function cosineSimilarity(a: number[], b: number[]): number {
-    if (a.length !== b.length) return 0;
-    let dot = 0;
-    let normA = 0;
-    let normB = 0;
-    for (let i = 0; i < a.length; i++) {
-        dot += a[i] * b[i];
-        normA += a[i] * a[i];
-        normB += b[i] * b[i];
-    }
-    const denom = Math.sqrt(normA) * Math.sqrt(normB);
-    return denom === 0 ? 0 : dot / denom;
+/// Backend `SearchHit` payload from `semantic_search_*` commands.
+/// Shape mirrors `BackendEmbeddingRow` (so we can reuse field names)
+/// plus a `similarity` score.
+interface BackendSearchHit {
+    id: string;
+    lecture_id: string;
+    chunk_text: string;
+    source_type: string;
+    position: number;
+    page_number: number | null;
+    created_at: string;
+    similarity: number;
+}
+
+function hitToResult(hit: BackendSearchHit): SearchResult {
+    return {
+        chunk: {
+            id: hit.id,
+            lectureId: hit.lecture_id,
+            chunkText: hit.chunk_text,
+            // Omit `embedding` — search consumers only need text + metadata,
+            // and skipping it saves a ~1.5 KB copy per result across the IPC.
+            embedding: [],
+            sourceType: hit.source_type === 'transcript' ? 'transcript' : 'pdf',
+            position: hit.position,
+            pageNumber: hit.page_number ?? undefined,
+            createdAt: hit.created_at,
+        },
+        similarity: hit.similarity,
+    };
 }
 
 class EmbeddingStorageService {
@@ -196,9 +213,13 @@ class EmbeddingStorageService {
     }
 
     /**
-     * In-process semantic search over a lecture's embeddings. Optionally
-     * boosts matches near `preferredPage` so PDF-slide-aware queries
-     * surface locally-relevant chunks first.
+     * Semantic search over a single lecture. Delegates to the Rust
+     * `semantic_search_lecture` command, which does the whole pipeline
+     * (query embed → batched cosine matmul → page boost → top-K) on
+     * whichever Candle device the embedding service picked — CUDA on
+     * GPU builds, Metal on macOS, CPU otherwise. Previously this ran
+     * a per-chunk JS cosine loop on the main renderer thread, which
+     * was the last CPU-bound step in the RAG query path.
      */
     public async semanticSearch(
         lectureId: string,
@@ -206,44 +227,34 @@ class EmbeddingStorageService {
         topK = 5,
         preferredPage?: number
     ): Promise<SearchResult[]> {
-        const queryEmbedding = await generateLocalEmbedding(query);
-        const records = await this.getEmbeddingsByLecture(lectureId);
-        if (!records.length) return [];
-
-        const scored: SearchResult[] = records.map((chunk) => {
-            let sim = cosineSimilarity(queryEmbedding, chunk.embedding);
-            if (preferredPage !== undefined && chunk.pageNumber !== undefined) {
-                const gap = Math.abs(chunk.pageNumber - preferredPage);
-                if (gap <= 5) sim += 0.1;
-                else if (gap <= 10) sim += 0.05;
-            }
-            return { chunk, similarity: sim };
+        const hits = await invoke<BackendSearchHit[]>('semantic_search_lecture', {
+            lectureId,
+            query,
+            topK,
+            preferredPage: preferredPage ?? null,
         });
-
-        scored.sort((a, b) => b.similarity - a.similarity);
-        return scored.slice(0, topK);
+        return hits.map(hitToResult);
     }
 
     /**
-     * Cross-lecture semantic search scoped to a course. Pulls the
-     * course's lectures via storageService, unions their embeddings,
-     * and ranks them all against `query`.
+     * Cross-lecture search scoped to a course. The Rust side unions
+     * every lecture's embeddings into a single matrix and runs one
+     * matmul against the query, so a 10-lecture × 200-chunk course
+     * finishes in the same few ms as a single-lecture search.
      */
     public async semanticSearchByCourse(
         query: string,
         courseId: string,
         topK = 5
     ): Promise<SearchResult[]> {
-        const lectures = await storageService.listLecturesByCourse(courseId);
-        const queryEmbedding = await generateLocalEmbedding(query);
-        const all: EmbeddingRecord[] = [];
-        for (const lecture of lectures) {
-            all.push(...(await this.getEmbeddingsByLecture(lecture.id)));
-        }
-        return all
-            .map((chunk) => ({ chunk, similarity: cosineSimilarity(queryEmbedding, chunk.embedding) }))
-            .sort((a, b) => b.similarity - a.similarity)
-            .slice(0, topK);
+        const userId = authService.getUser()?.username || 'default_user';
+        const hits = await invoke<BackendSearchHit[]>('semantic_search_course', {
+            courseId,
+            userId,
+            query,
+            topK,
+        });
+        return hits.map(hitToResult);
     }
 
     public async deleteByLecture(lectureId: string): Promise<void> {

--- a/ClassNoteAI/src/services/llm/providers/chatgpt-oauth.ts
+++ b/ClassNoteAI/src/services/llm/providers/chatgpt-oauth.ts
@@ -16,7 +16,6 @@
 
 import { fetch } from '@tauri-apps/plugin-http';
 import { invoke } from '@tauri-apps/api/core';
-import { listen, type UnlistenFn } from '@tauri-apps/api/event';
 import { openUrl } from '@tauri-apps/plugin-opener';
 import { keyStore } from '../keyStore';
 import { randomState, randomVerifier, sha256Challenge } from '../pkce';
@@ -41,24 +40,19 @@ const PROVIDER_ID = 'chatgpt-oauth';
 const OAUTH_CLIENT_ID = 'app_EMoamEEZ73f0CkXaXp7hrann';
 const OAUTH_AUTHORIZE = 'https://auth.openai.com/oauth/authorize';
 const OAUTH_TOKEN = 'https://auth.openai.com/oauth/token';
-// Codex's OAuth client has `http://localhost:1455/auth/callback` registered
-// as its ONLY valid redirect_uri server-side. Falling back to 1456+ makes
-// auth.openai.com reject the callback with "unknown_error" (see issue #36).
-// So we try 1455 exactly once; if it's held (often by VS Code's WebView
-// debugger or a previous dev session in TIME_WAIT) the user has to free it.
 const PREFERRED_CALLBACK_PORT = 1455;
-const CALLBACK_PORT_MAX_ATTEMPTS = 1;
+const CALLBACK_PORT_MAX_ATTEMPTS = 10;
 const CALLBACK_PATH = '/auth/callback';
 const OAUTH_SCOPES = 'openid profile email offline_access';
-const CALLBACK_TIMEOUT_SECS = 180;
+const CALLBACK_TIMEOUT_SECS = 300;
 
 function redirectUriFor(port: number): string {
   return `http://localhost:${port}${CALLBACK_PATH}`;
 }
 
-interface OAuthListenResult {
-  port: number;
-  path: string;
+interface OAuthCallback {
+  code: string;
+  state: string;
 }
 
 // Responses API endpoint on the ChatGPT backend (not api.openai.com).
@@ -138,44 +132,11 @@ export class ChatGPTOAuthProvider implements LLMProvider {
     const challenge = await sha256Challenge(verifier);
     const state = randomState();
 
-    // 1) Subscribe to the `oauth:bound` event BEFORE kicking the
-    //    listener invoke, so we can't miss it on a fast bind.
-    let unlisten: UnlistenFn | undefined;
-    const boundPort = new Promise<number>((resolve, reject) => {
-      const timer = setTimeout(() => {
-        unlisten?.();
-        reject(
-          new LLMError(
-            'OAuth listener did not bind to port 1455 (held by another app — often VS Code). Close it and try again.',
-            'auth',
-            PROVIDER_ID,
-          ),
-        );
-      }, 10_000);
-      listen<number>('oauth:bound', (e) => {
-        clearTimeout(timer);
-        unlisten?.();
-        resolve(e.payload);
-      })
-        .then((u) => {
-          unlisten = u;
-        })
-        .catch(reject);
-    });
-
-    // 2) Start the callback listener. It'll emit `oauth:bound` with the
-    //    port it actually bound to — possibly a fallback if 1455 was held
-    //    (e.g. VS Code). Issue #30 / #36.
-    const listenPromise = invoke<OAuthListenResult>('oauth_listen_for_code', {
-      port: PREFERRED_CALLBACK_PORT,
-      timeoutSecs: CALLBACK_TIMEOUT_SECS,
+    const port = await invoke<number>('oauth_bind_port', {
+      preferredPort: PREFERRED_CALLBACK_PORT,
       maxAttempts: CALLBACK_PORT_MAX_ATTEMPTS,
     });
-
-    // 3) Wait for Rust to tell us which port it's actually on, THEN open
-    //    the browser with a matching redirect_uri.
-    const actualPort = await boundPort;
-    const redirectUri = redirectUriFor(actualPort);
+    const redirectUri = redirectUriFor(port);
     const params = new URLSearchParams({
       response_type: 'code',
       client_id: OAUTH_CLIENT_ID,
@@ -194,17 +155,13 @@ export class ChatGPTOAuthProvider implements LLMProvider {
     const authUrl = `${OAUTH_AUTHORIZE}?${params.toString()}`;
     await openUrl(authUrl);
 
-    const result = await listenPromise;
-    const parsed = new URL(result.path, `http://localhost:${result.port}`);
-    const returnedState = parsed.searchParams.get('state');
-    const code = parsed.searchParams.get('code');
-    const err = parsed.searchParams.get('error');
+    const result = await invoke<OAuthCallback>('oauth_wait_for_code', {
+      timeoutSecs: CALLBACK_TIMEOUT_SECS,
+    });
+    if (!result.code) throw new LLMError('OAuth callback missing `code`', 'auth', PROVIDER_ID);
+    if (result.state !== state) throw new LLMError('OAuth state mismatch', 'auth', PROVIDER_ID);
 
-    if (err) throw new LLMError(`OAuth error: ${err}`, 'auth', PROVIDER_ID);
-    if (!code) throw new LLMError('OAuth callback missing `code`', 'auth', PROVIDER_ID);
-    if (returnedState !== state) throw new LLMError('OAuth state mismatch', 'auth', PROVIDER_ID);
-
-    const tokens = await this.exchangeCodeForTokens(code, verifier, redirectUri);
+    const tokens = await this.exchangeCodeForTokens(result.code, verifier, redirectUri);
     this.persistTokens(tokens);
     return tokens;
   }

--- a/ClassNoteAI/src/services/logDiagnostics.ts
+++ b/ClassNoteAI/src/services/logDiagnostics.ts
@@ -1,0 +1,99 @@
+interface RedactRule {
+  label: string;
+  pattern: RegExp;
+  replacement: string;
+}
+
+const REDACT_RULES: RedactRule[] = [
+  {
+    label: 'openaiKey',
+    pattern: /\bsk-[A-Za-z0-9_-]+\b/g,
+    replacement: '[REDACTED_OPENAI_KEY]',
+  },
+  {
+    label: 'githubPat',
+    pattern: /\bghp_[A-Za-z0-9]+\b/g,
+    replacement: '[REDACTED_GITHUB_PAT]',
+  },
+  {
+    label: 'githubOAuth',
+    pattern: /\bgho_[A-Za-z0-9]+\b/g,
+    replacement: '[REDACTED_GITHUB_OAUTH]',
+  },
+  {
+    label: 'googleApiKey',
+    pattern: /\bAIza[0-9A-Za-z_-]{35}\b/g,
+    replacement: '[REDACTED_GOOGLE_API_KEY]',
+  },
+  {
+    label: 'bearerToken',
+    pattern: /\bBearer\s+[A-Za-z0-9._~+\/-]+=*\b/gi,
+    replacement: 'Bearer [REDACTED_BEARER_TOKEN]',
+  },
+  {
+    label: 'windowsUserPath',
+    pattern: /C:\\Users\\[^\\/\s]+/g,
+    replacement: 'C:\\Users\\[REDACTED_USER]',
+  },
+  {
+    label: 'macosUserPath',
+    pattern: /\/Users\/[^/\s]+/g,
+    replacement: '/Users/[REDACTED_USER]',
+  },
+  {
+    label: 'linuxUserPath',
+    pattern: /\/home\/[^/\s]+/g,
+    replacement: '/home/[REDACTED_USER]',
+  },
+];
+
+export function redactLogContent(raw: string): {
+  redacted: string;
+  hits: Record<string, number>;
+} {
+  const hits: Record<string, number> = {};
+  let redacted = raw;
+
+  for (const rule of REDACT_RULES) {
+    const pattern = new RegExp(
+      rule.pattern.source,
+      rule.pattern.flags.includes('g') ? rule.pattern.flags : `${rule.pattern.flags}g`,
+    );
+    const matches = redacted.match(pattern);
+    if (!matches || matches.length === 0) continue;
+
+    hits[rule.label] = (hits[rule.label] ?? 0) + matches.length;
+    redacted = redacted.replace(pattern, rule.replacement);
+  }
+
+  return { redacted, hits };
+}
+
+export function buildGithubIssueUrl(logSnippet: string, appVersion: string): string {
+  const params = new URLSearchParams({
+    title: '[Bug] ',
+    body: [
+      '## Environment',
+      `- App version: ${appVersion}`,
+      `- User agent: ${typeof navigator !== 'undefined' ? navigator.userAgent : 'unknown'}`,
+      '',
+      '## Steps to Reproduce',
+      '1. ',
+      '2. ',
+      '3. ',
+      '',
+      '## Expected Behavior',
+      '- ',
+      '',
+      '## Actual Behavior',
+      '- ',
+      '',
+      '## Redacted Diagnostics Log',
+      '```text',
+      logSnippet || '(empty)',
+      '```',
+    ].join('\n'),
+  });
+
+  return `https://github.com/sklonely/ClassNoteAI/issues/new?${params.toString()}`;
+}

--- a/ClassNoteAI/src/services/ocrService.ts
+++ b/ClassNoteAI/src/services/ocrService.ts
@@ -15,6 +15,24 @@
 import { storageService } from './storageService';
 import { fetch } from '@tauri-apps/plugin-http';
 
+const ocrContentHashCache = new Map<string, string>();
+
+function decodeBase64ToBytes(base64: string): Uint8Array {
+    const normalized = base64.includes(',') ? base64.slice(base64.indexOf(',') + 1) : base64;
+    const binary = atob(normalized);
+    const bytes = new Uint8Array(binary.length);
+    for (let i = 0; i < binary.length; i++) {
+        bytes[i] = binary.charCodeAt(i);
+    }
+    return bytes;
+}
+
+export async function computeContentHash(bytes: ArrayBuffer | Uint8Array): Promise<string> {
+    const input = bytes instanceof Uint8Array ? bytes : new Uint8Array(bytes);
+    const digest = await crypto.subtle.digest('SHA-256', input);
+    return Array.from(new Uint8Array(digest), (value) => value.toString(16).padStart(2, '0')).join('');
+}
+
 export interface OCRResult {
     pageNumber: number;
     text: string;
@@ -60,6 +78,16 @@ class OCRService {
      */
     public async recognizePage(imageBase64: string, pageNumber: number, retries: number = 2): Promise<OCRResult> {
         try {
+            const pageHash = await computeContentHash(decodeBase64ToBytes(imageBase64));
+            const cachedText = ocrContentHashCache.get(pageHash);
+            if (cachedText) {
+                return {
+                    pageNumber,
+                    text: cachedText,
+                    success: true,
+                };
+            }
+
             const host = await this.getHost();
             if (!host) {
                 throw new Error('Ollama host not configured — skipping OCR');
@@ -103,6 +131,8 @@ class OCRService {
                 // Debug 模式輸出 (顯示前 100 字)
                 console.log(`[OCRService] 頁面 ${pageNumber} OCR 完成 (${text.length} 字):`);
                 console.log(`--- Page ${pageNumber} Start ---\n${text.slice(0, 100)}${text.length > 100 ? '...' : ''}\n--- Page ${pageNumber} End ---`);
+
+                ocrContentHashCache.set(pageHash, text);
 
                 return {
                     pageNumber,

--- a/ClassNoteAI/src/services/ragService.ts
+++ b/ClassNoteAI/src/services/ragService.ts
@@ -17,7 +17,7 @@ import { chunkingService, TextChunk } from './chunkingService';
 import { embeddingStorageService, SearchResult } from './embeddingStorageService';
 import { generateLocalEmbedding, generateLocalEmbeddingsBatch } from './embeddingService';
 import { chat as llmChat, chatStream as llmChatStream, translateForRetrieval } from './llm';
-import { ocrService } from './ocrService';
+import { computeContentHash, ocrService } from './ocrService';
 import { remoteOcrService } from './remoteOcrService';
 import { pdfToImageService } from './pdfToImageService';
 // `pdfService` pulls in pdfjs-dist at module load, which needs the
@@ -279,6 +279,34 @@ class RAGService {
             ) => Promise<Array<{ pageNumber: number; text: string; success: boolean; error?: string }>>;
             type OcrBackend = { name: 'remote' | 'local'; recognize: OcrRecognize } | null;
 
+            const contentHashKey = `lecture_content_hash_${lectureId}`;
+            const pdfHash = pdfData
+                ? await computeContentHash(new Uint8Array(pdfData))
+                : 'no-pdf';
+            const contentHash = await computeContentHash(
+                new TextEncoder().encode(
+                    JSON.stringify({
+                        pdfHash,
+                        transcriptText: transcriptText ?? '',
+                    }),
+                ),
+            );
+            const persistContentHash = async () => {
+                await storageService.saveSetting(contentHashKey, contentHash);
+            };
+
+            if (!forceRefresh) {
+                const storedHash = await storageService.getSetting(contentHashKey);
+                if (storedHash === contentHash) {
+                    const hasExistingIndex = await embeddingStorageService.hasEmbeddings(lectureId);
+                    if (hasExistingIndex) {
+                        const stats = await embeddingStorageService.getStats(lectureId).catch(() => null);
+                        console.log(`[RAGService] Skipping OCR re-index for lecture ${lectureId}; content hash unchanged.`);
+                        return { chunksCount: stats?.total ?? 0, success: true };
+                    }
+                }
+            }
+
             let backend: OcrBackend = null;
 
             if (pdfData) {
@@ -337,12 +365,16 @@ class RAGService {
                     // slide alignment.
                     const pdfSvc = await getPdfService();
                     const pagesText = await pdfSvc.extractAllPagesText(pdfData.slice(0));
-                    return this.indexLectureFromPages(
+                    const indexResult = await this.indexLectureFromPages(
                         lectureId,
                         pagesText.filter((p) => p.text.trim().length > 0).map((p) => ({ pageNumber: p.page, text: p.text })),
                         transcriptText,
                         onProgress,
                     );
+                    if (indexResult.success) {
+                        await persistContentHash();
+                    }
+                    return indexResult;
                 }
                 console.log(`[RAGService] Using OCR backend: ${backend.name}`);
             }
@@ -479,6 +511,7 @@ class RAGService {
             // must always describe the same chunk set for RRF fusion to
             // produce sensible results.
             bm25Service.invalidate(lectureId);
+            await persistContentHash();
 
             onProgress?.({
                 stage: 'storing',

--- a/ClassNoteAI/src/services/storageService.ts
+++ b/ClassNoteAI/src/services/storageService.ts
@@ -185,9 +185,12 @@ class StorageService {
     }
     try {
       return JSON.parse(settingsJson) as AppSettings;
-    } catch (e) {
-      console.error('解析設置失敗:', e);
-      return null;
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        console.warn('[StorageService] Failed to parse JSON for app_settings; returning null');
+        return null;
+      }
+      throw error;
     }
   }
 
@@ -209,9 +212,12 @@ class StorageService {
     }
     try {
       return JSON.parse(valueJson) as T;
-    } catch (e) {
-      console.error(`解析設置 ${key} 失敗:`, e);
-      return null;
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        console.warn(`[StorageService] Failed to parse JSON for setting ${key}; returning null`);
+        return null;
+      }
+      throw error;
     }
   }
 
@@ -255,10 +261,19 @@ class StorageService {
     let imported = 0;
 
     try {
-      const data = JSON.parse(jsonData);
+      let data = null;
+      try {
+        data = JSON.parse(jsonData);
+      } catch (error) {
+        if (error instanceof SyntaxError) {
+          console.warn('[StorageService] Failed to parse JSON for importData payload; returning null');
+        } else {
+          throw error;
+        }
+      }
 
       // 驗證數據格式
-      if (!data.lectures || !Array.isArray(data.lectures)) {
+      if (!data?.lectures || !Array.isArray(data.lectures)) {
         throw new Error('無效的數據格式：缺少 lectures 數組');
       }
 
@@ -429,15 +444,12 @@ class StorageService {
         qa_records: content.qa_records || [],
         generated_at: dbNote.generated_at,
       };
-    } catch (e) {
-      console.error('解析筆記內容失敗:', e);
-      return {
-        lecture_id: dbNote.lecture_id,
-        title: dbNote.title,
-        sections: [],
-        qa_records: [],
-        generated_at: dbNote.generated_at,
-      };
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        console.warn(`[StorageService] Failed to parse JSON for note ${lectureId}; returning null`);
+        return null;
+      }
+      throw error;
     }
   }
 
@@ -459,9 +471,12 @@ class StorageService {
     if (!data) return [];
     try {
       return JSON.parse(data);
-    } catch (e) {
-      console.error('解析對話歷史失敗:', e);
-      return [];
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        console.warn(`[StorageService] Failed to parse JSON for chat history ${key}; returning []`);
+        return [];
+      }
+      throw error;
     }
   }
 

--- a/ClassNoteAI/src/services/subtitleService.ts
+++ b/ClassNoteAI/src/services/subtitleService.ts
@@ -166,6 +166,31 @@ class SubtitleService {
   }
 
   /**
+   * Replace the entire segment array in one shot + notify once.
+   *
+   * Intended for reload-from-DB flows (e.g. video-import's per-chunk
+   * refresh): the old pattern was `clear() + addSegment() × N`,
+   * which fires N+1 notifyListeners calls — a 1000-segment lecture
+   * re-triggered 1001 React re-renders per refresh, and the video
+   * import does up to 140 refreshes for 70 chunks = ~140k re-renders.
+   * This method does 1 notify per refresh instead.
+   *
+   * Caller is responsible for passing fully-formed segments (same
+   * shape `addSegment` would produce). We deliberately do NOT run
+   * the display-text fallback chain here — bulk callers already
+   * have clean data from DB rows.
+   */
+  setSegments(segments: SubtitleSegment[], lectureId?: string): void {
+    this.segments = segments;
+    if (lectureId !== undefined) {
+      this.lectureId = lectureId;
+    }
+    this.currentText = '';
+    this.currentTranslation = undefined;
+    this.notifyListeners();
+  }
+
+  /**
    * 訂閱狀態變化
    */
   subscribe(listener: (state: SubtitleState) => void): () => void {

--- a/ClassNoteAI/src/services/transcriptionService.ts
+++ b/ClassNoteAI/src/services/transcriptionService.ts
@@ -68,6 +68,7 @@ export class TranscriptionService {
   // fine-refinement queue entirely instead of spamming errors every
   // FINE_DEBOUNCE_MS. Re-checked each new recording session.
   private fineRefinementEnabled: boolean = false;
+  private currentRefineIntensity: 'off' | 'light' | 'deep' = 'off';
 
   constructor() {
     // 綁定方法以避免 this 丟失
@@ -87,11 +88,21 @@ export class TranscriptionService {
    *  fine-refinement queue entirely if not. */
   public async refreshFineRefinementAvailability(): Promise<void> {
     try {
+      const { storageService } = await import('./storageService');
+      const settings = await storageService.getAppSettings().catch(() => null);
+      const intensity = settings?.experimental?.refineIntensity ?? 'off';
+      this.currentRefineIntensity = intensity;
+      if (intensity === 'off') {
+        this.fineRefinementEnabled = false;
+        return;
+      }
+
       const { resolveActiveProvider } = await import('./llm');
       const defaultId = localStorage.getItem('llm.defaultProvider') || undefined;
       const provider = await resolveActiveProvider(defaultId);
       this.fineRefinementEnabled = !!provider;
     } catch {
+      this.currentRefineIntensity = 'off';
       this.fineRefinementEnabled = false;
     }
   }
@@ -674,7 +685,7 @@ export class TranscriptionService {
    * is called once per recording session from NotesView.
    */
   private enqueueFineRefinement(id: string, text: string): void {
-    if (!this.fineRefinementEnabled) return;
+    if (!this.fineRefinementEnabled || this.currentRefineIntensity === 'off') return;
 
     this.fineQueue.push({ id, text });
     if (this.fineQueue.length >= TranscriptionService.FINE_BATCH_SIZE) {
@@ -693,6 +704,11 @@ export class TranscriptionService {
       clearTimeout(this.fineFlushTimer);
       this.fineFlushTimer = null;
     }
+    const { storageService } = await import('./storageService');
+    const settings = await storageService.getAppSettings().catch(() => null);
+    const intensity = settings?.experimental?.refineIntensity ?? 'off';
+    if (intensity === 'off') return;
+    this.currentRefineIntensity = intensity;
     if (!this.fineQueue.length) return;
     const batch = this.fineQueue.splice(0, this.fineQueue.length);
 
@@ -740,6 +756,17 @@ export class TranscriptionService {
       }
     } catch (e) {
       console.warn('[TranscriptionService] Fine refinement batch failed; keeping rough output:', e);
+    }
+  }
+
+  public setRefineIntensity(intensity: 'off' | 'light' | 'deep'): void {
+    this.currentRefineIntensity = intensity;
+    if (intensity === 'off') {
+      this.fineRefinementEnabled = false;
+    } else {
+      this.refreshFineRefinementAvailability().catch((e) =>
+        console.warn('[TranscriptionService] refresh after intensity change failed:', e)
+      );
     }
   }
 

--- a/ClassNoteAI/src/services/updateService.ts
+++ b/ClassNoteAI/src/services/updateService.ts
@@ -12,6 +12,24 @@ import { writeFile, BaseDirectory } from '@tauri-apps/plugin-fs';
 import { fetch } from '@tauri-apps/plugin-http';
 import { downloadDir, join } from '@tauri-apps/api/path';
 import { invoke } from '@tauri-apps/api/core';
+import { getVersion } from '@tauri-apps/api/app';
+import { storageService } from './storageService';
+
+export type ReleaseChannel = 'stable' | 'beta' | 'alpha';
+
+// Subset of GitHub's release JSON we actually consume.
+interface GithubRelease {
+    tag_name: string;
+    name: string;
+    prerelease: boolean;
+    draft: boolean;
+    published_at: string;
+    body: string | null;
+    assets: { name: string; browser_download_url: string }[];
+}
+
+const GITHUB_API_RELEASES_URL =
+    'https://api.github.com/repos/sklonely/ClassNoteAI/releases?per_page=30';
 
 /**
  * v0.6.1: the updater's `target` must match the platform key in the
@@ -62,24 +80,60 @@ export interface UpdateProgress {
 
 class UpdateService {
     private currentUpdate: Update | null = null;
+    // Non-stable channel flow bypasses the updater plugin (no runtime
+    // endpoint override). Stash the matched release here so
+    // downloadAndInstall can pick the right asset without refetching.
+    private pendingChannelRelease: GithubRelease | null = null;
 
     /**
-     * Check for available updates
+     * Which release channel the user is subscribed to. Defaults to
+     * `stable` on any read failure — we never want a storage hiccup to
+     * silently shift the user onto prereleases.
      */
+    async getReleaseChannel(): Promise<ReleaseChannel> {
+        try {
+            const settings = await storageService.getAppSettings();
+            const channel = settings?.updates?.channel;
+            if (channel === 'beta' || channel === 'alpha') return channel;
+            return 'stable';
+        } catch {
+            return 'stable';
+        }
+    }
+
+    async setReleaseChannel(channel: ReleaseChannel): Promise<void> {
+        const settings = (await storageService.getAppSettings()) ?? ({} as any);
+        const next = { ...settings, updates: { ...(settings.updates ?? {}), channel } };
+        await storageService.saveAppSettings(next);
+    }
+
     /**
-     * Check for available updates
+     * Check for available updates on the currently selected channel.
+     * - `stable` uses the Tauri updater plugin (signed, auto-install).
+     * - `beta` / `alpha` query GitHub's releases API and hand off the
+     *   matching release's installer to a manual download+open flow.
      */
     async checkForUpdates(): Promise<UpdateInfo> {
-        // Prevent update check in development mode to avoid confusion
         if (import.meta.env.DEV) {
             console.log('[UpdateService] Running in development mode, updates disabled.');
             return { available: false };
         }
 
+        const channel = await this.getReleaseChannel();
+        this.pendingChannelRelease = null;
+        this.currentUpdate = null;
+
+        if (channel === 'stable') {
+            return this.checkViaPlugin();
+        }
+        return this.checkViaGithubApi(channel);
+    }
+
+    private async checkViaPlugin(): Promise<UpdateInfo> {
         try {
             const target = await pickUpdaterTarget();
             console.log(
-                '[UpdateService] Checking for updates...',
+                '[UpdateService] Checking for updates (stable channel)...',
                 target ? `(target=${target})` : '(default target)',
             );
             const update = await check(target ? { target } : undefined);
@@ -99,7 +153,6 @@ class UpdateService {
             return { available: false };
         } catch (error) {
             console.error('[UpdateService] Failed to check for updates:', error);
-            // Enhance error message for common issues
             if (error instanceof Error) {
                 if (error.message.includes('Network')) {
                     throw new Error('無法連接到更新伺服器，請檢查網路連線。');
@@ -109,12 +162,79 @@ class UpdateService {
         }
     }
 
+    private async checkViaGithubApi(channel: 'beta' | 'alpha'): Promise<UpdateInfo> {
+        console.log(`[UpdateService] Checking for updates (${channel} channel) via GitHub API...`);
+        let releases: GithubRelease[];
+        try {
+            const resp = await fetch(GITHUB_API_RELEASES_URL, {
+                method: 'GET',
+                headers: { 'Accept': 'application/vnd.github+json' },
+            });
+            if (!resp.ok) {
+                throw new Error(`GitHub API returned ${resp.status} ${resp.statusText}`);
+            }
+            releases = await resp.json();
+        } catch (error) {
+            console.error('[UpdateService] GitHub API fetch failed:', error);
+            if (error instanceof Error && error.message.includes('Network')) {
+                throw new Error('無法連接到更新伺服器，請檢查網路連線。');
+            }
+            throw new Error('無法從 GitHub 取得 release 清單，請稍後再試。');
+        }
+
+        // `beta` = stable releases + explicit `*-beta*` tags.
+        // `alpha` = stable + any prerelease (alpha, beta, rc, etc.).
+        const matching = releases.filter((r) => {
+            if (r.draft) return false;
+            if (!r.prerelease) return true;
+            const tag = r.tag_name.toLowerCase();
+            if (channel === 'alpha') return true;
+            return tag.includes('-beta');
+        });
+
+        if (matching.length === 0) {
+            return { available: false };
+        }
+
+        // GitHub sorts `/releases` newest-first by created_at.
+        const newest = matching[0];
+        const newestVersion = stripTagPrefix(newest.tag_name);
+        const current = await getVersion();
+
+        if (!isVersionNewer(newestVersion, current)) {
+            console.log(
+                `[UpdateService] Current ${current} is at or ahead of newest ${channel} ${newestVersion}.`,
+            );
+            return { available: false };
+        }
+
+        this.pendingChannelRelease = newest;
+        console.log(`[UpdateService] ${channel} update available: ${newestVersion}`);
+        return {
+            available: true,
+            version: newestVersion,
+            body: newest.body ?? undefined,
+            date: newest.published_at,
+        };
+    }
+
     /**
-     * Download and install the update with progress callback
+     * Download and install the update with progress callback.
+     * Stable channel → Tauri updater plugin (signed, auto-install +
+     * relaunch). Beta/Alpha channel → manual download of the release
+     * installer asset, open it for the user to click through.
      */
     async downloadAndInstall(
         onProgress?: (progress: UpdateProgress) => void
     ): Promise<void> {
+        if (this.pendingChannelRelease) {
+            await this.downloadAndOpenChannelInstaller(
+                this.pendingChannelRelease,
+                onProgress,
+            );
+            return;
+        }
+
         if (!this.currentUpdate) {
             throw new Error('No update available. Call checkForUpdates first.');
         }
@@ -170,6 +290,40 @@ class UpdateService {
             }
             throw error;
         }
+    }
+
+    /**
+     * Pick the platform-appropriate installer asset from a GitHub
+     * release, stream it to the user's Downloads folder, and open it.
+     * Used for beta/alpha channels where the Tauri updater plugin's
+     * fixed endpoint can't be redirected at runtime.
+     */
+    private async downloadAndOpenChannelInstaller(
+        release: GithubRelease,
+        onProgress?: (progress: UpdateProgress) => void,
+    ): Promise<void> {
+        const isWindows = typeof navigator !== 'undefined' &&
+            navigator.userAgent.includes('Windows');
+        const buildVariant = await safeGetBuildVariant();
+
+        let pickedAssetName: string | undefined;
+        if (isWindows) {
+            const suffix = buildVariant === 'cuda' ? '_cuda' : '';
+            pickedAssetName = `ClassNoteAI_${stripTagPrefix(release.tag_name)}_x64${suffix}-setup.exe`;
+        } else {
+            pickedAssetName = `ClassNoteAI_${stripTagPrefix(release.tag_name)}_aarch64.dmg`;
+        }
+
+        const asset = release.assets.find((a) => a.name === pickedAssetName);
+        if (!asset) {
+            const names = release.assets.map((a) => a.name).join(', ');
+            throw new Error(
+                `在 release ${release.tag_name} 找不到對應的安裝檔 (${pickedAssetName})。可用的資產：${names || '(無)'}。`,
+            );
+        }
+
+        console.log(`[UpdateService] Downloading ${asset.name} from ${asset.browser_download_url}`);
+        await streamDownloadAndOpen(asset.browser_download_url, asset.name, onProgress);
     }
 
     /**
@@ -254,6 +408,103 @@ class UpdateService {
             throw error;
         }
     }
+}
+
+// ---- module-local helpers -------------------------------------------------
+
+function stripTagPrefix(tag: string): string {
+    return tag.startsWith('v') ? tag.slice(1) : tag;
+}
+
+/**
+ * Minimal semver-ish compare that's good enough for our tags: splits
+ * `MAJOR.MINOR.PATCH` (ignoring any prerelease suffix after `-`) and
+ * compares numerically per field. Returns true iff `next` strictly
+ * beats `current`.
+ *
+ * For same MAJOR.MINOR.PATCH but different prerelease tiers (e.g.
+ * 0.6.0-alpha.1 vs 0.6.0-alpha.2), we compare the full tail as
+ * strings — alpha.2 > alpha.1 lexicographically, which is fine until
+ * two-digit counters (alpha.10) show up. That's acceptable until we
+ * see cadence warrant it.
+ */
+function isVersionNewer(next: string, current: string): boolean {
+    const [nextCore, nextTail = ''] = next.split('-', 2);
+    const [currCore, currTail = ''] = current.split('-', 2);
+    const a = nextCore.split('.').map((x) => parseInt(x, 10) || 0);
+    const b = currCore.split('.').map((x) => parseInt(x, 10) || 0);
+    for (let i = 0; i < Math.max(a.length, b.length); i++) {
+        const ai = a[i] ?? 0;
+        const bi = b[i] ?? 0;
+        if (ai !== bi) return ai > bi;
+    }
+    // Same core. Stable (empty tail) > any prerelease tail.
+    if (!nextTail && currTail) return true;
+    if (nextTail && !currTail) return false;
+    return nextTail > currTail;
+}
+
+async function safeGetBuildVariant(): Promise<string | null> {
+    try {
+        return await invoke<string>('get_build_variant');
+    } catch {
+        return null;
+    }
+}
+
+async function streamDownloadAndOpen(
+    url: string,
+    filename: string,
+    onProgress?: (progress: UpdateProgress) => void,
+): Promise<void> {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), 10000);
+
+    const response = await fetch(url, { method: 'GET', signal: controller.signal });
+    clearTimeout(timeoutId);
+
+    if (!response.ok) {
+        throw new Error(`Failed to download installer: ${response.statusText} (${response.status})`);
+    }
+
+    const contentLength = parseInt(response.headers.get('content-length') || '0', 10);
+    let downloaded = 0;
+
+    const downloadDirPath = await downloadDir();
+    const filePath = await join(downloadDirPath, filename);
+    console.log(`[UpdateService] Saving to: ${filePath}`);
+
+    const reader = response.body?.getReader();
+    if (!reader) throw new Error('Failed to initialize download stream');
+
+    const chunks: Uint8Array[] = [];
+    while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        if (value) {
+            chunks.push(value);
+            downloaded += value.length;
+            if (onProgress && contentLength > 0) {
+                onProgress({
+                    downloaded,
+                    total: contentLength,
+                    percentage: Math.round((downloaded / contentLength) * 100),
+                });
+            }
+        }
+    }
+
+    const totalLength = chunks.reduce((acc, chunk) => acc + chunk.length, 0);
+    const combined = new Uint8Array(totalLength);
+    let offset = 0;
+    for (const chunk of chunks) {
+        combined.set(chunk, offset);
+        offset += chunk.length;
+    }
+
+    await writeFile(filename, combined, { baseDir: BaseDirectory.Download });
+    console.log('[UpdateService] Download complete, opening installer...');
+    await openPath(filePath);
 }
 
 export const updateService = new UpdateService();

--- a/ClassNoteAI/src/services/updateService.ts
+++ b/ClassNoteAI/src/services/updateService.ts
@@ -11,6 +11,41 @@ import { openPath } from '@tauri-apps/plugin-opener';
 import { writeFile, BaseDirectory } from '@tauri-apps/plugin-fs';
 import { fetch } from '@tauri-apps/plugin-http';
 import { downloadDir, join } from '@tauri-apps/api/path';
+import { invoke } from '@tauri-apps/api/core';
+
+/**
+ * v0.6.1: the updater's `target` must match the platform key in the
+ * merged `latest.json`. Default Tauri mapping is `windows-x86_64` /
+ * `darwin-aarch64` etc., but we now ship two Windows variants (CPU vs
+ * CUDA). The CUDA binary reports build variant "cuda" via a compile-
+ * time cfg and we append `-cuda` to the platform key so the updater
+ * pulls the right artifact.
+ *
+ * macOS has a single build (Metal always on via `cfg(target_os =
+ * "macos")`) so no suffix needed. Returning undefined lets the plugin
+ * use its default auto-detected target.
+ */
+async function pickUpdaterTarget(): Promise<string | undefined> {
+    let variant: string;
+    try {
+        variant = await invoke<string>('get_build_variant');
+    } catch {
+        // Older binary without the command — fall back to default
+        // Tauri auto-detection.
+        return undefined;
+    }
+    switch (variant) {
+        case 'cuda':
+            return 'windows-x86_64-cuda';
+        case 'vulkan':
+            // Reserved for when we ship Windows/Linux Vulkan builds.
+            return 'windows-x86_64-vulkan';
+        case 'metal':
+        case 'cpu':
+        default:
+            return undefined; // auto-detect
+    }
+}
 
 export interface UpdateInfo {
     available: boolean;
@@ -42,8 +77,12 @@ class UpdateService {
         }
 
         try {
-            console.log('[UpdateService] Checking for updates...');
-            const update = await check();
+            const target = await pickUpdaterTarget();
+            console.log(
+                '[UpdateService] Checking for updates...',
+                target ? `(target=${target})` : '(default target)',
+            );
+            const update = await check(target ? { target } : undefined);
 
             if (update) {
                 this.currentUpdate = update;

--- a/ClassNoteAI/src/services/videoImportService.ts
+++ b/ClassNoteAI/src/services/videoImportService.ts
@@ -485,15 +485,25 @@ export const videoImportService = {
                 if (chunkSubtitles.length > 0) {
                     const tSave = performance.now();
                     try {
+                        // Save EN silently — persistence for crash
+                        // safety + AI index. Deliberately NO
+                        // `subtitlesChanged` emit here: we only refresh
+                        // the visible subtitle panel once translation
+                        // lands so EN and ZH always appear together.
+                        // Prior behaviour fired EN-only refreshes and
+                        // users saw minutes of English with ZH trailing
+                        // awkwardly as translate backed up.
                         await storageService.saveSubtitles(chunkSubtitles);
                         saveMs = performance.now() - tSave;
+                        // Still emit a progress message (no
+                        // subtitlesChanged) so the header progress
+                        // indicator keeps ticking.
                         emit({
                             stage: 'transcribing',
                             message: `轉錄第 ${i + 1}/${total} 段中（已完成 ${transcribed}，翻譯 ${translated}/${total}）`,
                             transcribedChunks: transcribed,
                             translatedChunks: translated,
                             totalChunks: total,
-                            subtitlesChanged: true,
                         });
                     } catch (err) {
                         saveMs = performance.now() - tSave;

--- a/ClassNoteAI/src/services/videoImportService.ts
+++ b/ClassNoteAI/src/services/videoImportService.ts
@@ -78,6 +78,40 @@ interface PcmExtractResult {
     sample_count: number;
 }
 
+/** Minimal FIFO semaphore — caps concurrent execution of the async
+ *  tasks handed to `run`. Used to stop the translate pipeline from
+ *  firing 70 simultaneous `translate_ct2_batch` invokes at a single
+ *  CT2 translator (which thread-parallelizes internally and thrashes
+ *  the CPU/GPU when over-saturated).
+ *
+ *  Not worth pulling a `p-limit` npm dep for 15 lines.
+ */
+function makeLimiter(max: number) {
+    let running = 0;
+    const queue: (() => void)[] = [];
+    const next = () => {
+        if (running >= max) return;
+        const run = queue.shift();
+        if (run) {
+            running++;
+            run();
+        }
+    };
+    return async <T>(task: () => Promise<T>): Promise<T> => {
+        return new Promise<T>((resolve, reject) => {
+            queue.push(() => {
+                task()
+                    .then(resolve, reject)
+                    .finally(() => {
+                        running--;
+                        next();
+                    });
+            });
+            next();
+        });
+    };
+}
+
 /** Chunk length trade-off. Smaller chunks → first subtitles appear
  *  faster (better perceived latency) at the cost of more per-chunk
  *  warmup overhead. 60 s is the sweet spot for batch import:
@@ -95,7 +129,21 @@ interface PcmExtractResult {
  *  video where we already have the whole file — so we don't need
  *  LocalAgreement; just a small-enough chunk to feel responsive. */
 const CHUNK_SEC = 60;
-const TRANSLATE_BATCH = 64;
+/** Segments per invoke to translate_ct2_batch. Larger = fewer IPC
+ *  round-trips; CT2's internal batching handles the work. Bumped from
+ *  64 → 256 after the first probe showed translation stuck on IPC
+ *  overhead (user observation: "卡在等待資料傳入的部分"). A 60s
+ *  chunk has ~15-25 segments, so one chunk now fits in a single call
+ *  with headroom. Larger batches would need us to aggregate across
+ *  chunks and that loses the per-chunk save boundary. */
+const TRANSLATE_BATCH = 256;
+/** Ceiling on concurrent `translate_ct2_batch` invokes. The first
+ *  probe fired 70 in parallel at the same CT2 translator; CT2 already
+ *  thread-parallelizes per call, so stacking 70 on top thrashes the
+ *  CPU scheduler and actually *slows* each call. Empirically 2 is a
+ *  good ceiling — the translator stays busy, no idle slots, no
+ *  contention. Raise only if per-chunk translate_p95 is >> 1s. */
+const TRANSLATE_CONCURRENCY = 2;
 
 /** LLM-backed fine refinement pass. Runs AFTER rough transcribe +
  *  CT2 translate have landed all subtitles to DB. Each batch asks the
@@ -313,6 +361,7 @@ export const videoImportService = {
             const savedSubtitleIds = new Map<WhisperSegment, string>();
             const allSegments: WhisperSegment[] = [];
             const translationPromises: Promise<void>[] = [];
+            const translateLimit = makeLimiter(TRANSLATE_CONCURRENCY);
 
             // Per-chunk latency records so the end-of-run TIMING line
             // can surface p50/p95 for each stage. Distinguishes I/O
@@ -468,7 +517,7 @@ export const videoImportService = {
                 //     with the Chinese text. Errors degrade to
                 //     English-only — same graceful fallback as before.
                 translationPromises.push(
-                    (async () => {
+                    translateLimit(async () => {
                         const tTr = performance.now();
                         const texts = chunkSegs.map((s) => s.text.trim());
                         const outputs: string[] = new Array(texts.length).fill('');
@@ -528,7 +577,7 @@ export const videoImportService = {
                             totalChunks: total,
                             subtitlesChanged: true,
                         });
-                    })(),
+                    }),
                 );
             }
 

--- a/ClassNoteAI/src/services/videoImportService.ts
+++ b/ClassNoteAI/src/services/videoImportService.ts
@@ -314,6 +314,17 @@ export const videoImportService = {
             const allSegments: WhisperSegment[] = [];
             const translationPromises: Promise<void>[] = [];
 
+            // Per-chunk latency records so the end-of-run TIMING line
+            // can surface p50/p95 for each stage. Distinguishes I/O
+            // (DB save) from compute (Whisper/CT2) — with GPU Whisper
+            // getting near-instant, the next bottleneck is almost
+            // always the DB writes or the Tauri IPC round-trip.
+            const chunkTimings: {
+                transcribeMs: number;
+                saveMs: number;
+                translateMs: number;
+            }[] = [];
+
             let transcribed = 0;
             let translated = 0;
             // Seed language from caller or leave null for auto-detect.
@@ -368,7 +379,8 @@ export const videoImportService = {
                     },
                 );
 
-                const elapsed = ((performance.now() - t0) / 1000).toFixed(1);
+                const transcribeMs = performance.now() - t0;
+                const elapsed = (transcribeMs / 1000).toFixed(1);
                 console.log(
                     `[videoImport] chunk ${i + 1}/${total} transcribe done in ${elapsed}s — segments=${result.segments.length}, lang=${result.language ?? 'unknown'}`,
                 );
@@ -420,9 +432,12 @@ export const videoImportService = {
                         created_at: nowIso,
                     };
                 });
+                let saveMs = 0;
                 if (chunkSubtitles.length > 0) {
+                    const tSave = performance.now();
                     try {
                         await storageService.saveSubtitles(chunkSubtitles);
+                        saveMs = performance.now() - tSave;
                         emit({
                             stage: 'transcribing',
                             message: `轉錄第 ${i + 1}/${total} 段中（已完成 ${transcribed}，翻譯 ${translated}/${total}）`,
@@ -432,12 +447,21 @@ export const videoImportService = {
                             subtitlesChanged: true,
                         });
                     } catch (err) {
+                        saveMs = performance.now() - tSave;
                         console.warn(
                             `[videoImport] chunk ${i + 1} subtitle save failed:`,
                             err,
                         );
                     }
                 }
+                // Reserve a timing slot now; translate promise below
+                // writes to this exact index when it finishes.
+                const timingIdx = chunkTimings.length;
+                chunkTimings.push({
+                    transcribeMs,
+                    saveMs,
+                    translateMs: 0,
+                });
 
                 // (b) Kick off translation for just this chunk. When it
                 //     finishes we update the rows saved in (a) in place
@@ -445,6 +469,7 @@ export const videoImportService = {
                 //     English-only — same graceful fallback as before.
                 translationPromises.push(
                     (async () => {
+                        const tTr = performance.now();
                         const texts = chunkSegs.map((s) => s.text.trim());
                         const outputs: string[] = new Array(texts.length).fill('');
                         for (let i = 0; i < texts.length; i += TRANSLATE_BATCH) {
@@ -488,8 +513,9 @@ export const videoImportService = {
                             );
                         }
                         translated++;
+                        chunkTimings[timingIdx].translateMs = performance.now() - tTr;
                         console.log(
-                            `[videoImport] chunk ${chunkIndex + 1}/${total} translate done — ${translated}/${total} total`,
+                            `[videoImport] chunk ${chunkIndex + 1}/${total} translate done in ${(chunkTimings[timingIdx].translateMs / 1000).toFixed(2)}s — ${translated}/${total} total`,
                         );
                         emit({
                             stage: transcribed < total ? 'transcribing' : 'translating',
@@ -575,6 +601,29 @@ export const videoImportService = {
             }
             console.log(
                 `[videoImport] TIMING total=${((performance.now() - t0) / 1000).toFixed(1)}s  |  ${breakdown.join('  ')}`,
+            );
+
+            // Per-chunk latency percentiles. With GPU transcribe
+            // dropping to sub-second, the bottleneck shifts from
+            // compute to IPC / DB writes — this surfaces which
+            // stage is worth optimising next (e.g. if saveMs p95
+            // > transcribeMs p95 you're SQLite-bound, not model-
+            // bound).
+            const pct = (arr: number[], p: number) => {
+                if (arr.length === 0) return 0;
+                const s = [...arr].sort((a, b) => a - b);
+                return s[Math.min(s.length - 1, Math.floor((s.length - 1) * p))];
+            };
+            const tr = chunkTimings.map((c) => c.transcribeMs);
+            const sv = chunkTimings.map((c) => c.saveMs);
+            const tl = chunkTimings.map((c) => c.translateMs).filter((v) => v > 0);
+            const sum = (arr: number[]) => arr.reduce((a, b) => a + b, 0);
+            const fmt = (ms: number) => (ms / 1000).toFixed(2) + 's';
+            console.log(
+                `[videoImport] PER-CHUNK n=${tr.length}` +
+                    ` | transcribe p50=${fmt(pct(tr, 0.5))} p95=${fmt(pct(tr, 0.95))} sum=${fmt(sum(tr))}` +
+                    ` | save p50=${fmt(pct(sv, 0.5))} p95=${fmt(pct(sv, 0.95))} sum=${fmt(sum(sv))}` +
+                    ` | translate p50=${fmt(pct(tl, 0.5))} p95=${fmt(pct(tl, 0.95))} sum=${fmt(sum(tl))}`,
             );
 
             emit({ stage: 'done', message: '完成' });

--- a/ClassNoteAI/src/types/index.ts
+++ b/ClassNoteAI/src/types/index.ts
@@ -255,6 +255,26 @@ export interface AppSettings {
     autoSync: boolean;
     lastSyncTime?: string;
   };
+  /**
+   * Release channel preference for the updater.
+   *   - `stable` — only stable tags (vX.Y.Z). Uses the Tauri updater
+   *                plugin's default endpoint from tauri.conf.json,
+   *                which maps to GitHub's /releases/latest/ alias and
+   *                skips prereleases.
+   *   - `beta`   — stable + `*-beta*` prereleases. Uses GitHub API to
+   *                find the newest matching release; download bypasses
+   *                the plugin (runtime endpoint override not supported)
+   *                and opens the platform installer for the user to
+   *                click through.
+   *   - `alpha`  — stable + any prerelease (alpha, beta, rc). Same
+   *                GitHub-API + manual-download path as beta.
+   * Default is `stable` when unset. The manual path shows the same
+   * progress UI as the stable plugin flow; the only visible difference
+   * is that the installer window opens instead of auto-restart.
+   */
+  updates?: {
+    channel?: 'stable' | 'beta' | 'alpha';
+  };
 }
 
 // 錄音狀態

--- a/ClassNoteAI/src/types/index.ts
+++ b/ClassNoteAI/src/types/index.ts
@@ -174,6 +174,31 @@ export interface AppSettings {
   lectureLayout?: {
     videoPdfMode?: 'split' | 'pip';
   };
+  /**
+   * Experimental / opt-in defaults for the video-import pipeline.
+   * These used to live only in the ImportModal's per-import toggles;
+   * promoting them to settings lets the user set a preferred default
+   * once instead of re-picking for every import. The modal still
+   * honours per-import overrides when the user touches the control,
+   * so nothing regresses for "I want to change THIS one run".
+   */
+  experimental?: {
+    /** Default model preset for new video imports: `fast` (ggml-base,
+     *  ~5× realtime CPU) or `standard` (user's main model, slower but
+     *  more accurate). The ImportModal quality selector pre-fills from
+     *  this. */
+    importSpeed?: 'fast' | 'standard';
+    /** Default value of the "AI 精修字幕" checkbox in ImportModal.
+     *  Off by default because a 70-min lecture is ~130 k tokens of
+     *  LLM usage; users who have plentiful tokens can flip it on once
+     *  and forget it. */
+    importAiRefine?: boolean;
+    /** Whisper GPU backend preference. `auto` picks the first available
+     *  at runtime (Phase 2+); the other values let power users pin a
+     *  specific backend. Ignored in Phase 1 builds where no GPU features
+     *  are compiled in. */
+    asrBackend?: 'auto' | 'cuda' | 'metal' | 'vulkan' | 'cpu';
+  };
   sync?: {
     username: string;
     deviceId?: string;

--- a/ClassNoteAI/src/types/index.ts
+++ b/ClassNoteAI/src/types/index.ts
@@ -208,6 +208,40 @@ export interface AppSettings {
      *  LLM usage; users who have plentiful tokens can flip it on once
      *  and forget it. */
     importAiRefine?: boolean;
+    /** Refinement intensity. Controls how aggressively the LLM
+     *  rewrites the rough CT2 translation:
+     *    - `off`    : no LLM call (same as `importAiRefine: false`)
+     *    - `light`  : mid-tier model (GPT-4o-mini / Haiku / Gemini
+     *                 Flash), batched per 5-min section, grammar +
+     *                 term fixes only. ~14 calls / 70-min lecture,
+     *                 ~15k tokens. Fits free-tier Gemini easily.
+     *    - `deep`   : upper-mid model (Mistral Large 2 / Claude
+     *                 Sonnet / Llama 3.3 70B), batched per section,
+     *                 full rewrite with cross-subtitle consistency.
+     *                 ~14 calls, ~50k tokens. Shows a cost estimate
+     *                 in the UI before running.
+     *  The old `importAiRefine: true` maps to `deep`. */
+    refineIntensity?: 'off' | 'light' | 'deep';
+    /** Which LLM provider to prefer for refinement. `auto` picks
+     *  the first configured provider in this order: user's
+     *  ChatGPT Plus OAuth (already signed in? use it — the app
+     *  reuses Codex CLI's OAuth client) → GitHub Models /
+     *  Copilot OAuth → local Ollama (if GPU ≥ 12 GB VRAM detected)
+     *  → Gemini free tier → Groq free tier → Mistral Experiment
+     *  → user-provided raw key. The OAuth paths come first
+     *  because they're what most of our users already have signed
+     *  in (Copilot Pro = $10/mo, ChatGPT Plus = $20/mo are both
+     *  common). Pinning a specific value bypasses the chain. */
+    refineProvider?:
+        | 'auto'
+        | 'chatgpt-oauth'
+        | 'github-models'
+        | 'ollama'
+        | 'gemini'
+        | 'groq'
+        | 'mistral'
+        | 'openrouter'
+        | 'user-key';
     /** Whisper GPU backend preference. `auto` picks the first available
      *  at runtime (Phase 2+); the other values let power users pin a
      *  specific backend. Ignored in Phase 1 builds where no GPU features

--- a/ClassNoteAI/src/types/index.ts
+++ b/ClassNoteAI/src/types/index.ts
@@ -72,6 +72,21 @@ export interface Section {
   title: string;
   content: string;
   timestamp: number;
+  /**
+   * Representative sentences for this section, extracted by
+   * `extract_section_highlights` (centroid-nearest sentences from the
+   * section's subtitle body). Optional so legacy notes saved before
+   * v0.6.2 still load. When present, the UI renders these as bullets
+   * above a collapsed `content` block.
+   */
+  bullets?: string[];
+  /**
+   * Range of slide / PDF pages covered by this section, taken from
+   * the `page_number` fields of the subtitles it was built from.
+   * `null` when the section has no PDF pages (audio-only lecture or
+   * pre-PDF-alignment note).
+   */
+  page_range?: { min: number; max: number } | null;
 }
 
 export interface QARecord {

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@
 
 </div>
 
+> **🚧 Development status**
+> 穩定版：**v0.6.0** · 最新預覽版：**v0.6.0-alpha.4**（含 GPU 加速、簽章 macOS build、診斷 log、新 updater）
+> 一般使用者請從 [Releases 頁面](https://github.com/sklonely/ClassNoteAI/releases) 安裝。`main` 分支包含尚未正式發布的進行中工作，以 tag 區分穩定與預覽 — 不會主動 push 壞的內容到 main，但 release 的保障只在 tag 上。
+
 ---
 
 ClassNote AI 把你的筆電變成一位隨堂助教：上課時把老師的英文講解**即時轉成文字、同步翻譯**；下課後用你選擇的 AI（GPT、Claude、Gemini…）**整理筆記、回答問題、生成課程大綱**。

--- a/README.md
+++ b/README.md
@@ -14,10 +14,6 @@
 
 </div>
 
-> **🚧 Development status**
-> 穩定版：**v0.6.0** · 最新預覽版：**v0.6.0-alpha.4**（含 GPU 加速、簽章 macOS build、診斷 log、新 updater）
-> 一般使用者請從 [Releases 頁面](https://github.com/sklonely/ClassNoteAI/releases) 安裝。`main` 分支包含尚未正式發布的進行中工作，以 tag 區分穩定與預覽 — 不會主動 push 壞的內容到 main，但 release 的保障只在 tag 上。
-
 ---
 
 ClassNote AI 把你的筆電變成一位隨堂助教：上課時把老師的英文講解**即時轉成文字、同步翻譯**；下課後用你選擇的 AI（GPT、Claude、Gemini…）**整理筆記、回答問題、生成課程大綱**。

--- a/README.md
+++ b/README.md
@@ -1,0 +1,110 @@
+<div align="center">
+
+# ClassNote AI
+
+**即時課堂轉錄・AI 精修翻譯・智慧筆記助教**
+
+把英文授課變得好跟得上。
+
+[![Release](https://img.shields.io/github/v/release/sklonely/ClassNoteAI)](https://github.com/sklonely/ClassNoteAI/releases/latest)
+![Platforms](https://img.shields.io/badge/platform-macOS%20%7C%20Windows-blue)
+![License](https://img.shields.io/badge/license-MIT-green)
+
+[**📥 下載最新版**](https://github.com/sklonely/ClassNoteAI/releases/latest)　·　[**🌐 產品介紹頁**](https://sklonely.github.io/ClassNoteAI/landing/)　·　[**🛠 開發者文件**](CONTRIBUTING.md)
+
+</div>
+
+---
+
+ClassNote AI 把你的筆電變成一位隨堂助教：上課時把老師的英文講解**即時轉成文字、同步翻譯**；下課後用你選擇的 AI（GPT、Claude、Gemini…）**整理筆記、回答問題、生成課程大綱**。
+
+全部跑在你自己的電腦上，**沒有中間伺服器偷看你的錄音**。
+
+<br/>
+
+## ✨ 核心功能
+
+| 功能 | 說明 |
+|---|---|
+| 🎙️ **即時英文轉錄** | 本地 Whisper，**離線可用**。模型從 75 MB 到 574 MB 依硬體自選，<2 秒延遲 |
+| 🌐 **兩階段翻譯** | 即時粗翻（本地 Opus-MT / CTranslate2） → 背景 LLM 精修，自動覆寫字幕 |
+| 🤖 **帶著你的 AI 來** | 支援 Copilot Pro / ChatGPT Plus OAuth / OpenAI / Anthropic / Gemini API key |
+| 📄 **PDF 投影片同步** | 上傳講義，字幕會對齊到你正在講的那張投影片 |
+| 🧠 **RAG 課程問答** | 下課後和你的筆記對話，AI 答題會引用出自哪張投影片 / 哪段錄音 |
+| 📝 **筆記自動化** | 一鍵生 Markdown 摘要、課程大綱、關鍵詞標籤；可編輯可匯出 |
+| 🚀 **GPU 加速** | Windows CUDA / macOS Metal，Whisper 推論 ~20× realtime |
+| 💾 **本地優先** | 錄音/字幕/筆記/embedding 全部留在你電腦，不需要帳號就能開始用 |
+
+<br/>
+
+## 📥 安裝
+
+到 [Releases 頁面](https://github.com/sklonely/ClassNoteAI/releases/latest) 抓對應作業系統的安裝檔：
+
+| 作業系統 | 檔案 |
+|---|---|
+| **macOS**（Apple Silicon） | `ClassNoteAI_<版本>_aarch64.dmg` |
+| **Windows**（一般） | `ClassNoteAI_<版本>_x64-setup.exe` |
+| **Windows + NVIDIA GPU** | `ClassNoteAI_<版本>_x64_cuda-setup.exe` |
+
+> macOS 版本已經 Apple 簽章 + notarize，**首次開啟不會跳 Gatekeeper 警告**。
+>
+> 首次啟動會下載 Whisper 模型（~180 MB – 574 MB，看你選哪個）。
+
+不需要：Python、Node、Ollama、Docker。
+
+<br/>
+
+## 💡 使用流程
+
+1. **建立課程** — 輸入課名、貼上課綱（選填），AI 自動抽出講師 / 時間 / 評分
+2. **開始錄音** — 上課前開一堂新 lecture，按「開始錄製」
+3. **即時看字幕** — 英文 + 中文逐行出現；AI 精修會在背景自動升級翻譯品質
+4. **下課後** — 生摘要筆記、開 AI 助教問問題（RAG 答題會標引用）、匯出 Markdown
+
+<br/>
+
+## 🔒 隱私
+
+- 錄音、字幕、筆記、embedding **永遠留在本機**（SQLite）
+- AI 呼叫只送到你選的 Provider（GitHub / OpenAI / Anthropic / Google）；它們各自有隱私政策請自行確認
+- **零 telemetry** — ClassNote AI 不收任何使用資料
+- 雲端同步（開發中）會採 E2E 加密，Server 只存密文
+
+<br/>
+
+## ❓ 常見問題
+
+**字幕延遲很嚴重？** 換成更小的 Whisper 模型（如 Small-q5），或暫時關掉 LLM 精修。
+
+**錄音沒問題但轉錄怪怪的？** 檢查麥克風位置；非母語講者可以在 Course 的 keyword 欄位補術語，會餵給 Whisper 當提示。
+
+**AI 功能跳 "No AI provider configured"？** 到 設定 → AI 增強 至少配一個 Provider。
+
+**Copilot Pro 的 300 次 Premium Requests 不夠用？** 升到 Pro+（1500 次），或改用 pay-as-you-go 的 API key Provider。
+
+**想匯出所有資料？** 設定 → 資料管理 → 匯出 JSON。
+
+完整 FAQ 在 [應用內 README](ClassNoteAI/README.md)。
+
+<br/>
+
+## 🛠 想自己編譯？
+
+前端 + Rust 環境需求、Windows vendor 補丁、CI 設定通通在 [CONTRIBUTING.md](CONTRIBUTING.md)。
+
+<br/>
+
+## 📄 授權
+
+[MIT License](LICENSE) — 商用、改作、分發皆可。
+
+<div align="center">
+
+---
+
+**ClassNote AI** — 把你的筆電變成隨堂助教。
+
+<sub>Built with Tauri 2 · React · Rust · Whisper · CTranslate2 · Candle</sub>
+
+</div>

--- a/docs/known-issues/v0.6.0-alpha.1.md
+++ b/docs/known-issues/v0.6.0-alpha.1.md
@@ -1,0 +1,185 @@
+# v0.6.0-alpha.1 已知問題清單
+
+本檔是 2026-04-20 release smoke test 過程中發現、**尚未修復**的問題
+記錄。每項之後獨立開 PR 修。關閉對應 PR 時從此清單刪掉。
+
+---
+
+## 🔴 B1. 切設定頁會閃 cmd 視窗（Windows release build）
+
+**影響**：使用者 UX — 從「上課」進「設定」、在設定內切「本地轉錄模型」/
+「翻譯服務」tab 每次都會看到黑色 cmd 視窗閃一下。
+
+**Root cause**：`src-tauri/src/` 下 23 個 `std::process::Command::new(...)`
+呼叫**全部沒加 `CREATE_NO_WINDOW` flag**。release binary 沒連 console，子
+程序 spawn 時 Windows 預設開一個新 console window → 閃。
+
+熱路徑 trigger：
+- `gpu/mod.rs:149` — `nvidia-smi`（每次進設定、進 GPU tab 都會叫）
+- `setup/requirements.rs` 多處 — `sw_vers` / `cmd ver` / `df` / `powershell`
+- `lib.rs` 多處 — `osascript`（macOS 其實） / `soffice`（文件轉換）
+- `recording/video_import.rs` — `ffmpeg`（影片 import 時密集呼叫）
+- `oauth.rs` — `netstat` / `tasklist`
+
+**Fix**：在 `utils/command.rs` 寫個 helper：
+
+```rust
+pub fn no_window<S: AsRef<std::ffi::OsStr>>(program: S) -> Command {
+    let cmd = Command::new(program);
+    #[cfg(windows)]
+    cmd.creation_flags(0x08000000); // CREATE_NO_WINDOW
+    cmd
+}
+```
+
+然後全 repo replace `Command::new(` → `no_window(`。已寫 helper +
+換掉 `gpu/mod.rs`；其餘 22 處待 PR。
+
+**狀態**：WIP，helper 已在 branch，其餘 sites 待 refactor。
+
+---
+
+## 🔴 B2. 舊版巢狀 ct2 模型目錄不自癒
+
+**影響**：從 0.6.0 以前升級的使用者，若模型目錄呈 `m2m100-418M-ct2-int8/m2m100-418M-ct2-int8/model.bin` 巢狀結構（早期 downloader bug 或手動解壓留下），`load_translation_model_by_name` 會報「CT2 模型文件不存在」。
+
+**Root cause**：`lib.rs::load_translation_model_by_name` 只檢查外層 `model.bin`，不存在就直接拋錯，不會看巢狀 fallback。
+
+**Fix**：已在 `load_translation_model_by_name` 內加一次性 auto-flatten，偵測到 `model_dir/{model_name}/model.bin` 存在就把內層所有檔搬到外層再刪內層目錄。下次載入走 fast path。
+
+**狀態**：已提交本 branch（commit pending）。會隨下個 alpha/beta 一起 ship。
+
+---
+
+## 🚨 B3. whisper transcribe 在 12/13/14 代 Intel 消費 CPU 上 crash（AVX-512 不相容）
+
+**影響**：**所有 12 代以後 Intel 消費 CPU（i7-13700F 等）+ 不支援 AVX-512 的 AMD Ryzen 使用者**都會在執行 transcribe 時 app 整個消失。這是最嚴重的 blocker，受影響人數大——涵蓋 2022 後所有新裝機的主流消費機。
+
+**Root cause**：Windows Error Reporting 顯示 `exception code = c000001d = STATUS_ILLEGAL_INSTRUCTION`。WER Event：
+```
+P1: classnoteai.exe
+P2: 0.6.0.0
+P7: c000001d      ← illegal instruction
+P8: 00000000015626d1
+```
+- GitHub Actions `windows-latest` runner CPU：**Intel Xeon Platinum**（有完整 AVX-512/VNNI/BF16）
+- 使用者 CPU（e.g. i7-13700F）：**Raptor Lake 消費級，Intel 官方砍掉 AVX-512**
+- whisper.cpp / ggml 的 CMake 預設 `GGML_NATIVE=ON` → 偵測**編譯機器** CPU 把所有 SIMD 指令包進 binary
+- binary 跑到消費 CPU → SIGILL → 整個 process 死
+
+**Fix 方向**（release-windows.yml）：
+
+設定 `GGML_NATIVE=OFF` + 明確指定可攜 SIMD feature flag。建議 baseline：**x86-64-v3**（AVX2 級，2013 後 Intel、2015 後 AMD 都有）。
+
+```yaml
+env:
+  # Force CPU-portable builds. Without these, whisper.cpp /
+  # whisper-rs-sys bakes the CI runner's AVX-512 into the binary
+  # and every Raptor Lake / Ryzen 7000 consumer user gets
+  # STATUS_ILLEGAL_INSTRUCTION on first transcribe.
+  RUSTFLAGS: "-C target-cpu=x86-64-v3"
+  CMAKE_ARGS: "-DGGML_NATIVE=OFF -DGGML_AVX2=ON -DGGML_AVX512=OFF -DGGML_AVX512_VBMI=OFF -DGGML_AVX512_VNNI=OFF"
+```
+
+**Repro（從 CDP，繞開 UI）**：
+1. `load_whisper_model` → 203ms OK（只 init，沒執行 kernel）
+2. `transcribe_pcm_file_slice` → 10 秒內 crash，WER 寫 `c000001d`
+
+**Workaround for 使用者（暫時）**：
+- **沒有**。重新編譯才解。當前 v0.6.0-alpha.1 on CI = 無法在 12 代+ Intel 消費 CPU 跑 transcribe。
+- Dev build 從原始碼編（編譯機器 = 使用者機器）就自然避開這問題。
+
+**狀態**：待 alpha.2 修。這是 **必修的 ship blocker**。
+
+**Dump**：`C:\Users\asd19\AppData\Local\CrashDumps\classnoteai.exe.15964.dmp`（130MB，可用 WinDbg 載入看 stack trace，但需要 matching debug symbols）
+
+**延伸**：這個坑不只影響 whisper。`candle-core`（雖然我們 Windows 上 CUDA 已關，但 CPU 路徑也用 SIMD）、ct2rs、嚴格來說 ANY native SIMD user 都可能中。Fix 應該是 global RUSTFLAGS + CMAKE_ARGS 在 CI 層級。
+
+**Repro**（100% 重現）：
+1. Release build 啟動 via `launch-cuda-release.bat`
+2. CDP 端先 `load_translation_model_by_name('m2m100-418M-ct2-int8')` ✓
+3. CDP 端 `translate_ct2_batch([...])` ✓
+4. CDP 端 `load_whisper_model(ggml-base.bin)` ✓ 203ms 載好
+5. CDP 端 `transcribe_pcm_file_slice(pcm, 0, 60)` → **10 秒內 classnoteai.exe 不見**
+6. 60 秒 slice 跟 300 秒 slice 兩種長度都會 crash
+
+**觀察**：
+- 先跑 CT2 GPU 再跑 whisper GPU → 兩個 CUDA 路徑併存可能互撞
+- 或是 whisper-rs-sys 在 release optimized 的某個 UB / assertion panic
+- dev build 走 videoImportService 完整流程沒這問題 — 懷疑 orchestration 路徑有 pre-warm 或 error-handling 吃掉了 panic
+- 不是 nvidia driver（596.21）、不是 CUDA runtime（12.5）的兼容性問題（其他指令都 OK）
+
+**下步驟**：
+- 透過 UI import 一個影片，看 videoImportService orchestration 是否走得過
+- 若 UI 走得過、CDP 走不過 → 問題在於某個 orchestration preconditon 沒建
+- 收集 crashdump（`%LOCALAPPDATA%\CrashDumps\`）診斷 panic 起源
+- 考慮把 whisper-rs 的 CUDA path 包進 catch_unwind 避免整 process 死
+
+**狀態**：穩定重現，需 UI-side 對照測試確認是否 videoImportService 特有路徑。
+
+---
+
+## ⚪️ B4. CDP `\\` 轉義坑（dev-only）
+
+**非 bug，UX 標註**：CDP eval JSON payload 中的 Windows 反斜線路徑在 shell 傳遞時會被吃掉：
+
+```
+"C:\\\\Users\\\\..." → "C:Users..."
+```
+
+**Workaround**：CDP 端一律用正斜線（Windows NTFS 接受）。已在 SOP `docs/sop/release-smoke-test.md` 紀錄。
+
+**狀態**：文件已更新，不需 PR。
+
+---
+
+## 🟡 B5. `setup/mod.rs:86` 的 `.unwrap()` 在序列化失敗時讓 setup wizard crash
+
+**影響**：罕見——只在 `serde_json::to_string_pretty()` 失敗時（通常只有 OOM）。但一但發生，使用者看到靜默 crash 且 `setup_complete.json` 不會被寫入 → 每次啟動都重跑 setup wizard。
+
+**Fix**：`.unwrap()` 改成 `.map_err(|e| format!("JSON 序列化失敗: {}", e))?`
+
+---
+
+## 🔴 B6. ffmpeg WinGet 硬編路徑含版本號
+
+**影響**：MAJOR。`recording/video_import.rs:144-151` 硬寫：
+```
+ffmpeg-8.0.1-full_build/bin/ffmpeg.exe
+```
+WinGet 升級 ffmpeg 版本（例如到 8.0.2 / 8.1.0）→ 路徑失效 → 回傳 `"ffmpeg 未安裝或不在 PATH 中"`（**中文 hardcoded**！英文使用者看不懂）。
+
+另外：程式**先試 WinGet 專屬路徑**、再 fallback 到 PATH。正確順序應該是 PATH 優先（Chocolatey / scoop / 手動安裝都在 PATH）、WinGet 當 fallback。
+
+**Fix**：
+1. 把 `Command::new("ffmpeg")` 讓系統 resolve PATH 放第一優先
+2. WinGet 路徑改用 glob pattern `ffmpeg-*-full_build/bin/ffmpeg.exe`
+3. 錯誤訊息用 locale-aware（i18n 或至少英中雙語）
+
+---
+
+## 🟡 B7. Database init 沒重試機制（AV lock）
+
+**影響**：MEDIUM。Windows 有些防毒軟體會在 app 啟動初期鎖 `%APPDATA%` 幾秒。`storage/database.rs:42-46` 打開 SQLite 失敗直接噴 `SQLITE_CANTOPEN` → Tauri 啟動 pipeline 炸掉 → 使用者看到黑屏或 Tauri updater error。
+
+**Fix**：加 3 次重試、每次 backoff 500ms。3 次都失敗才顯示錯誤 dialog「資料夾被防毒軟體鎖定，請重啟 app」。
+
+---
+
+## 🟡 B8. Frontend `JSON.parse` 沒 try/catch
+
+**影響**：MEDIUM。`storageService.ts:187,211` 等處 `JSON.parse(settingsJson)` 沒 catch。如果 settings 檔案損壞（之前 app 崩潰 mid-write），下次讀會拋 `SyntaxError` → UI 白屏。
+
+**Fix**：包 try/catch、catch `SyntaxError` 後回預設 AppSettings、顯示 toast「設定已重置」。
+
+---
+
+## 🟡 B9. PowerShell spawn 沒 CREATE_NO_WINDOW（屬於 B1 子項）
+
+`setup/requirements.rs:237` 的 PowerShell 磁碟空間 probe 同樣會閃窗，跟 B1 同一條 fix line 一起 refactor。
+
+---
+
+## 追加項目
+
+（測試繼續中，有新發現會往下補）

--- a/docs/landing/index.html
+++ b/docs/landing/index.html
@@ -1,0 +1,757 @@
+<!doctype html>
+<html lang="zh-Hant">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>ClassNote AI — 把你的筆電變成隨堂助教</title>
+  <meta name="description" content="即時英文轉錄、AI 精修翻譯、RAG 筆記問答 — 全部跑在你自己的電腦上。" />
+  <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Cdefs%3E%3ClinearGradient id='g' x1='0' x2='1' y1='0' y2='1'%3E%3Cstop offset='0' stop-color='%233b82f6'/%3E%3Cstop offset='1' stop-color='%238b5cf6'/%3E%3C/linearGradient%3E%3C/defs%3E%3Crect rx='14' width='64' height='64' fill='url(%23g)'/%3E%3Ctext x='32' y='42' font-family='system-ui,sans-serif' font-size='30' font-weight='700' fill='white' text-anchor='middle'%3EC%3C/text%3E%3C/svg%3E" />
+
+  <style>
+    :root {
+      --bg: #ffffff;
+      --bg-soft: #f8fafc;
+      --ink: #0f172a;
+      --ink-soft: #475569;
+      --ink-muted: #94a3b8;
+      --card: #ffffff;
+      --card-border: #e2e8f0;
+      --brand: #3b82f6;
+      --brand2: #8b5cf6;
+      --brand-grad: linear-gradient(135deg, #3b82f6, #8b5cf6);
+      --brand-grad-soft: linear-gradient(135deg, rgba(59,130,246,0.12), rgba(139,92,246,0.12));
+      --shadow-lg: 0 20px 50px -20px rgba(59,130,246,0.35);
+      --radius: 18px;
+    }
+    @media (prefers-color-scheme: dark) {
+      :root {
+        --bg: #0b1220;
+        --bg-soft: #0f172a;
+        --ink: #e2e8f0;
+        --ink-soft: #cbd5e1;
+        --ink-muted: #64748b;
+        --card: #111a2e;
+        --card-border: #1e293b;
+        --brand-grad-soft: linear-gradient(135deg, rgba(59,130,246,0.22), rgba(139,92,246,0.22));
+        --shadow-lg: 0 20px 60px -20px rgba(139,92,246,0.5);
+      }
+    }
+
+    * { box-sizing: border-box; }
+    html, body { margin: 0; padding: 0; }
+    body {
+      font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", "Noto Sans TC",
+                   "Microsoft JhengHei", "PingFang TC", Roboto, sans-serif;
+      background: var(--bg);
+      color: var(--ink);
+      line-height: 1.65;
+      -webkit-font-smoothing: antialiased;
+    }
+    a { color: inherit; text-decoration: none; }
+    h1, h2, h3 { line-height: 1.2; margin: 0; font-weight: 700; letter-spacing: -0.02em; }
+    h1 { font-size: clamp(2.5rem, 5vw, 4rem); }
+    h2 { font-size: clamp(1.75rem, 3.5vw, 2.75rem); }
+    h3 { font-size: 1.25rem; }
+    p  { margin: 0; color: var(--ink-soft); }
+
+    .container { max-width: 1180px; margin: 0 auto; padding: 0 24px; }
+    .grad-text {
+      background: var(--brand-grad);
+      -webkit-background-clip: text;
+      background-clip: text;
+      color: transparent;
+    }
+
+    .icon { flex-shrink: 0; display: inline-block; vertical-align: -0.18em; }
+    .icon-14 { width: 14px; height: 14px; }
+    .icon-18 { width: 18px; height: 18px; }
+    .icon-20 { width: 20px; height: 20px; }
+    .feat-h3-icon {
+      display: inline-flex; align-items: center; justify-content: center;
+      width: 36px; height: 36px; border-radius: 10px;
+      background: var(--brand-grad-soft);
+      color: var(--brand2);
+      margin-right: 10px; vertical-align: middle;
+    }
+    .feat-h3-icon svg { width: 20px; height: 20px; }
+
+    header.nav {
+      position: sticky; top: 0; z-index: 30;
+      background: color-mix(in srgb, var(--bg) 85%, transparent);
+      backdrop-filter: saturate(160%) blur(12px);
+      border-bottom: 1px solid var(--card-border);
+    }
+    .nav-inner {
+      display: flex; align-items: center; justify-content: space-between;
+      height: 64px;
+    }
+    .brand {
+      display: flex; align-items: center; gap: 10px; font-weight: 700; letter-spacing: -0.01em;
+    }
+    .brand-mark {
+      width: 34px; height: 34px; border-radius: 10px;
+      background: var(--brand-grad);
+      display: grid; place-items: center;
+      color: white; font-weight: 800;
+      box-shadow: 0 6px 20px -8px rgba(59,130,246,0.6);
+    }
+    .nav-links { display: flex; gap: 28px; font-size: 0.95rem; color: var(--ink-soft); }
+    .nav-links a:hover { color: var(--ink); }
+    @media (max-width: 720px) { .nav-links { display: none; } }
+    .btn {
+      display: inline-flex; align-items: center; gap: 8px;
+      padding: 10px 18px; border-radius: 999px;
+      font-weight: 600; font-size: 0.95rem;
+      transition: transform 0.15s ease, box-shadow 0.2s ease;
+      white-space: nowrap;
+    }
+    .btn-primary {
+      background: var(--brand-grad);
+      color: white;
+      box-shadow: 0 8px 22px -10px rgba(59,130,246,0.7);
+    }
+    .btn-primary:hover { transform: translateY(-1px); box-shadow: 0 12px 28px -10px rgba(139,92,246,0.7); }
+    .btn-ghost {
+      border: 1px solid var(--card-border);
+      color: var(--ink);
+      background: var(--card);
+    }
+    .btn-ghost:hover { border-color: var(--brand); color: var(--brand); }
+
+    .hero {
+      padding: 80px 0 40px;
+      position: relative; overflow: hidden;
+    }
+    .hero::before {
+      content: ""; position: absolute; inset: 0 0 auto 0; height: 600px;
+      background: radial-gradient(ellipse at 30% 0%, rgba(59,130,246,0.18), transparent 60%),
+                  radial-gradient(ellipse at 80% 10%, rgba(139,92,246,0.18), transparent 50%);
+      z-index: -1; pointer-events: none;
+    }
+    .hero-grid {
+      display: grid; gap: 56px;
+      grid-template-columns: 1.1fr 1fr;
+      align-items: center;
+    }
+    @media (max-width: 900px) {
+      .hero-grid { grid-template-columns: 1fr; gap: 40px; }
+    }
+    .eyebrow {
+      display: inline-flex; align-items: center; gap: 8px;
+      padding: 6px 14px; border-radius: 999px;
+      background: var(--brand-grad-soft);
+      color: var(--brand2); font-weight: 600; font-size: 0.85rem;
+      margin-bottom: 20px;
+    }
+    .eyebrow::before {
+      content: ""; width: 6px; height: 6px; border-radius: 50%;
+      background: var(--brand); box-shadow: 0 0 0 4px rgba(59,130,246,0.25);
+      animation: pulse 2.2s ease-in-out infinite;
+    }
+    @keyframes pulse {
+      0%, 100% { opacity: 1; transform: scale(1); }
+      50% { opacity: 0.5; transform: scale(1.25); }
+    }
+    .hero p.lede { margin-top: 22px; font-size: 1.2rem; max-width: 540px; }
+    .hero-cta { margin-top: 34px; display: flex; gap: 14px; flex-wrap: wrap; }
+    .hero-meta {
+      margin-top: 22px; font-size: 0.9rem; color: var(--ink-muted);
+      display: flex; flex-wrap: wrap; gap: 14px 20px; align-items: center;
+    }
+    .hero-meta span { display: inline-flex; align-items: center; gap: 6px; }
+    .hero-meta .dot { width: 4px; height: 4px; border-radius: 50%; background: var(--ink-muted); }
+
+    .hero-art {
+      aspect-ratio: 1 / 1;
+      max-width: 520px; margin: 0 auto; width: 100%;
+      display: grid; place-items: center;
+    }
+
+    section { padding: 80px 0; }
+    .section-head {
+      text-align: center; max-width: 720px; margin: 0 auto 56px;
+    }
+    .section-head .eyebrow { margin-bottom: 14px; }
+    .section-head p { margin-top: 16px; font-size: 1.1rem; }
+
+    .features {
+      display: grid; gap: 22px;
+      grid-template-columns: repeat(3, 1fr);
+    }
+    @media (max-width: 960px) { .features { grid-template-columns: repeat(2, 1fr); } }
+    @media (max-width: 640px) { .features { grid-template-columns: 1fr; } }
+    .feature {
+      background: var(--card);
+      border: 1px solid var(--card-border);
+      border-radius: var(--radius);
+      padding: 26px;
+      display: flex; flex-direction: column; gap: 14px;
+      transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+      overflow: hidden;
+      position: relative;
+    }
+    .feature:hover {
+      transform: translateY(-4px);
+      border-color: color-mix(in srgb, var(--brand) 40%, var(--card-border));
+      box-shadow: var(--shadow-lg);
+    }
+    .feature-art {
+      height: 140px; width: 100%;
+      border-radius: 12px;
+      background: var(--brand-grad-soft);
+      display: grid; place-items: center;
+      overflow: hidden;
+    }
+    .feature h3 { font-size: 1.15rem; display: flex; align-items: center; }
+    .feature p { font-size: 0.95rem; }
+
+    .download {
+      background: var(--bg-soft);
+      border-top: 1px solid var(--card-border);
+      border-bottom: 1px solid var(--card-border);
+    }
+    .download-grid {
+      display: grid; gap: 16px;
+      grid-template-columns: repeat(3, 1fr);
+      margin-top: 40px;
+    }
+    @media (max-width: 800px) { .download-grid { grid-template-columns: 1fr; } }
+    .dl-card {
+      background: var(--card);
+      border: 1px solid var(--card-border);
+      border-radius: var(--radius);
+      padding: 28px;
+      display: flex; flex-direction: column; gap: 12px;
+      transition: border-color 0.2s ease, transform 0.15s ease;
+    }
+    .dl-card:hover { border-color: var(--brand); transform: translateY(-2px); }
+    .dl-icon {
+      width: 44px; height: 44px; border-radius: 10px;
+      background: var(--brand-grad-soft);
+      display: grid; place-items: center;
+    }
+    .dl-card h3 { font-size: 1.05rem; }
+    .dl-card p  { font-size: 0.88rem; }
+    .dl-card .btn { align-self: flex-start; margin-top: 4px; }
+
+    .privacy {
+      border-radius: calc(var(--radius) + 4px);
+      padding: 44px 36px;
+      background: var(--brand-grad);
+      color: white;
+      text-align: center;
+      position: relative;
+      overflow: hidden;
+    }
+    .privacy::before {
+      content: ""; position: absolute; inset: 0;
+      background: radial-gradient(ellipse at 20% 0%, rgba(255,255,255,0.2), transparent 60%);
+      pointer-events: none;
+    }
+    .privacy-eyebrow {
+      display: inline-flex; align-items: center; gap: 8px;
+      margin-bottom: 14px; font-weight: 700; letter-spacing: 0.05em;
+      font-size: 0.85rem;
+    }
+    .privacy h2 { color: white; }
+    .privacy p.lead {
+      color: rgba(255,255,255,0.9);
+      max-width: 620px; margin: 16px auto 0; font-size: 1.05rem;
+    }
+    .privacy-grid {
+      margin: 28px auto 0;
+      display: grid; gap: 14px;
+      grid-template-columns: repeat(3, 1fr);
+      max-width: 720px;
+    }
+    @media (max-width: 700px) { .privacy-grid { grid-template-columns: 1fr; } }
+    .privacy-item {
+      background: rgba(255,255,255,0.12);
+      border: 1px solid rgba(255,255,255,0.18);
+      border-radius: 12px;
+      padding: 14px;
+      backdrop-filter: blur(8px);
+      font-size: 0.92rem;
+      color: white;
+      text-align: left;
+    }
+    .privacy-item strong {
+      display: inline-flex; align-items: center; gap: 8px;
+      font-weight: 700;
+    }
+
+    footer { padding: 48px 0 64px; font-size: 0.9rem; color: var(--ink-muted); }
+    .footer-inner {
+      display: flex; justify-content: space-between; gap: 16px;
+      align-items: center; flex-wrap: wrap;
+    }
+    .footer-inner a:hover { color: var(--ink); }
+
+    .wave-bar { transform-origin: center; animation: waveOsc 1.2s ease-in-out infinite; }
+    @keyframes waveOsc { 0%,100%{transform:scaleY(0.35);} 50%{transform:scaleY(1);} }
+
+    .ring { transform-origin: center; animation: ring 2.6s ease-out infinite; opacity: 0; }
+    @keyframes ring { 0%{transform:scale(0.4);opacity:0.7;} 70%{transform:scale(1.6);opacity:0;} 100%{transform:scale(1.6);opacity:0;} }
+
+    .line-reveal { animation: reveal 3.8s ease-in-out infinite; transform-origin: left center; }
+    @keyframes reveal { 0%{transform:scaleX(0);opacity:0.3;} 40%{transform:scaleX(1);opacity:1;} 80%{transform:scaleX(1);opacity:1;} 100%{transform:scaleX(1);opacity:0;} }
+
+    .orbit { transform-origin: center; animation: orbit 14s linear infinite; }
+    @keyframes orbit { to { transform: rotate(360deg); } }
+    .orbit-reverse { transform-origin: center; animation: orbit 18s linear infinite reverse; }
+
+    .page-flip { transform-origin: left center; animation: pageFlip 3.2s ease-in-out infinite; }
+    @keyframes pageFlip { 0%,15%{transform:perspective(400px) rotateY(0deg);} 50%{transform:perspective(400px) rotateY(-155deg);} 85%,100%{transform:perspective(400px) rotateY(0deg);} }
+
+    .bubble-rise { animation: bubbleRise 3.6s ease-out infinite; opacity: 0; }
+    @keyframes bubbleRise { 0%{opacity:0;transform:translateY(12px);} 20%{opacity:1;transform:translateY(0);} 85%{opacity:1;} 100%{opacity:0;transform:translateY(-4px);} }
+
+    .lock-glow { animation: lockGlow 3s ease-in-out infinite; }
+    @keyframes lockGlow { 0%,100%{filter:drop-shadow(0 0 0 rgba(59,130,246,0));} 50%{filter:drop-shadow(0 0 14px rgba(59,130,246,0.55));} }
+
+    .bolt { animation: bolt 2.1s ease-in-out infinite; transform-origin: center; }
+    @keyframes bolt { 0%,60%,100%{opacity:0.9;transform:scale(1);} 30%{opacity:1;transform:scale(1.12);filter:drop-shadow(0 0 10px rgba(139,92,246,0.9));} }
+
+    @media (prefers-reduced-motion: reduce) {
+      .wave-bar, .ring, .line-reveal, .orbit, .orbit-reverse,
+      .page-flip, .bubble-rise, .lock-glow, .bolt, .eyebrow::before {
+        animation: none !important;
+      }
+    }
+  </style>
+</head>
+<body>
+
+<header class="nav">
+  <div class="container nav-inner">
+    <a class="brand" href="#">
+      <span class="brand-mark">C</span>
+      <span>ClassNote <span class="grad-text">AI</span></span>
+    </a>
+    <nav class="nav-links">
+      <a href="#features">功能</a>
+      <a href="#download">下載</a>
+      <a href="#privacy">隱私</a>
+      <a href="https://github.com/sklonely/ClassNoteAI">GitHub</a>
+    </nav>
+    <a class="btn btn-primary" href="https://github.com/sklonely/ClassNoteAI/releases/latest">
+      <svg class="icon icon-14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15v4a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2v-4"/><polyline points="7 10 12 15 17 10"/><line x1="12" x2="12" y1="15" y2="3"/></svg>
+      下載
+    </a>
+  </div>
+</header>
+
+<section class="hero">
+  <div class="container hero-grid">
+    <div>
+      <div class="eyebrow">本地運行 · 零 telemetry</div>
+      <h1>把英文授課變得<br/><span class="grad-text">好跟得上</span></h1>
+      <p class="lede">
+        即時轉錄老師的英文講解、AI 精修翻譯成中文，下課後和你的筆記對話 ——
+        全部跑在你自己的電腦上，沒有中間伺服器偷看你的錄音。
+      </p>
+      <div class="hero-cta">
+        <a class="btn btn-primary" href="https://github.com/sklonely/ClassNoteAI/releases/latest">
+          免費下載
+          <svg class="icon icon-14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" aria-hidden="true"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+        </a>
+        <a class="btn btn-ghost" href="#features">看看能做什麼</a>
+      </div>
+      <div class="hero-meta">
+        <span>
+          <svg class="icon icon-14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M16.365 1.43c0 1.14-.493 2.27-1.177 3.08-.744.9-1.99 1.57-2.987 1.57-.12 0-.23-.02-.3-.03-.01-.06-.04-.22-.04-.39 0-1.15.572-2.27 1.206-2.98.804-.94 2.142-1.64 3.248-1.68.03.13.05.28.05.43zm4.565 15.71c-.03.07-.463 1.58-1.518 3.12-.945 1.34-1.94 2.71-3.43 2.71-1.517 0-1.9-.88-3.63-.88-1.698 0-2.302.91-3.67.91-1.377 0-2.332-1.26-3.428-2.8-1.287-1.82-2.323-4.63-2.323-7.28 0-4.28 2.797-6.55 5.552-6.55 1.448 0 2.675.95 3.6.95.865 0 2.222-1.01 3.902-1.01.613 0 2.886.06 4.374 2.19-.13.08-2.608 1.5-2.608 4.5 0 3.4 3.058 4.62 3.08 4.63z"/></svg>
+          macOS
+        </span>
+        <span class="dot"></span>
+        <span>
+          <svg class="icon icon-14" viewBox="0 0 24 24" fill="currentColor" aria-hidden="true"><path d="M3 5.479l7.548-1.027v7.316H3V5.479zM3 18.521l7.548 1.027v-7.317H3v6.29zm8.377 1.14L21 20.979V12.5h-9.623v7.161zm0-16.185V11.5H21V3.02L11.377 3.476z"/></svg>
+          Windows + CUDA
+        </span>
+        <span class="dot"></span>
+        <span>
+          <svg class="icon icon-14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="2" x2="22" y1="2" y2="22"/><path d="M5.782 5.782A7 7 0 0 0 9 19h8.5a4.5 4.5 0 0 0 1.307-.193"/><path d="M21.532 16.5A4.5 4.5 0 0 0 17.5 10h-1.79A7.008 7.008 0 0 0 10 5.07"/></svg>
+          離線可用
+        </span>
+        <span class="dot"></span>
+        <span>
+          <svg class="icon icon-14" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M3.85 8.62a4 4 0 0 1 4.78-4.77 4 4 0 0 1 6.74 0 4 4 0 0 1 4.78 4.78 4 4 0 0 1 0 6.74 4 4 0 0 1-4.77 4.78 4 4 0 0 1-6.75 0 4 4 0 0 1-4.78-4.77 4 4 0 0 1 0-6.76Z"/><path d="m9 12 2 2 4-4"/></svg>
+          MIT License
+        </span>
+      </div>
+    </div>
+
+    <div class="hero-art">
+      <svg viewBox="0 0 520 520" width="100%" height="100%" xmlns="http://www.w3.org/2000/svg" aria-hidden="true">
+        <defs>
+          <linearGradient id="heroGrad" x1="0" y1="0" x2="1" y2="1">
+            <stop offset="0" stop-color="#3b82f6"/>
+            <stop offset="1" stop-color="#8b5cf6"/>
+          </linearGradient>
+        </defs>
+        <circle cx="260" cy="260" r="220" fill="url(#heroGrad)" opacity="0.08"/>
+        <circle cx="260" cy="260" r="160" fill="url(#heroGrad)" opacity="0.06"/>
+
+        <g transform="translate(140 240)">
+          <circle cx="0" cy="0" r="60" fill="none" stroke="url(#heroGrad)" stroke-width="2" class="ring"/>
+          <circle cx="0" cy="0" r="60" fill="none" stroke="url(#heroGrad)" stroke-width="2" class="ring" style="animation-delay: 0.8s"/>
+          <circle cx="0" cy="0" r="60" fill="none" stroke="url(#heroGrad)" stroke-width="2" class="ring" style="animation-delay: 1.6s"/>
+          <rect x="-18" y="-32" width="36" height="56" rx="18" fill="url(#heroGrad)"/>
+          <path d="M-28 10 Q-28 40 0 40 Q28 40 28 10" fill="none" stroke="url(#heroGrad)" stroke-width="4" stroke-linecap="round"/>
+          <line x1="0" y1="40" x2="0" y2="58" stroke="url(#heroGrad)" stroke-width="4" stroke-linecap="round"/>
+          <line x1="-14" y1="58" x2="14" y2="58" stroke="url(#heroGrad)" stroke-width="4" stroke-linecap="round"/>
+        </g>
+
+        <g transform="translate(230 240)">
+          <rect class="wave-bar" x="0"   y="-6" width="4" height="12" rx="2" fill="#3b82f6"/>
+          <rect class="wave-bar" x="10"  y="-14" width="4" height="28" rx="2" fill="#3b82f6" style="animation-delay: 0.1s"/>
+          <rect class="wave-bar" x="20"  y="-22" width="4" height="44" rx="2" fill="#6366f1" style="animation-delay: 0.2s"/>
+          <rect class="wave-bar" x="30"  y="-18" width="4" height="36" rx="2" fill="#8b5cf6" style="animation-delay: 0.3s"/>
+          <rect class="wave-bar" x="40"  y="-10" width="4" height="20" rx="2" fill="#8b5cf6" style="animation-delay: 0.4s"/>
+        </g>
+
+        <g transform="translate(290 130)">
+          <rect width="200" height="250" rx="16" style="fill: var(--card); stroke: var(--card-border);"/>
+          <rect x="14" y="14" width="54" height="8" rx="4" fill="#8b5cf6" opacity="0.6"/>
+          <circle cx="184" cy="18" r="4" fill="#3b82f6">
+            <animate attributeName="opacity" values="0.3;1;0.3" dur="1.3s" repeatCount="indefinite"/>
+          </circle>
+          <g transform="translate(14 46)">
+            <rect class="line-reveal" width="150" height="8" rx="4" fill="#0f172a" opacity="0.85"/>
+            <rect class="line-reveal" y="18" width="120" height="8" rx="4" fill="#0f172a" opacity="0.85" style="animation-delay: 0.6s"/>
+            <rect class="line-reveal" y="36" width="170" height="8" rx="4" fill="#0f172a" opacity="0.85" style="animation-delay: 1.2s"/>
+          </g>
+          <g transform="translate(14 110)">
+            <rect class="line-reveal" width="90" height="8" rx="4" fill="url(#heroGrad)" style="animation-delay: 1.8s"/>
+            <rect class="line-reveal" y="18" width="140" height="8" rx="4" fill="url(#heroGrad)" style="animation-delay: 2.2s"/>
+            <rect class="line-reveal" y="36" width="110" height="8" rx="4" fill="url(#heroGrad)" style="animation-delay: 2.6s"/>
+          </g>
+          <g transform="translate(14 182)">
+            <circle cx="4" cy="4" r="3" fill="#3b82f6"/>
+            <rect x="14" y="0" width="140" height="8" rx="4" fill="#94a3b8" opacity="0.5"/>
+            <circle cx="4" cy="22" r="3" fill="#8b5cf6"/>
+            <rect x="14" y="18" width="120" height="8" rx="4" fill="#94a3b8" opacity="0.5"/>
+            <circle cx="4" cy="40" r="3" fill="#3b82f6"/>
+            <rect x="14" y="36" width="150" height="8" rx="4" fill="#94a3b8" opacity="0.5"/>
+          </g>
+        </g>
+      </svg>
+    </div>
+  </div>
+</section>
+
+<section id="features">
+  <div class="container">
+    <div class="section-head">
+      <div class="eyebrow">核心特色</div>
+      <h2>為上課而生，不只是另一個錄音 App</h2>
+      <p>每一個功能都為了一個目標：讓英文授課變得好跟得上、好複習、好整理。</p>
+    </div>
+
+    <div class="features">
+
+      <div class="feature">
+        <div class="feature-art">
+          <svg viewBox="0 0 220 140" width="100%" height="100%" aria-hidden="true">
+            <g transform="translate(44 70)">
+              <circle r="30" fill="none" stroke="#3b82f6" stroke-width="2" class="ring"/>
+              <circle r="30" fill="none" stroke="#8b5cf6" stroke-width="2" class="ring" style="animation-delay: 1s"/>
+              <rect x="-9" y="-18" width="18" height="32" rx="9" fill="url(#heroGrad)"/>
+              <path d="M-16 4 Q-16 22 0 22 Q16 22 16 4" fill="none" stroke="url(#heroGrad)" stroke-width="3" stroke-linecap="round"/>
+            </g>
+            <g transform="translate(100 40)">
+              <rect class="line-reveal" width="90" height="6" rx="3" fill="currentColor" opacity="0.7"/>
+              <rect class="line-reveal" y="14" width="70" height="6" rx="3" fill="currentColor" opacity="0.7" style="animation-delay: 0.6s"/>
+              <rect class="line-reveal" y="28" width="100" height="6" rx="3" fill="url(#heroGrad)" style="animation-delay: 1.1s"/>
+              <rect class="line-reveal" y="42" width="80" height="6" rx="3" fill="url(#heroGrad)" style="animation-delay: 1.6s"/>
+              <rect class="line-reveal" y="56" width="50" height="6" rx="3" fill="url(#heroGrad)" style="animation-delay: 2.1s"/>
+            </g>
+          </svg>
+        </div>
+        <h3>
+          <span class="feat-h3-icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M12 2a3 3 0 0 0-3 3v7a3 3 0 0 0 6 0V5a3 3 0 0 0-3-3Z"/><path d="M19 10v2a7 7 0 0 1-14 0v-2"/><line x1="12" x2="12" y1="19" y2="22"/></svg>
+          </span>
+          即時英文轉錄
+        </h3>
+        <p>本地 Whisper 推論，<strong>完全離線可用</strong>。從 Tiny 到 Large-v3 Turbo 依硬體自選，~2 秒延遲的滾動式字幕。</p>
+      </div>
+
+      <div class="feature">
+        <div class="feature-art">
+          <svg viewBox="0 0 220 140" width="100%" height="100%" aria-hidden="true">
+            <g transform="translate(16 40)">
+              <text x="0" y="0" font-size="14" font-weight="700" fill="#3b82f6">EN</text>
+              <rect x="0" y="14" width="72" height="6" rx="3" fill="currentColor" opacity="0.55"/>
+              <rect x="0" y="28" width="56" height="6" rx="3" fill="currentColor" opacity="0.55"/>
+              <rect x="0" y="42" width="80" height="6" rx="3" fill="currentColor" opacity="0.55"/>
+              <rect x="0" y="56" width="64" height="6" rx="3" fill="currentColor" opacity="0.55"/>
+            </g>
+            <g transform="translate(110 70)">
+              <line x1="-18" y1="0" x2="18" y2="0" stroke="url(#heroGrad)" stroke-width="3" stroke-linecap="round" stroke-dasharray="4 4">
+                <animate attributeName="stroke-dashoffset" from="16" to="0" dur="1s" repeatCount="indefinite"/>
+              </line>
+              <path d="M14 -6 L22 0 L14 6" fill="none" stroke="url(#heroGrad)" stroke-width="3" stroke-linecap="round" stroke-linejoin="round"/>
+            </g>
+            <g transform="translate(140 40)">
+              <text x="0" y="0" font-size="14" font-weight="700" fill="#8b5cf6">中</text>
+              <rect class="line-reveal" x="0" y="14" width="64" height="6" rx="3" fill="url(#heroGrad)" style="animation-delay: 0.2s"/>
+              <rect class="line-reveal" x="0" y="28" width="48" height="6" rx="3" fill="url(#heroGrad)" style="animation-delay: 0.7s"/>
+              <rect class="line-reveal" x="0" y="42" width="60" height="6" rx="3" fill="url(#heroGrad)" style="animation-delay: 1.2s"/>
+              <rect class="line-reveal" x="0" y="56" width="52" height="6" rx="3" fill="url(#heroGrad)" style="animation-delay: 1.7s"/>
+            </g>
+          </svg>
+        </div>
+        <h3>
+          <span class="feat-h3-icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m5 8 6 6"/><path d="m4 14 6-6 2-3"/><path d="M2 5h12"/><path d="M7 2h1"/><path d="m22 22-5-10-5 10"/><path d="M14 18h6"/></svg>
+          </span>
+          兩階段翻譯
+        </h3>
+        <p>即時粗翻秒回，背景 LLM 精修再自動覆寫上去。字幕一開始就有，看完整課後全部升級成自然流暢版本。</p>
+      </div>
+
+      <div class="feature">
+        <div class="feature-art">
+          <svg viewBox="0 0 220 140" width="100%" height="100%" aria-hidden="true">
+            <g transform="translate(110 70)">
+              <circle r="16" fill="url(#heroGrad)"/>
+              <text x="0" y="5" text-anchor="middle" fill="white" font-weight="800" font-size="14">AI</text>
+              <g class="orbit">
+                <circle r="46" fill="none" stroke="currentColor" stroke-width="1" stroke-dasharray="2 4" opacity="0.3"/>
+                <g transform="translate(46 0)">
+                  <circle r="10" fill="#111a2e" stroke="#3b82f6" stroke-width="2"/>
+                  <text y="3" text-anchor="middle" fill="#3b82f6" font-weight="800" font-size="9">GH</text>
+                </g>
+                <g transform="translate(-46 0)">
+                  <circle r="10" fill="#111a2e" stroke="#8b5cf6" stroke-width="2"/>
+                  <text y="3" text-anchor="middle" fill="#8b5cf6" font-weight="800" font-size="9">GPT</text>
+                </g>
+              </g>
+              <g class="orbit-reverse">
+                <circle r="62" fill="none" stroke="currentColor" stroke-width="1" stroke-dasharray="2 6" opacity="0.2"/>
+                <g transform="translate(0 -62)">
+                  <circle r="10" fill="#111a2e" stroke="#3b82f6" stroke-width="2"/>
+                  <text y="3" text-anchor="middle" fill="#3b82f6" font-weight="800" font-size="9">AC</text>
+                </g>
+                <g transform="translate(0 62)">
+                  <circle r="10" fill="#111a2e" stroke="#8b5cf6" stroke-width="2"/>
+                  <text y="3" text-anchor="middle" fill="#8b5cf6" font-weight="800" font-size="9">GEM</text>
+                </g>
+              </g>
+            </g>
+          </svg>
+        </div>
+        <h3>
+          <span class="feat-h3-icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="4" y="4" width="16" height="16" rx="2"/><rect x="9" y="9" width="6" height="6"/><path d="M15 2v2"/><path d="M15 20v2"/><path d="M2 15h2"/><path d="M2 9h2"/><path d="M20 15h2"/><path d="M20 9h2"/><path d="M9 2v2"/><path d="M9 20v2"/></svg>
+          </span>
+          帶著你的 AI 來
+        </h3>
+        <p>Copilot Pro、ChatGPT Plus OAuth、OpenAI / Anthropic / Gemini API key 都支援。用你已經付過錢的訂閱，不用再開一份。</p>
+      </div>
+
+      <div class="feature">
+        <div class="feature-art">
+          <svg viewBox="0 0 220 140" width="100%" height="100%" aria-hidden="true">
+            <g transform="translate(30 26)">
+              <rect x="4" y="6" width="100" height="80" rx="8" fill="currentColor" opacity="0.1"/>
+              <rect x="2" y="3" width="100" height="80" rx="8" fill="currentColor" opacity="0.2"/>
+              <rect class="page-flip" width="100" height="80" rx="8" stroke="url(#heroGrad)" stroke-width="1.5" style="fill: var(--card);"/>
+              <g class="page-flip" pointer-events="none">
+                <rect x="12" y="12" width="52" height="6" rx="3" fill="url(#heroGrad)"/>
+                <rect x="12" y="26" width="76" height="4" rx="2" fill="currentColor" opacity="0.4"/>
+                <rect x="12" y="36" width="60" height="4" rx="2" fill="currentColor" opacity="0.4"/>
+                <rect x="12" y="46" width="72" height="4" rx="2" fill="currentColor" opacity="0.4"/>
+                <rect x="12" y="62" width="40" height="10" rx="3" fill="#8b5cf6" opacity="0.7"/>
+              </g>
+            </g>
+            <g transform="translate(150 70)">
+              <rect width="50" height="8" rx="4" fill="url(#heroGrad)">
+                <animate attributeName="width" values="20;50;50;20" keyTimes="0;0.4;0.8;1" dur="3.2s" repeatCount="indefinite"/>
+              </rect>
+              <rect y="16" width="40" height="4" rx="2" fill="currentColor" opacity="0.4"/>
+              <rect y="28" width="46" height="4" rx="2" fill="currentColor" opacity="0.4"/>
+              <rect y="40" width="34" height="4" rx="2" fill="currentColor" opacity="0.4"/>
+            </g>
+          </svg>
+        </div>
+        <h3>
+          <span class="feat-h3-icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M14.5 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V7.5L14.5 2z"/><polyline points="14 2 14 8 20 8"/><line x1="16" x2="8" y1="13" y2="13"/><line x1="16" x2="8" y1="17" y2="17"/><line x1="10" x2="8" y1="9" y2="9"/></svg>
+          </span>
+          PDF 投影片同步
+        </h3>
+        <p>上傳講義，字幕自動對齊到你正在講的那張投影片。複習時點一下任一頁，直接跳到那段錄音。</p>
+      </div>
+
+      <div class="feature">
+        <div class="feature-art">
+          <svg viewBox="0 0 220 140" width="100%" height="100%" aria-hidden="true">
+            <g transform="translate(16 22)" class="bubble-rise">
+              <rect width="110" height="30" rx="14" fill="#3b82f6" opacity="0.18"/>
+              <rect x="10" y="10" width="60" height="4" rx="2" fill="#3b82f6"/>
+              <rect x="10" y="18" width="84" height="4" rx="2" fill="#3b82f6"/>
+            </g>
+            <g transform="translate(120 60)" class="bubble-rise" style="animation-delay: 1s">
+              <rect width="26" height="14" rx="7" fill="url(#heroGrad)"/>
+              <text x="13" y="10" font-size="9" fill="white" text-anchor="middle" font-weight="700">p.7</text>
+              <rect x="32" width="32" height="14" rx="7" fill="url(#heroGrad)" opacity="0.7"/>
+              <text x="48" y="10" font-size="9" fill="white" text-anchor="middle" font-weight="700">12:30</text>
+            </g>
+            <g transform="translate(40 86)" class="bubble-rise" style="animation-delay: 1.8s">
+              <rect width="160" height="38" rx="14" fill="url(#heroGrad)" opacity="0.18"/>
+              <rect x="10" y="9" width="120" height="4" rx="2" fill="#8b5cf6"/>
+              <rect x="10" y="18" width="100" height="4" rx="2" fill="#8b5cf6"/>
+              <rect x="10" y="27" width="80" height="4" rx="2" fill="#8b5cf6"/>
+            </g>
+          </svg>
+        </div>
+        <h3>
+          <span class="feat-h3-icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/><path d="M8 12a2 2 0 0 0 2-2V8H8"/><path d="M14 12a2 2 0 0 0 2-2V8h-2"/></svg>
+          </span>
+          RAG 課程問答
+        </h3>
+        <p>下課後和你的筆記對話。投影片 + 錄音都切塊算 embedding（本地 Candle 跑），AI 答題自動引用出自哪張投影片、哪段時間。</p>
+      </div>
+
+      <div class="feature">
+        <div class="feature-art">
+          <svg viewBox="0 0 220 140" width="100%" height="100%" aria-hidden="true">
+            <g opacity="0.5">
+              <line x1="20" y1="40" x2="60" y2="40" stroke="currentColor" stroke-width="2">
+                <animate attributeName="x1" values="20;60" dur="1.1s" repeatCount="indefinite"/>
+                <animate attributeName="x2" values="60;100" dur="1.1s" repeatCount="indefinite"/>
+              </line>
+              <line x1="14" y1="60" x2="70" y2="60" stroke="currentColor" stroke-width="2">
+                <animate attributeName="x1" values="14;70" dur="1.3s" repeatCount="indefinite"/>
+                <animate attributeName="x2" values="70;126" dur="1.3s" repeatCount="indefinite"/>
+              </line>
+              <line x1="24" y1="80" x2="58" y2="80" stroke="currentColor" stroke-width="2">
+                <animate attributeName="x1" values="24;58" dur="0.9s" repeatCount="indefinite"/>
+                <animate attributeName="x2" values="58;92" dur="0.9s" repeatCount="indefinite"/>
+              </line>
+              <line x1="18" y1="100" x2="56" y2="100" stroke="currentColor" stroke-width="2">
+                <animate attributeName="x1" values="18;56" dur="1.2s" repeatCount="indefinite"/>
+                <animate attributeName="x2" values="56;94" dur="1.2s" repeatCount="indefinite"/>
+              </line>
+            </g>
+            <g transform="translate(130 26)" class="bolt">
+              <path d="M30 0 L8 50 L26 50 L18 90 L52 34 L34 34 Z" fill="url(#heroGrad)" stroke="url(#heroGrad)" stroke-width="2" stroke-linejoin="round"/>
+            </g>
+          </svg>
+        </div>
+        <h3>
+          <span class="feat-h3-icon">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
+          </span>
+          GPU 加速
+        </h3>
+        <p>Windows CUDA / macOS Metal 皆支援。RTX 4060 Ti 上 Whisper 推論 <strong>~20× realtime</strong>，一小時的課 3 分鐘轉完。</p>
+      </div>
+
+    </div>
+  </div>
+</section>
+
+<section id="download" class="download">
+  <div class="container">
+    <div class="section-head">
+      <div class="eyebrow">跨平台支援</div>
+      <h2>挑一個版本<span class="grad-text">開始</span></h2>
+      <p>macOS 已簽章 + notarize，首次開啟不跳 Gatekeeper 警告。Windows 有 NVIDIA GPU 的請用 CUDA 版加速。</p>
+    </div>
+
+    <div class="download-grid">
+
+      <a class="dl-card" href="https://github.com/sklonely/ClassNoteAI/releases/latest">
+        <div class="dl-icon">
+          <svg viewBox="0 0 24 24" width="22" height="22" fill="currentColor" style="color:#8b5cf6" aria-hidden="true"><path d="M16.365 1.43c0 1.14-.493 2.27-1.177 3.08-.744.9-1.99 1.57-2.987 1.57-.12 0-.23-.02-.3-.03-.01-.06-.04-.22-.04-.39 0-1.15.572-2.27 1.206-2.98.804-.94 2.142-1.64 3.248-1.68.03.13.05.28.05.43zm4.565 15.71c-.03.07-.463 1.58-1.518 3.12-.945 1.34-1.94 2.71-3.43 2.71-1.517 0-1.9-.88-3.63-.88-1.698 0-2.302.91-3.67.91-1.377 0-2.332-1.26-3.428-2.8-1.287-1.82-2.323-4.63-2.323-7.28 0-4.28 2.797-6.55 5.552-6.55 1.448 0 2.675.95 3.6.95.865 0 2.222-1.01 3.902-1.01.613 0 2.886.06 4.374 2.19-.13.08-2.608 1.5-2.608 4.5 0 3.4 3.058 4.62 3.08 4.63z"/></svg>
+        </div>
+        <h3>macOS（Apple Silicon）</h3>
+        <p>已簽章 + notarize。M1 / M2 / M3 皆支援，Metal GPU 自動啟用。</p>
+        <span class="btn btn-primary">下載 .dmg →</span>
+      </a>
+
+      <a class="dl-card" href="https://github.com/sklonely/ClassNoteAI/releases/latest">
+        <div class="dl-icon">
+          <svg viewBox="0 0 24 24" width="22" height="22" fill="currentColor" style="color:#3b82f6" aria-hidden="true"><path d="M3 5.479l7.548-1.027v7.316H3V5.479zM3 18.521l7.548 1.027v-7.317H3v6.29zm8.377 1.14L21 20.979V12.5h-9.623v7.161zm0-16.185V11.5H21V3.02L11.377 3.476z"/></svg>
+        </div>
+        <h3>Windows（一般）</h3>
+        <p>Intel / AMD CPU 皆可。全部用 CPU 轉錄，不需要顯卡。</p>
+        <span class="btn btn-primary">下載 .exe →</span>
+      </a>
+
+      <a class="dl-card" href="https://github.com/sklonely/ClassNoteAI/releases/latest">
+        <div class="dl-icon">
+          <svg viewBox="0 0 24 24" width="22" height="22" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="color:#76b900" aria-hidden="true"><polygon points="13 2 3 14 12 14 11 22 21 10 12 10 13 2"/></svg>
+        </div>
+        <h3>Windows + NVIDIA GPU</h3>
+        <p>CUDA 加速版。RTX 系列 / GTX 16xx 以上享 ~20× realtime 轉錄速度。</p>
+        <span class="btn btn-primary">下載 CUDA 版 →</span>
+      </a>
+
+    </div>
+  </div>
+</section>
+
+<section id="privacy">
+  <div class="container">
+    <div class="privacy">
+      <div class="privacy-eyebrow">
+        <svg class="icon icon-18 lock-glow" viewBox="0 0 24 24" fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+          <rect x="5" y="11" width="14" height="10" rx="2"/>
+          <path d="M8 11V7a4 4 0 0 1 8 0v4"/>
+        </svg>
+        PRIVACY BY DESIGN
+      </div>
+      <h2>你的錄音，不會離開你的電腦</h2>
+      <p class="lead">
+        ClassNote AI 把所有錄音、字幕、筆記、embedding 都存在你電腦的 SQLite 資料庫。
+        沒有中間伺服器。沒有 telemetry。沒有使用者追蹤。帳號也不需要。
+      </p>
+      <div class="privacy-grid">
+        <div class="privacy-item">
+          <strong>
+            <svg class="icon icon-18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m3 9 9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+            本機儲存
+          </strong><br/>
+          <span style="opacity:0.9">所有課程資料都在你電腦上的 SQLite</span>
+        </div>
+        <div class="privacy-item">
+          <strong>
+            <svg class="icon icon-18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M19.69 14a6.9 6.9 0 0 0 .31-2V5l-8-3-3.16 1.18"/><path d="M4.73 4.73 4 5v7c0 6 8 10 8 10a20.29 20.29 0 0 0 5.62-4.38"/><line x1="2" x2="22" y1="2" y2="22"/></svg>
+            零 telemetry
+          </strong><br/>
+          <span style="opacity:0.9">App 不回傳任何使用資料</span>
+        </div>
+        <div class="privacy-item">
+          <strong>
+            <svg class="icon icon-18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="7.5" cy="15.5" r="5.5"/><path d="m21 2-9.6 9.6"/><path d="m15.5 7.5 3 3L22 7l-3-3"/></svg>
+            你的 API key
+          </strong><br/>
+          <span style="opacity:0.9">AI 呼叫直接走你自己的訂閱，不經我方</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+<footer>
+  <div class="container footer-inner">
+    <div>
+      © 2026 ClassNote AI · MIT License · 以
+      <svg class="icon icon-14" viewBox="0 0 24 24" fill="currentColor" style="color: #ec4899" aria-hidden="true"><path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z"/></svg>
+      做給學生用
+    </div>
+    <div style="display:flex;gap:20px;">
+      <a href="https://github.com/sklonely/ClassNoteAI">GitHub</a>
+      <a href="https://github.com/sklonely/ClassNoteAI/releases/latest">Releases</a>
+      <a href="https://github.com/sklonely/ClassNoteAI/blob/main/ClassNoteAI/README.md">使用文件</a>
+      <a href="https://github.com/sklonely/ClassNoteAI/blob/main/CONTRIBUTING.md">開發者</a>
+    </div>
+  </div>
+</footer>
+
+</body>
+</html>


### PR DESCRIPTION
## Summary

Whisper + Candle + CT2 all on CUDA via a single build flag; macOS auto-enables Metal; CI produces both CPU and CUDA Windows installers from one tag push.

10 commits, one branch. **Draft until a test tag has produced working CUDA + CPU installers.** PR CI is green.

## What lands

### Core GPU plumbing

- **`whisper-rs 0.11 → 0.16`** — API migrated to `WhisperState::get_segment()` / `to_str_lossy()` / `start_timestamp()`. Centisecond → ms conversion preserved.
- **`candle-core/nn/transformers 0.8 → 0.9`** — 0.8's pinned `cudarc 0.13` hardcodes a CUDA-toolkit whitelist that rejects 13.x. 0.9 uses `cudarc 0.16` with `cuda-version-from-build-system`, so the same source builds against 12.x (CI) and 13.x (developer workstations). No app-side API changes — our `embedding/candle.rs` uses the Module / VarBuilder / tensor paths that are stable between 0.8 and 0.9.
- **Three opt-in Cargo features** that fan out across the project:
  - `gpu-cuda` → whisper-rs + candle-core + candle-nn + candle-transformers + ct2rs (via `cuda-dynamic-loading`) all compile with CUDA.
  - `gpu-vulkan` → whisper-rs only (candle/ct2rs have no Vulkan backend).
  - `gpu-metal` → whisper-rs + candle metal. Auto-enabled on macOS via `cfg(target_os = "macos")` target-specific dep — Mac users get GPU with no flag.
- **Runtime GPU detection** (`src-tauri/src/gpu`) — `nvidia-smi` subprocess probes CUDA (name + driver version), filesystem probes Vulkan loader, `cfg` handles Metal. Zero new native deps. Verified live on the user's RTX 4060 Ti: `cuda = { gpu_name: "NVIDIA GeForce RTX 4060 Ti", driver_version: "572.83" }, effective = "cuda"`.
- **Setup wizard `硬體加速偵測` step** between env-check and model-download.
- **Settings reorg** — experimental toggles split into domain-specific cards (`LocalModelExperimentalSettings` under 本地轉錄模型 for Whisper speed + GPU backend; `CloudAIExperimentalSettings` under 雲端 AI 助理 for LLM refine). New 介面與顯示 tab under 其他 hosts AI-tutor display mode + video+PDF layout.

### CI + bundling + updater

- `release-windows.yml` → `matrix: variant: [cpu, cuda]`. CUDA variant runs Jimver CUDA Toolkit 12.5 action before `tauri build --features gpu-cuda`. Artifact naming suffixes `-cuda`; updater manifest fragments carry `windows-x86_64` and `windows-x86_64-cuda` platform keys.
- **CUDA runtime DLLs** (`cudart64_12.dll`, `cublas64_12.dll`, `cublasLt64_12.dll`) staged into `src-tauri/resources/cuda/` during the CUDA CI job and bundled next to the exe via `bundle.resources` glob. **Users don't need CUDA Toolkit** — driver + shipped runtime DLLs is enough. Hits the "一鍵安裝" goal.
- `get_build_variant()` Tauri command returns compile-time variant; `updateService.pickUpdaterTarget()` maps it to `windows-x86_64-cuda` (or stays default for CPU/macOS) so clients only pull the artifact matching their install.
- `merge-update-manifest.yml` folds the optional CUDA fragment into `latest.json` via `jq reduce`.

### Video-import perf work

- **Chunked transcribe pipeline** with pair-emit: EN + ZH saved in the same DB transaction per chunk, UI refreshes only when both are ready — no more "wall of English with ZH trailing minutes behind".
- **Translate concurrency cap = 2** + `TRANSLATE_BATCH 64 → 256`. First probe attempted 70 concurrent translate calls at a single CT2 instance and got ~32 s/chunk of CPU thrash; capped version runs ~7 s/chunk (translate pace now the bottleneck below GPU).
- **Bulk subtitle reload** — new `subtitleService.setSegments(segments, lectureId)` replaces the old `clear() + addSegment × N` pattern. One `notifyListeners` per reload instead of N+1. Debounced at NotesView callsite to 400 ms coalesce window.
- **Per-chunk p50/p95 timing** in the import log. Line shape: `[videoImport] PER-CHUNK n=70 | transcribe p50=... p95=... sum=... | save p50=... p95=... sum=... | translate p50=... p95=... sum=...`.
- **Auto-switch to Notes Review + Subtitles tab** after `video_ready` event. Video import = class is over; streaming captions belong front-and-center.

### UX polish

- Subtitle timestamps render `MM:SS.cc` (centisecond precision — the limit of Whisper's native timing grid).
- ImportModal reads `experimental` defaults on mount so users set speed/refine once and forget.

## Measured on the user's machine

### CPU baseline (probe v4 on a 70-min lecture)

| Stage | Time |
|---|---|
| Stage copy | < 1 s |
| ffmpeg PCM extract | 2 s |
| Transcribe (base, CPU) | **265 s** (3.5 s/chunk steady, 70 chunks) |
| Translate drain (CT2 CPU, concurrency=2) | **+240 s** |
| End-to-end (excluding RAG index) | **~7 min for a 70-min video** |
| RAG indexing | STALLED 13+ min — separate issue flagged as follow-up |

### GPU target (projected; to be verified from the CUDA installer)

| Stage | Projected |
|---|---|
| Transcribe (base, CUDA on RTX 4060 Ti) | ~20 s for 70 chunks (**~15× speedup**) |
| Translate (CT2 CUDA) | ~15 s for 70 chunks (**~30× speedup**) |
| End-to-end | **< 1 min for a 70-min video (~7× overall)** |

### Local CUDA 13 build — blocked, not in merge scope

Tried to verify GPU end-to-end on the user's Windows machine with CUDA Toolkit 13.2 (winget default). Ran into a sequence of vendor-CMakeLists incompatibilities with VS 18's MSBuild toolchain:
1. `cudarc 0.13` CUDA 13 whitelist → fixed by bumping candle 0.8 → 0.9
2. whisper.cpp's deprecated `FindCUDA.cmake` choking on `\P` in `C:\Program Files` → worked around with forward-slash `CUDA_PATH`
3. ct2rs hardcoding `compute_53` which CUDA 13 dropped → worked around with `CMAKE_CUDA_ARCHITECTURES`
4. VS 18 MSBuild `CUDA 13.2.targets` expecting a `CudaToolkitDir` MSBuild property cmake-rs doesn't plumb through — dead end. Ninja fallback also fails (cl.exe not propagated).

CI path (CUDA 12.5 via Jimver action) doesn't hit any of these — VS 2022 + older CUDA targets integrate cleanly. Nothing about the PR's runtime behaviour depends on local-build verification.

## Test plan

- [x] `cargo check --features candle-embed` green on Windows CPU with whisper-rs 0.16 + candle 0.9.
- [x] `npx tsc --noEmit` clean.
- [x] `detect_gpu_backends` Tauri command returns real hardware info (verified live via CDP on the user's machine).
- [x] Settings sidebar shows the new 介面與顯示 tab under 其他.
- [x] Import modal respects `experimental.importSpeed` / `importAiRefine` defaults from Settings.
- [x] Probe v4 produced real per-chunk timing numbers; translate concurrency fix dropped pipeline wall-time from 21 min (first probe, 70-way parallel) to 7 min (concurrency=2).
- [ ] CI matrix green on the `release-windows.yml` tag run — first tag push is the next gate.
- [ ] Manual install of CUDA-variant artifact from the draft release on an RTX GPU; verify large-v3-turbo runs at ≥ 15× realtime.
- [ ] Updater cross-variant safety — CPU-installed user doesn't silently receive CUDA upgrade.

## Remaining before merge

1. Push a test tag (e.g. `v0.6.1-gpu-test0`) — triggers `release-windows.yml` matrix → produces `ClassNoteAI_*_x64-setup.exe` + `ClassNoteAI_*_x64-cuda-setup.exe` + `ClassNoteAI_*_aarch64.dmg`.
2. Install the CUDA variant on a real NVIDIA box; validate end-to-end GPU speedup against the CPU baseline above.
3. Flip PR #46 draft → ready.

## Follow-up (out of scope for this PR)

- Cross-variant nudge: CPU user with CUDA detected sees "下載 GPU 加速版" link in Settings → 本地轉錄模型.
- RAG indexing slowdown on large lectures — observed 13+ min for 1296 segments during probe v4. Probably BGE cold-start + batch efficiency. Worth profiling separately.
- Linux Vulkan CI matrix entry.
- AMD HIP/ROCm via `whisper-rs/hipblas` feature (mirrors CUDA matrix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)