### PR TITLE
fix(updater): CUDA asset filename uses '-cuda' not '_cuda'

### DIFF
--- a/ClassNoteAI/src/services/updateService.ts
+++ b/ClassNoteAI/src/services/updateService.ts
@@ -308,7 +308,11 @@ class UpdateService {
 
         let pickedAssetName: string | undefined;
         if (isWindows) {
-            const suffix = buildVariant === 'cuda' ? '_cuda' : '';
+            // Match the SUFFIX produced by release-windows.yml matrix:
+            // CUDA variant adds "-cuda" (hyphen, not underscore), CPU
+            // variant adds nothing. See
+            // .github/workflows/release-windows.yml `matrix.variant`.
+            const suffix = buildVariant === 'cuda' ? '-cuda' : '';
             pickedAssetName = `ClassNoteAI_${stripTagPrefix(release.tag_name)}_x64${suffix}-setup.exe`;
         } else {
             pickedAssetName = `ClassNoteAI_${stripTagPrefix(release.tag_name)}_aarch64.dmg`;


### PR DESCRIPTION
User report from alpha.3 → alpha.4 auto-update on Alpha channel:

> 在 release v0.6.0-alpha.4 找不到對應的安裝檔 (ClassNoteAI_0.6.0-alpha.4_x64_cuda-setup.exe)

Asset name mismatch: my Alpha/Beta channel path in updateService.ts was building Windows CUDA installer names with **underscore**, but `release-windows.yml:54` matrix defines `suffix: "-cuda"` with **hyphen**.

Wrong:  `ClassNoteAI_<ver>_x64_cuda-setup.exe`
Right:  `ClassNoteAI_<ver>_x64-cuda-setup.exe`

One-char fix + a comment pointing back at the workflow so this doesn't drift again.

Users affected: CUDA builds using Alpha / Beta channel. Stable channel (Tauri plugin-updater) is unaffected — it reads `latest.json` manifests which reference the correct names.

Verified:
- `npx tsc --noEmit`: clean
- CPU path + macOS .dmg path both unchanged (empty suffix / .dmg name matched all along)