### PR TITLE
docs(roadmap): revise course-import plan — sub-agent not Canvas-API-first

### DIFF
--- a/ClassNoteAI/docs/roadmap/v0.6.0-plan.md
+++ b/ClassNoteAI/docs/roadmap/v0.6.0-plan.md
@@ -107,31 +107,54 @@ Nice-to-have (can slip to v0.6.1):
 
 ---
 
-## 1. Canvas API integration + Journal view
+## 1. Course import (sub-agent) + Journal view
 
-**Priority**: high (OSU / most US universities use Canvas).
-**Effort**: 3-5 days.
-**Risk**: low — Canvas has a proper REST API, no scraping needed.
+**Priority**: high (most students hit this daily).
+**Effort**: 1-2 weeks (scoped below).
+**Risk**: medium — depends on how reliable a sub-agent is at traversing arbitrary course sites.
 
-### Why API, not scraping
+### Why NOT a Canvas-API-only path (revised 2026-04-21)
 
-- Canvas publishes https://canvas.instructure.com/doc/api/
-- Token-based auth (user generates personal access token from their
-  Canvas profile settings)
-- Endpoints cover: courses, assignments, announcements, calendar
-  events, files, modules, rubrics
-- Stable, documented, no CAPTCHA / rate-limit traps, no DOM changes
-  to break the scraper
+Earlier plan assumed Canvas API as the happy path. Reality check from the user: **most schools do NOT expose the Canvas API to students** — even institutions that run Canvas internally often restrict API access to admins / instructors, or disable token generation entirely for undergrads. The Canvas API path only helps a small fraction of users.
 
-Scraping is Phase B (v0.7+) for non-Canvas professors who publish
-on their own site — that path uses LLM extraction (paste URL → mini
-model pulls structured data out). Separate from this phase.
+Instead, the course-import feature uses a **lightweight sub-agent** (LLM-driven browser tool — the same Paths / Computer-Use family of APIs that ship with current agent SDKs). The agent:
+
+- Takes a URL the user pastes (course LMS page, professor's syllabus page, Google Classroom, whatever)
+- Navigates the page (possibly behind a login the user has already done in their main browser — Tauri webview can share session)
+- Extracts structured data: assignments, due dates, announcements, readings, lecture schedule
+- Writes the extracted rows to the same `journal_items` / `courses` tables
+
+**Why a sub-agent beats a hand-coded scraper**:
+- No DOM-fragility tax — the agent re-figures out the layout each run. Canvas, Blackboard, Moodle, Sakai, Google Classroom, and professor personal sites all work through the same entry point.
+- Low code surface on our side — we ship one "import course from URL" flow, not N flavor-specific scrapers.
+- Natural language output tuning — the agent can normalize "Problem Set 3" / "PS3" / "HW #3" to a canonical form; a regex scraper can't.
+
+**Trade-offs**:
+- Cost: each import calls an LLM (multiple tool-use rounds). Budget via user's existing ChatGPT / Copilot subscription when possible.
+- Reliability: needs eval harness to catch drift — "did the agent correctly extract 10 assignments from this sample course page?" Should track in an `evals/course-import/` fixture set.
+- Authentication: Tauri webview can be pointed at the user's LMS with their session cookie. The sub-agent runs INSIDE that webview so it inherits login state. Avoids storing user passwords / LMS credentials.
+
+### Canvas API becomes a fast-path, not the only path
+
+For the subset of users whose schools DO provide Canvas API tokens, keep a direct API route as an optional enhancement. Same `journal_items` schema; faster and cheaper than the agent path. Settings → 「課程整合」 offers both entries:
+- 「從網址匯入課程」 (agent path, default) — paste any LMS URL
+- 「Canvas Token (進階)」 — paste token if your school provides it
+
+Both paths populate the same Journal.
+
+### Unified with "non-Canvas scraping" — one feature, not two
+
+Earlier plan split Canvas-API (v0.6.0-beta) from non-Canvas scraping (v0.7+). With the sub-agent approach, **there is no meaningful distinction** — the agent treats every URL the same way. This compresses two roadmap line-items into one milestone.
 
 ### Feature shape
 
-Settings → 「Canvas 整合」:
-- Paste personal access token
-- "Test connection" button → lists available courses
+Settings → 「課程整合」:
+- 「從網址匯入」 input field + 「掃描」 button
+  - Opens a Tauri sub-webview on the URL (inherits main-session cookies)
+  - Sub-agent extracts, previews structured data
+  - User confirms → writes to Journal
+- 「Canvas Token (進階)」 accordion for the API path
+- 「我的課程」 list of imported courses with last-sync timestamps + "重新匯入" button
 
 New top-level nav tab: 「Journal」 (alongside 上課 / 設置):
 - Today / This week / This term views
@@ -145,21 +168,18 @@ New top-level nav tab: 「Journal」 (alongside 上課 / 設置):
 ### Storage
 
 New tables:
-- `canvas_connection` (user_id, token_encrypted, base_url, last_sync)
+- `course_connections` (id, user_id, source_type: 'agent'|'canvas-api',
+  source_url, last_sync, sync_cursor)
 - `journal_items` (id, user_id, course_id, type:
-  assignment/announcement/event, canvas_id, title, body, due_at,
-  status, ...)
+  assignment/announcement/event/reading, source_row_id, title, body,
+  due_at, status, ...)
 
-Soft-linked to existing `courses` table by a `canvas_course_id`
+Soft-linked to existing `courses` table by a `course_connection_id`
 column; the import flow creates or matches existing course rows.
 
-### What the user asked us to align on
+### Evaluation harness
 
-- Which nav structure — I recommend adding 「Journal」 as a third
-  top-level tab (上課 / Journal / 設置). User agreed in the
-  discussion.
-- Non-Canvas sites: user wants this eventually but it's deferred
-  to v0.7+. Canvas-first is the right call.
+`evals/course-import/` fixtures — snapshots of real course pages (user-anonymized) + expected extraction. Run nightly (once we restore an eval workflow, deferred separately). Flag drift when agent extraction diverges from ground truth on > 10% of items.
 
 ---
 
@@ -247,10 +267,10 @@ and works regardless of whether Obsidian is open.
 ```
 v0.5.4  — single-instance fix + themed ConfirmDialog (PR #44)
 v0.6.0-alpha — video import (must-have set above)
-v0.6.0-beta  — Canvas API + Journal tab
+v0.6.0-beta  — Course import (sub-agent + Canvas API) + Journal tab
 v0.6.0       — Obsidian unidirectional export
 v0.6.1       — Sync relay MVP
-v0.7.0       — Non-Canvas scraping, Obsidian bidirectional
+v0.7.0       — Obsidian bidirectional sync (scraping merged into v0.6.0-beta via sub-agent)
 ```
 
 Video import is put first because it's the product's core value


### PR DESCRIPTION
User reality check: most schools don't expose Canvas API to students. Revising v0.6.0 roadmap to use a sub-agent primary path with Canvas API as optional fast-path. Also collapses v0.7+ non-Canvas scraping into v0.6.0-beta since the sub-agent treats every URL the same way.