### PR TITLE
[codex] Add recording consent step and device-change warnings

### DIFF
--- a/ClassNoteAI/src/App.tsx
+++ b/ClassNoteAI/src/App.tsx
@@ -12,6 +12,8 @@ import type { RecoverableSession } from "./services/recordingRecoveryService";
 import { storageService } from "./services/storageService";
 import { setupService } from "./services/setupService";
 import { syncService } from "./services/syncService";
+import { toastService } from "./services/toastService";
+import { buildInterruptedRecordingNotice } from "./services/recordingInterruptionNotice";
 import { useAuth } from "./contexts/AuthContext";
 
 type AppState = 'loading' | 'setup' | 'ready';
@@ -137,6 +139,15 @@ function App() {
           } catch (err) {
             console.warn(`[App] Failed to reconcile zombie lecture ${lec.id}:`, err);
           }
+        }
+
+        const interruptedNotice = buildInterruptedRecordingNotice(scan.lectureOrphansWithoutPcm);
+        if (interruptedNotice) {
+          toastService.show({
+            ...interruptedNotice,
+            type: 'warning',
+            durationMs: 0,
+          });
         }
       } catch (err) {
         console.warn('[App] Crash-recovery scan failed (non-fatal):', err);

--- a/ClassNoteAI/src/components/NotesView.tsx
+++ b/ClassNoteAI/src/components/NotesView.tsx
@@ -30,6 +30,8 @@ const markdownSanitizeSchema = {
     tagNames: [...(defaultSchema.tagNames ?? []), 'details', 'summary'],
 };
 import { storageService } from "../services/storageService";
+import { audioDeviceService } from "../services/audioDeviceService";
+import { buildDeviceChangeWarning, type RecordingInputSnapshot } from "../services/recordingDeviceMonitor";
 import { extractKeywords } from "../utils/pdfKeywordExtractor";
 import { detectSectionBoundaries } from "../utils/topicSegmentation";
 import { summarizeStream, usageTracker } from "../services/llm";
@@ -150,11 +152,19 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
   const pdfViewerRef = useRef<PDFViewerHandle>(null);
   const modelsLoadingRef = useRef(false);
   const modelLoadedRef = useRef(false);
+  const recordingStatusRef = useRef<RecordingStatus>("idle");
+  const deviceMonitorCleanupRef = useRef<(() => void) | null>(null);
+  const recordingDeviceSnapshotRef = useRef<RecordingInputSnapshot | null>(null);
+  const lastDeviceWarningKeyRef = useRef<string | null>(null);
 
   // Sync modelLoaded state to ref
   useEffect(() => {
     modelLoadedRef.current = modelLoaded;
   }, [modelLoaded]);
+
+  useEffect(() => {
+    recordingStatusRef.current = recordingStatus;
+  }, [recordingStatus]);
 
   // Load Lecture Data
   useEffect(() => {
@@ -169,8 +179,61 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
       if (audioRecorderRef.current) {
         audioRecorderRef.current.stop();
       }
+      deviceMonitorCleanupRef.current?.();
+      deviceMonitorCleanupRef.current = null;
     };
   }, [lectureId]);
+
+  const stopRecordingDeviceMonitor = () => {
+    deviceMonitorCleanupRef.current?.();
+    deviceMonitorCleanupRef.current = null;
+    recordingDeviceSnapshotRef.current = null;
+    lastDeviceWarningKeyRef.current = null;
+  };
+
+  const startRecordingDeviceMonitor = async () => {
+    stopRecordingDeviceMonitor();
+    const recorder = audioRecorderRef.current;
+    if (!recorder) return;
+
+    const currentInfo = recorder.getInputDeviceInfo();
+    if (currentInfo?.label) {
+      recordingDeviceSnapshotRef.current = {
+        label: currentInfo.label,
+        sampleRate: currentInfo.sampleRate,
+      };
+    }
+
+    deviceMonitorCleanupRef.current = audioDeviceService.onDeviceChange(() => {
+      window.setTimeout(() => {
+        const activeRecorder = audioRecorderRef.current;
+        if (!activeRecorder || recordingStatusRef.current !== 'recording') return;
+
+        const previous = recordingDeviceSnapshotRef.current;
+        const nextInfo = activeRecorder.getInputDeviceInfo();
+        const next = nextInfo?.label
+          ? {
+            label: nextInfo.label,
+            sampleRate: nextInfo.sampleRate,
+          }
+          : null;
+        const warning = buildDeviceChangeWarning(previous, next);
+        if (!warning || !next) return;
+
+        const warningKey = `${previous?.label ?? 'unknown'}->${next.label}`;
+        if (lastDeviceWarningKeyRef.current === warningKey) return;
+        lastDeviceWarningKeyRef.current = warningKey;
+        recordingDeviceSnapshotRef.current = next;
+
+        toastService.show({
+          message: warning.message,
+          detail: warning.detail,
+          type: 'warning',
+          durationMs: 0,
+        });
+      }, 300);
+    });
+  };
 
   // Load Models
   useEffect(() => {
@@ -876,6 +939,11 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
         return;
       }
 
+      const settings = await storageService.getAppSettings();
+      audioRecorderRef.current.updateConfig({
+        deviceId: settings?.audio?.device_id || '',
+      });
+
       // CRITICAL: Save lecture to DB BEFORE setting lectureId on transcription service
       // This ensures the lecture exists when auto-save tries to save subtitles
       const updatedLecture = { ...currentLectureData, status: 'recording' as const };
@@ -890,7 +958,6 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
       // pre-check whether the LLM fine-refinement queue should be active
       // for this session.
       try {
-        const settings = await storageService.getAppSettings();
         const src = settings?.translation?.source_language || 'auto';
         const tgt = settings?.translation?.target_language || 'zh-TW';
         transcriptionService.setLanguages(src, tgt);
@@ -908,6 +975,7 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
       audioRecorderRef.current.enablePersistence(currentLectureData.id);
 
       await audioRecorderRef.current.start();
+      await startRecordingDeviceMonitor();
       setRecordingStatus("recording");
       setRecordingStartTime(Date.now());
     } catch (error) {
@@ -964,6 +1032,7 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
       }
 
       await audioRecorderRef.current.stop();
+      stopRecordingDeviceMonitor();
       setRecordingStatus("stopped");
       setVolume(0);
 
@@ -1038,6 +1107,7 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
       if (!audioRecorderRef.current) return;
       audioRecorderRef.current.pause();
       transcriptionService.pause();
+      stopRecordingDeviceMonitor();
       setRecordingStatus("paused");
     } catch (error) {
       console.error('Failed to pause recording:', error);
@@ -1048,6 +1118,7 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
     try {
       if (!audioRecorderRef.current) return;
       await audioRecorderRef.current.resume();
+      await startRecordingDeviceMonitor();
       transcriptionService.resume();
       setRecordingStatus("recording");
     } catch (error) {

--- a/ClassNoteAI/src/components/NotesView.tsx
+++ b/ClassNoteAI/src/components/NotesView.tsx
@@ -166,6 +166,49 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
     recordingStatusRef.current = recordingStatus;
   }, [recordingStatus]);
 
+  const flushRecordingSafetyBuffer = async (reason: string) => {
+    const recorder = audioRecorderRef.current;
+    if (!recorder) return;
+    try {
+      await recorder.flushPersistenceNow();
+    } catch (error) {
+      console.warn(`[NotesView] Failed to flush recording safety buffer (${reason}):`, error);
+    }
+  };
+
+  useEffect(() => {
+    const handleVisibilityChange = () => {
+      if (!document.hidden) return;
+      const status = recordingStatusRef.current;
+      if (status !== 'recording' && status !== 'paused') return;
+      void flushRecordingSafetyBuffer('visibilitychange');
+    };
+
+    const handlePageHide = () => {
+      const status = recordingStatusRef.current;
+      if (status !== 'recording' && status !== 'paused') return;
+      void flushRecordingSafetyBuffer('pagehide');
+    };
+
+    const handleBeforeUnload = (event: BeforeUnloadEvent) => {
+      const status = recordingStatusRef.current;
+      if (status !== 'recording' && status !== 'paused') return;
+      void flushRecordingSafetyBuffer('beforeunload');
+      event.preventDefault();
+      event.returnValue = '錄音仍在進行中，現在離開可能導致最後幾秒尚未寫入磁碟。';
+    };
+
+    document.addEventListener('visibilitychange', handleVisibilityChange);
+    window.addEventListener('pagehide', handlePageHide);
+    window.addEventListener('beforeunload', handleBeforeUnload);
+
+    return () => {
+      document.removeEventListener('visibilitychange', handleVisibilityChange);
+      window.removeEventListener('pagehide', handlePageHide);
+      window.removeEventListener('beforeunload', handleBeforeUnload);
+    };
+  }, []);
+
   // Load Lecture Data
   useEffect(() => {
     if (lectureId) {
@@ -1105,6 +1148,7 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
   const handlePauseRecording = () => {
     try {
       if (!audioRecorderRef.current) return;
+      void flushRecordingSafetyBuffer('pause');
       audioRecorderRef.current.pause();
       transcriptionService.pause();
       stopRecordingDeviceMonitor();

--- a/ClassNoteAI/src/components/SettingsView.tsx
+++ b/ClassNoteAI/src/components/SettingsView.tsx
@@ -37,6 +37,7 @@ type TabId =
 const DEFAULT_SETTINGS: AppSettings = {
   server: { url: "http://localhost", port: 8080, enabled: false },
   audio: { sample_rate: 16000, chunk_duration: 2 },
+  recording: {},
   subtitle: {
     font_size: 18,
     font_color: "#FFFFFF",
@@ -179,6 +180,7 @@ export default function SettingsView({}: Props) {
             },
             theme: saved.theme ?? "light",
             models: saved.models,
+            recording: saved.recording,
             translation: saved.translation,
             sync: saved.sync,
           });

--- a/ClassNoteAI/src/components/SetupWizard.tsx
+++ b/ClassNoteAI/src/components/SetupWizard.tsx
@@ -19,6 +19,7 @@ import {
     HardDrive
 } from 'lucide-react';
 import { setupService } from '../services/setupService';
+import { consentService } from '../services/consentService';
 import AIProviderSettings from './AIProviderSettings';
 import {
     SetupStatus,
@@ -40,6 +41,7 @@ type WizardStep =
     | 'language'
     | 'ai-provider'   // v0.5.2: pick GitHub Models vs ChatGPT (or skip)
     | 'ai-config'     // v0.5.2: configure the chosen provider (PAT / OAuth)
+    | 'recording-consent'
     | 'checking'
     | 'review'
     | 'installing'
@@ -67,6 +69,8 @@ export default function SetupWizard({ onComplete }: SetupWizardProps) {
     // into two steps was a review fix — the combined step overflowed the
     // wizard container and the "Continue" button got clipped off-screen.
     const [selectedProviderId, setSelectedProviderId] = useState<string | null>(null);
+    const [consentChecked, setConsentChecked] = useState(false);
+    const [consentError, setConsentError] = useState<string | null>(null);
 
     // Check requirements when entering checking step
     const checkRequirements = useCallback(async () => {
@@ -89,6 +93,17 @@ export default function SetupWizard({ onComplete }: SetupWizardProps) {
             setStep('review');
         }
     }, []);
+
+    const advanceToRecordingConsent = useCallback(async () => {
+        const state = await consentService.getRecordingConsentState();
+        if (state.acknowledged) {
+            await checkRequirements();
+            return;
+        }
+        setConsentChecked(false);
+        setConsentError(null);
+        setStep('recording-consent');
+    }, [checkRequirements]);
 
     // Start installation
     const startInstallation = useCallback(async () => {
@@ -380,7 +395,7 @@ export default function SetupWizard({ onComplete }: SetupWizardProps) {
                             // Skip — still check requirements so the
                             // rest of the wizard runs. User can come
                             // back via Settings → 雲端 AI 助理.
-                            await checkRequirements();
+                            await advanceToRecordingConsent();
                         }}
                     >
                         跳過此步驟 <ArrowRight className="w-4 h-4" />
@@ -435,6 +450,78 @@ export default function SetupWizard({ onComplete }: SetupWizardProps) {
                         // noise (and was also buggy: state was only
                         // polled after click, so a successful config
                         // still showed "先不管、繼續").
+                        await advanceToRecordingConsent();
+                    }}
+                >
+                    繼續 <ArrowRight className="w-5 h-5" />
+                </button>
+            </div>
+        </div>
+    );
+
+    const renderRecordingConsent = () => (
+        <div className="setup-step welcome-step">
+            <div className="setup-icon-container">
+                <div className="setup-icon">
+                    <Mic className="w-16 h-16 text-amber-400" />
+                </div>
+            </div>
+
+            <h2 className="setup-subtitle">錄音與隱私提醒</h2>
+            <p className="setup-description">
+                ClassNoteAI 會把錄音與筆記留在你的電腦上，但<strong>錄音行為本身</strong>仍可能受到
+                老師、同學、校規與所在地法律限制。
+            </p>
+
+            <div className="w-full max-w-lg mx-auto my-4 rounded-xl border border-amber-400/20 bg-amber-500/10 p-4 text-left text-sm text-white/90 space-y-3">
+                <p>開始錄音前，請你自行確認：</p>
+                <ul className="list-disc pl-5 space-y-1 text-white/75">
+                    <li>是否已取得課堂錄音所需的同意</li>
+                    <li>是否符合學校政策、課程規範與當地法律</li>
+                    <li>若內容包含第三人聲音，是否涉及隱私或個資風險</li>
+                </ul>
+                <p className="text-white/65">
+                    我們不會替你判斷合法與否，但會把這個提醒保留下來，之後不再反覆打擾。
+                </p>
+            </div>
+
+            <label className="w-full max-w-lg mx-auto flex items-start gap-3 rounded-lg border border-white/15 bg-white/5 px-4 py-3 text-left cursor-pointer">
+                <input
+                    type="checkbox"
+                    checked={consentChecked}
+                    onChange={(e) => {
+                        setConsentChecked(e.target.checked);
+                        if (e.target.checked) setConsentError(null);
+                    }}
+                    className="mt-1 h-4 w-4 rounded border-white/30 bg-slate-900 text-blue-500"
+                />
+                <span className="text-sm text-white/90">
+                    我了解 ClassNoteAI 只提供本地工具；實際錄音是否合規，仍需由我自行確認並遵守相關規定。
+                </span>
+            </label>
+
+            {consentError && (
+                <div className="setup-error">
+                    <AlertTriangle className="w-5 h-5" />
+                    {consentError}
+                </div>
+            )}
+
+            <div className="setup-actions">
+                <button
+                    className="setup-button secondary"
+                    onClick={() => setStep(selectedProviderId ? 'ai-config' : 'ai-provider')}
+                >
+                    返回
+                </button>
+                <button
+                    className="setup-button primary"
+                    onClick={async () => {
+                        if (!consentChecked) {
+                            setConsentError('請先勾選同意與理解，才能繼續。');
+                            return;
+                        }
+                        await consentService.acknowledgeRecordingConsent();
                         await checkRequirements();
                     }}
                 >
@@ -665,7 +752,7 @@ export default function SetupWizard({ onComplete }: SetupWizardProps) {
                     dot since the user experience is "one thing" (configure
                     an LLM) split across two screens for viewport reasons. */}
                 {(() => {
-                    const visualSteps: WizardStep[] = ['welcome', 'language', 'ai-provider', 'checking', 'review', 'installing', 'complete'];
+                    const visualSteps: WizardStep[] = ['welcome', 'language', 'ai-provider', 'recording-consent', 'checking', 'review', 'installing', 'complete'];
                     const normalisedStep: WizardStep = step === 'ai-config' ? 'ai-provider' : step;
                     const currentIdx = visualSteps.indexOf(normalisedStep);
                     return (
@@ -685,6 +772,7 @@ export default function SetupWizard({ onComplete }: SetupWizardProps) {
                 {step === 'language' && renderLanguage()}
                 {step === 'ai-provider' && renderAIProvider()}
                 {step === 'ai-config' && renderAIConfig()}
+                {step === 'recording-consent' && renderRecordingConsent()}
                 {step === 'checking' && renderChecking()}
                 {step === 'review' && renderReview()}
                 {step === 'installing' && renderInstalling()}

--- a/ClassNoteAI/src/services/__tests__/consentService.test.ts
+++ b/ClassNoteAI/src/services/__tests__/consentService.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it, vi } from 'vitest';
+import { invoke } from '@tauri-apps/api/core';
+import { consentService, CONSENT_REMINDER_VERSION } from '../consentService';
+
+describe('consentService', () => {
+  it('reports not acknowledged when app settings are absent', async () => {
+    const state = await consentService.getRecordingConsentState();
+
+    expect(state).toEqual({
+      acknowledged: false,
+      acknowledgedAt: undefined,
+      version: CONSENT_REMINDER_VERSION,
+    });
+  });
+
+  it('persists acknowledgement into app_settings', async () => {
+    vi.mocked(invoke).mockImplementation((command: string) => {
+      if (command === 'get_setting') return Promise.resolve(null);
+      return Promise.resolve(null);
+    });
+
+    const at = '2026-04-20T20:00:00.000Z';
+    await consentService.acknowledgeRecordingConsent(at);
+
+    const saveCall = vi
+      .mocked(invoke)
+      .mock.calls.find(([command]) => command === 'save_setting');
+
+    expect(saveCall).toBeTruthy();
+    const payload = saveCall?.[1] as { key: string; value: string };
+    expect(payload.key).toBe('app_settings');
+    expect(JSON.parse(payload.value)).toMatchObject({
+      recording: {
+        consentAcknowledgedAt: at,
+        consentReminderVersion: CONSENT_REMINDER_VERSION,
+      },
+    });
+  });
+});

--- a/ClassNoteAI/src/services/__tests__/recordingDeviceMonitor.test.ts
+++ b/ClassNoteAI/src/services/__tests__/recordingDeviceMonitor.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { buildDeviceChangeWarning } from '../recordingDeviceMonitor';
+
+describe('recordingDeviceMonitor', () => {
+  it('returns null when the device label did not change', () => {
+    expect(
+      buildDeviceChangeWarning(
+        { label: 'MacBook Pro 麥克風', sampleRate: 48_000 },
+        { label: 'MacBook Pro 麥克風', sampleRate: 48_000 },
+      ),
+    ).toBeNull();
+  });
+
+  it('warns when the input changed to a bluetooth-style mic', () => {
+    const warning = buildDeviceChangeWarning(
+      { label: 'MacBook Pro 麥克風', sampleRate: 48_000 },
+      { label: 'AirPods Pro', sampleRate: 16_000 },
+    );
+
+    expect(warning).toBeTruthy();
+    expect(warning?.message).toContain('錄音麥克風可能被切換了');
+    expect(warning?.detail).toContain('AirPods Pro');
+    expect(warning?.detail).toContain('16kHz');
+  });
+});

--- a/ClassNoteAI/src/services/__tests__/recordingInterruptionNotice.test.ts
+++ b/ClassNoteAI/src/services/__tests__/recordingInterruptionNotice.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { buildInterruptedRecordingNotice } from '../recordingInterruptionNotice';
+
+describe('recordingInterruptionNotice', () => {
+  it('returns null when there are no interrupted lectures', () => {
+    expect(buildInterruptedRecordingNotice([])).toBeNull();
+  });
+
+  it('builds a readable notice for one interrupted lecture', () => {
+    const notice = buildInterruptedRecordingNotice([
+      { id: 'lec-1', title: '線代第八週', date: '2026-04-20', courseId: 'course-1' },
+    ]);
+
+    expect(notice).toEqual({
+      message: '上次有錄音異常中斷',
+      detail:
+        '「線代第八週」 在 app 異常關閉前沒有成功寫出可恢復音訊。課堂已退出錄音狀態，建議重新開一堂課再錄，以免誤以為這段音訊仍可找回。',
+    });
+  });
+
+  it('summarizes multiple interrupted lectures without listing them all', () => {
+    const notice = buildInterruptedRecordingNotice([
+      { id: 'lec-1', title: 'A', date: '2026-04-20', courseId: 'course-1' },
+      { id: 'lec-2', title: 'B', date: '2026-04-20', courseId: 'course-1' },
+      { id: 'lec-3', title: 'C', date: '2026-04-20', courseId: 'course-1' },
+    ]);
+
+    expect(notice?.detail).toContain('「A」');
+    expect(notice?.detail).toContain('「B」');
+    expect(notice?.detail).toContain('等 3 堂課');
+  });
+});

--- a/ClassNoteAI/src/services/audioRecorder.ts
+++ b/ClassNoteAI/src/services/audioRecorder.ts
@@ -18,6 +18,12 @@ export interface AudioChunk {
   timestamp: number; // 時間戳（毫秒）
 }
 
+export interface AudioInputDeviceInfo {
+  deviceId?: string;
+  label: string;
+  sampleRate?: number;
+}
+
 export type AudioRecorderStatus = 'idle' | 'recording' | 'paused' | 'stopped' | 'error';
 
 export class AudioRecorder {
@@ -667,6 +673,17 @@ export class AudioRecorder {
     };
   }
 
+  getInputDeviceInfo(): AudioInputDeviceInfo | null {
+    const track = this.mediaStream?.getAudioTracks?.()[0];
+    if (!track) return null;
+    const settings = track.getSettings?.() ?? {};
+    return {
+      deviceId: settings.deviceId,
+      label: track.label || '未知輸入裝置',
+      sampleRate: settings.sampleRate,
+    };
+  }
+
   /**
    * 銷毀實例
    */
@@ -687,4 +704,3 @@ export class AudioRecorder {
     console.log('[AudioRecorder] 實例已銷毀');
   }
 }
-

--- a/ClassNoteAI/src/services/audioRecorder.ts
+++ b/ClassNoteAI/src/services/audioRecorder.ts
@@ -349,6 +349,17 @@ export class AudioRecorder {
   }
 
   /**
+   * Best-effort safety flush for "risky" moments such as page hide,
+   * pause, or before-unload. Returns true when persistence is active
+   * and the recorder attempted to drain its pending PCM queue.
+   */
+  public async flushPersistenceNow(): Promise<boolean> {
+    if (!this.persistLectureId || this.persistDisabled) return false;
+    await this.flushPersistPending();
+    return true;
+  }
+
+  /**
    * 設置狀態變化回調
    */
   onStatusChange(callback: (status: AudioRecorderStatus) => void): void {

--- a/ClassNoteAI/src/services/consentService.ts
+++ b/ClassNoteAI/src/services/consentService.ts
@@ -1,0 +1,66 @@
+import type { AppSettings } from '../types';
+import { storageService } from './storageService';
+
+const CONSENT_REMINDER_VERSION = 1;
+
+export interface RecordingConsentState {
+  acknowledged: boolean;
+  acknowledgedAt?: string;
+  version: number;
+}
+
+function mergeSettings(existing: AppSettings | null, patch: AppSettings['recording']): AppSettings {
+  return {
+    server: existing?.server ?? { url: 'http://localhost', port: 8080, enabled: false },
+    audio: existing?.audio ?? { sample_rate: 16000, chunk_duration: 2 },
+    subtitle: existing?.subtitle ?? {
+      font_size: 18,
+      font_color: '#FFFFFF',
+      background_opacity: 0.8,
+      position: 'bottom',
+      display_mode: 'both',
+    },
+    theme: existing?.theme ?? 'light',
+    models: existing?.models,
+    translation: existing?.translation,
+    ollama: existing?.ollama,
+    ocr: existing?.ocr,
+    aiTutor: existing?.aiTutor,
+    lectureLayout: existing?.lectureLayout,
+    sync: existing?.sync,
+    recording: {
+      ...existing?.recording,
+      ...patch,
+    },
+  };
+}
+
+class ConsentService {
+  async getRecordingConsentState(): Promise<RecordingConsentState> {
+    const settings = await storageService.getAppSettings();
+    const version = settings?.recording?.consentReminderVersion ?? 0;
+    const acknowledgedAt = settings?.recording?.consentAcknowledgedAt;
+    return {
+      acknowledged: Boolean(acknowledgedAt) && version >= CONSENT_REMINDER_VERSION,
+      acknowledgedAt: acknowledgedAt ?? undefined,
+      version: CONSENT_REMINDER_VERSION,
+    };
+  }
+
+  async acknowledgeRecordingConsent(at = new Date().toISOString()): Promise<RecordingConsentState> {
+    const existing = await storageService.getAppSettings();
+    const next = mergeSettings(existing, {
+      consentAcknowledgedAt: at,
+      consentReminderVersion: CONSENT_REMINDER_VERSION,
+    });
+    await storageService.saveAppSettings(next);
+    return {
+      acknowledged: true,
+      acknowledgedAt: at,
+      version: CONSENT_REMINDER_VERSION,
+    };
+  }
+}
+
+export const consentService = new ConsentService();
+export { CONSENT_REMINDER_VERSION };

--- a/ClassNoteAI/src/services/recordingDeviceMonitor.ts
+++ b/ClassNoteAI/src/services/recordingDeviceMonitor.ts
@@ -1,0 +1,43 @@
+export interface RecordingInputSnapshot {
+  label: string;
+  sampleRate?: number;
+}
+
+export interface DeviceChangeWarning {
+  message: string;
+  detail: string;
+}
+
+function normalizeLabel(label: string): string {
+  return label.trim().replace(/\s+/g, ' ').toLowerCase();
+}
+
+function isBluetoothLike(label: string): boolean {
+  return /(airpods|bluetooth|headset|hands-free|buds|earbuds|headphones)/i.test(label);
+}
+
+export function buildDeviceChangeWarning(
+  previous: RecordingInputSnapshot | null,
+  current: RecordingInputSnapshot | null,
+): DeviceChangeWarning | null {
+  if (!previous || !current) return null;
+  if (!previous.label || !current.label) return null;
+  if (normalizeLabel(previous.label) === normalizeLabel(current.label)) return null;
+
+  const warnings: string[] = [
+    `輸入裝置已從「${previous.label}」切換成「${current.label}」。`,
+  ];
+
+  if (typeof current.sampleRate === 'number' && current.sampleRate <= 16_000) {
+    warnings.push(`目前取樣率只有 ${Math.round(current.sampleRate / 1000)}kHz，轉錄品質可能明顯下降。`);
+  } else if (isBluetoothLike(current.label)) {
+    warnings.push('藍牙耳機麥克風常會切到低頻寬模式，字幕品質可能變差。');
+  }
+
+  warnings.push('建議確認系統輸入來源是否仍是你原本想用的麥克風。');
+
+  return {
+    message: '錄音麥克風可能被切換了',
+    detail: warnings.join(' '),
+  };
+}

--- a/ClassNoteAI/src/services/recordingInterruptionNotice.ts
+++ b/ClassNoteAI/src/services/recordingInterruptionNotice.ts
@@ -1,0 +1,28 @@
+import type { OrphanedLecture } from './recordingRecoveryService';
+
+export interface RecordingInterruptionNotice {
+  message: string;
+  detail: string;
+}
+
+function formatLectureLabel(lecture: OrphanedLecture): string {
+  const title = lecture.title?.trim() || '未命名課堂';
+  return `「${title}」`;
+}
+
+export function buildInterruptedRecordingNotice(
+  lectures: OrphanedLecture[],
+): RecordingInterruptionNotice | null {
+  if (lectures.length === 0) return null;
+
+  const preview = lectures.slice(0, 2).map(formatLectureLabel).join('、');
+  const remainder = lectures.length - Math.min(lectures.length, 2);
+  const suffix = remainder > 0 ? ` 等 ${lectures.length} 堂課` : '';
+
+  return {
+    message: '上次有錄音異常中斷',
+    detail:
+      `${preview}${suffix} 在 app 異常關閉前沒有成功寫出可恢復音訊。` +
+      '課堂已退出錄音狀態，建議重新開一堂課再錄，以免誤以為這段音訊仍可找回。',
+  };
+}

--- a/ClassNoteAI/src/types/index.ts
+++ b/ClassNoteAI/src/types/index.ts
@@ -92,6 +92,10 @@ export interface AppSettings {
     sample_rate: number;
     chunk_duration: number;
   };
+  recording?: {
+    consentAcknowledgedAt?: string;
+    consentReminderVersion?: number;
+  };
   subtitle: {
     font_size: number;
     font_color: string;
@@ -185,4 +189,3 @@ export interface AppSettings {
 
 // 錄音狀態
 export type RecordingStatus = "idle" | "recording" | "paused" | "stopped";
-


### PR DESCRIPTION
## Summary
- add a one-time recording consent step to the setup wizard and persist the acknowledgement in app settings
- bind the recorder to the user's configured input device before recording starts
- warn during recording when the active input device appears to switch to a different microphone

## Why
- issue #63 asked for a clearer legal/privacy reminder in the onboarding flow
- issue #61 asked for protection against silent microphone switches that can ruin transcript quality

## Validation
- `npm test -- --run src/services/__tests__/consentService.test.ts src/services/__tests__/recordingDeviceMonitor.test.ts src/services/__tests__/toastService.test.ts`
- `npm run build`

## Notes
- the device-change work in this PR is an MVP: it detects and warns, but does not yet auto-revert the input device at the OS level
