### PR TITLE
fix(ci): bump sccache-action v0.0.4 → v0.0.9 (fix GHA cache 400)

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -44,7 +44,7 @@ jobs:
       # the first warm-cache build). Metal shader compilation is not
       # cached by sccache (similar to CUDA on Windows).
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.4
+        uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Enable sccache for rustc
         run: |

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -65,7 +65,7 @@ jobs:
       # path. nvcc / CUDA kernel compilation is NOT cached — that still
       # runs full each time.
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.4
+        uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Enable sccache for rustc
         run: |


### PR DESCRIPTION
v0.0.4 is pre-2024; GHA cache API has evolved and it hits HTTP 400 on ghac. Every pr-check-windows run since #29 has been failing silently at cargo check — surfaced when 5 dependabot PRs all showed the same failure.

v0.0.9 (2025-06) uses the current API. Pure version bump, same config.