### PR TITLE
chore(release): bump version to 0.6.0-alpha.6

### DIFF
--- a/ClassNoteAI/package.json
+++ b/ClassNoteAI/package.json
@@ -1,7 +1,7 @@
 {
   "name": "classnoteai",
   "private": true,
-  "version": "0.6.0-alpha.5",
+  "version": "0.6.0-alpha.6",
   "type": "module",
   "scripts": {
     "dev": "vite --debug",

--- a/ClassNoteAI/src-tauri/Cargo.lock
+++ b/ClassNoteAI/src-tauri/Cargo.lock
@@ -874,7 +874,7 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "classnoteai"
-version = "0.6.0-alpha.5"
+version = "0.6.0-alpha.6"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/ClassNoteAI/src-tauri/Cargo.toml
+++ b/ClassNoteAI/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "classnoteai"
-version = "0.6.0-alpha.5"
+version = "0.6.0-alpha.6"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/ClassNoteAI/src-tauri/tauri.conf.json
+++ b/ClassNoteAI/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ClassNoteAI",
-  "version": "0.6.0-alpha.5",
+  "version": "0.6.0-alpha.6",
   "identifier": "com.classnoteai",
   "build": {
     "beforeDevCommand": "npm run dev",


### PR DESCRIPTION
Version bump for alpha.6 tag.

Main shipment: Tailwind v4 migration (#89) + the batch of CI fixes (#85/#86/#87/#88/#90) that unbricked every Windows PR check in the process.