### PR TITLE
fix(ci): bump pr-check.yml sccache-action v0.0.4 → v0.0.9 (missed in #87)

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -83,7 +83,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Setup sccache
-        uses: mozilla-actions/sccache-action@v0.0.4
+        uses: mozilla-actions/sccache-action@v0.0.9
 
       - name: Enable sccache for rustc
         run: |


### PR DESCRIPTION
Follow-up to #87. I updated release-windows and release-macos yaml but pr-check.yml got missed. This is the last one.

After this, dependabot PR #78-#82's pr-check-windows should go green on re-run.