### PR TITLE
fix(ci): drop --no-default-features from pr-check-windows

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -144,5 +144,10 @@ jobs:
         run: |
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvars64.bat"
           cd src-tauri
-          # --no-default-features skips candle-embed heavy deps; embedding regressions caught at release build (saves ~3-5 min, fixes #29)
-          cargo check --no-default-features --message-format=short
+          # NOTE: --no-default-features removed. It skipped candle-embed but
+          # lib.rs unconditionally calls EmbeddingService::{extract_representative_sentences,
+          # batch_cosine_similarity} at lines 1276/1351/1423 which only exist
+          # under that feature. So the "speedup" was actually breaking every
+          # PR check on Windows. sccache alone keeps most of the win.
+          # Follow-up: feature-gate those call sites, then re-add --no-default-features.
+          cargo check --message-format=short


### PR DESCRIPTION
My own #29 broke every Windows PR check. `--no-default-features` disables `candle-embed` but `lib.rs` unconditionally calls methods that only exist under that feature (E0599 at 1276/1351/1423).

Dropping the flag restores Windows CI. sccache still provides the meaningful speedup (native C++ cache survives Cargo.lock churn). Follow-up: feature-gate the callers and re-enable the flag.