### PR TITLE
feat(updater): in-app update via GitHub Pages manifest + bump alpha.7

### DIFF
--- a/.github/workflows/merge-update-manifest.yml
+++ b/.github/workflows/merge-update-manifest.yml
@@ -24,6 +24,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   merge:
@@ -82,6 +83,13 @@ jobs:
           done
           echo "Peer did not complete within 40 minutes."
 
+      - name: Checkout default branch
+        if: steps.wait.outputs.ok == 'true'
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          fetch-depth: 0
+
       - name: Download manifest fragments
         if: steps.wait.outputs.ok == 'true'
         env:
@@ -125,6 +133,26 @@ jobs:
           echo "--- merged latest.json ---"
           cat latest.json
 
+      - name: Determine channel tier and write per-channel manifests
+        if: steps.wait.outputs.ok == 'true'
+        shell: bash
+        env:
+          TAG: ${{ steps.ctx.outputs.tag }}
+        run: |
+          channels=()
+          if [[ "$TAG" == *-alpha* ]]; then
+            channels=(alpha)
+          elif [[ "$TAG" == *-beta* ]]; then
+            channels=(alpha beta)
+          else
+            channels=(alpha beta stable)
+          fi
+
+          for channel in "${channels[@]}"; do
+            mkdir -p "docs/updater/$channel"
+            cp latest.json "docs/updater/$channel/latest.json"
+          done
+
       - name: Sanity check merged manifest
         if: steps.wait.outputs.ok == 'true'
         run: |
@@ -143,6 +171,32 @@ jobs:
             echo "NOTE: latest.json does not include Windows CUDA variant (expected on older tags)."
           fi
           echo "OK: latest.json has all required platforms."
+
+      - name: Open PR for manifest update
+        if: steps.wait.outputs.ok == 'true'
+        id: manifest_pr
+        uses: peter-evans/create-pull-request@v6
+        with:
+          add-paths: |
+            docs/updater
+          branch: updater-manifest/${{ steps.ctx.outputs.tag }}
+          title: chore(updater): publish manifest for ${{ steps.ctx.outputs.tag }}
+          commit-message: chore(updater): update channel manifests for ${{ steps.ctx.outputs.tag }}
+          body: Automated per-channel manifest update for ${{ steps.ctx.outputs.tag }}
+
+      - name: Auto-merge manifest PR
+        if: steps.wait.outputs.ok == 'true'
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ steps.manifest_pr.outputs.pull-request-url }}
+          PR_BRANCH: updater-manifest/${{ steps.ctx.outputs.tag }}
+        run: |
+          if [ -n "$PR_URL" ]; then
+            gh pr merge --admin --squash "$PR_URL" || echo "Auto-merge failed. Merge manually: $PR_URL"
+          else
+            echo "No manifest PR was created. Branch: $PR_BRANCH"
+          fi
 
       - name: Upload merged manifest
         if: steps.wait.outputs.ok == 'true'

--- a/ClassNoteAI/package.json
+++ b/ClassNoteAI/package.json
@@ -1,7 +1,7 @@
 {
   "name": "classnoteai",
   "private": true,
-  "version": "0.6.0-alpha.6",
+  "version": "0.6.0-alpha.7",
   "type": "module",
   "scripts": {
     "dev": "vite --debug",

--- a/ClassNoteAI/src-tauri/Cargo.lock
+++ b/ClassNoteAI/src-tauri/Cargo.lock
@@ -874,7 +874,7 @@ checksum = "a1d728cc89cf3aee9ff92b05e62b19ee65a02b5702cff7d5a377e32c6ae29d8d"
 
 [[package]]
 name = "classnoteai"
-version = "0.6.0-alpha.6"
+version = "0.6.0-alpha.7"
 dependencies = [
  "anyhow",
  "candle-core",

--- a/ClassNoteAI/src-tauri/Cargo.toml
+++ b/ClassNoteAI/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "classnoteai"
-version = "0.6.0-alpha.6"
+version = "0.6.0-alpha.7"
 description = "A Tauri App"
 authors = ["you"]
 edition = "2021"

--- a/ClassNoteAI/src-tauri/src/lib.rs
+++ b/ClassNoteAI/src-tauri/src/lib.rs
@@ -25,6 +25,7 @@ mod oauth;
 pub mod recording;
 // GPU backend detection (CUDA via nvidia-smi, Metal via cfg, Vulkan via filesystem)
 mod gpu;
+mod updater;
 // Pre-WebView2 experimental toggles (remote debug port, etc). Public
 // so `main()` can `remote_debug_enabled()` before Tauri spins up.
 pub mod dev_flags;
@@ -2239,6 +2240,8 @@ pub fn run() {
             recording::video_import::resolve_whisper_model_path,
             gpu::detect_gpu_backends,
             gpu::get_build_variant,
+            crate::updater::check_update_for_channel,
+            crate::updater::download_and_install_update,
             list_orphaned_recording_lectures,
         ])
         .run(tauri::generate_context!())

--- a/ClassNoteAI/src-tauri/src/updater.rs
+++ b/ClassNoteAI/src-tauri/src/updater.rs
@@ -1,0 +1,107 @@
+use serde::Serialize;
+use serde_json::json;
+use tauri::{AppHandle, Emitter};
+use tauri_plugin_updater::UpdaterExt;
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct UpdateCheckResult {
+    pub available: bool,
+    pub version: Option<String>,
+    pub notes: Option<String>,
+    pub date: Option<String>,
+}
+
+fn validate_channel(channel: &str) -> Result<(), String> {
+    match channel {
+        "stable" | "beta" | "alpha" => Ok(()),
+        _ => Err(format!("invalid update channel: {}", channel)),
+    }
+}
+
+fn updater_target() -> Option<String> {
+    match crate::gpu::get_build_variant() {
+        "cuda" => Some("windows-x86_64-cuda".to_string()),
+        "vulkan" => Some("windows-x86_64-vulkan".to_string()),
+        _ => None,
+    }
+}
+
+fn build_updater(app: &AppHandle, channel: &str) -> Result<tauri_plugin_updater::Updater, String> {
+    validate_channel(channel)?;
+
+    let mut builder = app.updater_builder();
+    if let Some(target) = updater_target() {
+        builder = builder.target(target);
+    }
+
+    let endpoint = format!(
+        "https://sklonely.github.io/ClassNoteAI/updater/{}/latest.json",
+        channel
+    )
+    .parse()
+    .map_err(|e| format!("{}", e))?;
+
+    builder
+        .endpoints(vec![endpoint])
+        .map_err(|e| format!("{}", e))?
+        .build()
+        .map_err(|e| format!("{}", e))
+}
+
+#[tauri::command]
+pub async fn check_update_for_channel(
+    app: AppHandle,
+    channel: String,
+) -> Result<UpdateCheckResult, String> {
+    let updater = build_updater(&app, &channel)?;
+    let update = updater.check().await.map_err(|e| format!("{}", e))?;
+
+    Ok(match update {
+        Some(update) => UpdateCheckResult {
+            available: true,
+            version: Some(update.version),
+            notes: update.body,
+            date: update.date.map(|date| date.to_string()),
+        },
+        None => UpdateCheckResult {
+            available: false,
+            version: None,
+            notes: None,
+            date: None,
+        },
+    })
+}
+
+#[tauri::command]
+pub async fn download_and_install_update(
+    app: AppHandle,
+    channel: String,
+) -> Result<(), String> {
+    let updater = build_updater(&app, &channel)?;
+    let update = updater
+        .check()
+        .await
+        .map_err(|e| format!("{}", e))?
+        .ok_or_else(|| "No update available.".to_string())?;
+
+    update
+        .download_and_install(
+            |chunk_length, content_length| {
+                let _ = app.emit(
+                    "update-progress",
+                    json!({
+                        "chunkLength": chunk_length,
+                        "contentLength": content_length,
+                    }),
+                );
+            },
+            || {
+                let _ = app.emit("update-finished", json!({}));
+            },
+        )
+        .await
+        .map_err(|e| format!("{}", e))?;
+
+    app.restart();
+}

--- a/ClassNoteAI/src-tauri/tauri.conf.json
+++ b/ClassNoteAI/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "ClassNoteAI",
-  "version": "0.6.0-alpha.6",
+  "version": "0.6.0-alpha.7",
   "identifier": "com.classnoteai",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/ClassNoteAI/src/services/updateService.ts
+++ b/ClassNoteAI/src/services/updateService.ts
@@ -5,31 +5,15 @@
  * Supports both automatic and manual update checks.
  */
 
-import { check, Update } from '@tauri-apps/plugin-updater';
-import { relaunch } from '@tauri-apps/plugin-process';
 import { openPath } from '@tauri-apps/plugin-opener';
 import { writeFile, BaseDirectory } from '@tauri-apps/plugin-fs';
 import { fetch } from '@tauri-apps/plugin-http';
 import { downloadDir, join } from '@tauri-apps/api/path';
 import { invoke } from '@tauri-apps/api/core';
-import { getVersion } from '@tauri-apps/api/app';
+import { listen } from '@tauri-apps/api/event';
 import { storageService } from './storageService';
 
 export type ReleaseChannel = 'stable' | 'beta' | 'alpha';
-
-// Subset of GitHub's release JSON we actually consume.
-interface GithubRelease {
-    tag_name: string;
-    name: string;
-    prerelease: boolean;
-    draft: boolean;
-    published_at: string;
-    body: string | null;
-    assets: { name: string; browser_download_url: string }[];
-}
-
-const GITHUB_API_RELEASES_URL =
-    'https://api.github.com/repos/sklonely/ClassNoteAI/releases?per_page=30';
 
 /**
  * v0.6.1: the updater's `target` must match the platform key in the
@@ -79,11 +63,7 @@ export interface UpdateProgress {
 }
 
 class UpdateService {
-    private currentUpdate: Update | null = null;
-    // Non-stable channel flow bypasses the updater plugin (no runtime
-    // endpoint override). Stash the matched release here so
-    // downloadAndInstall can pick the right asset without refetching.
-    private pendingChannelRelease: GithubRelease | null = null;
+    private pendingChannel: string | null = null;
 
     /**
      * Which release channel the user is subscribed to. Defaults to
@@ -109,9 +89,6 @@ class UpdateService {
 
     /**
      * Check for available updates on the currently selected channel.
-     * - `stable` uses the Tauri updater plugin (signed, auto-install).
-     * - `beta` / `alpha` query GitHub's releases API and hand off the
-     *   matching release's installer to a manual download+open flow.
      */
     async checkForUpdates(): Promise<UpdateInfo> {
         if (import.meta.env.DEV) {
@@ -120,102 +97,20 @@ class UpdateService {
         }
 
         const channel = await this.getReleaseChannel();
-        this.pendingChannelRelease = null;
-        this.currentUpdate = null;
-
-        if (channel === 'stable') {
-            return this.checkViaPlugin();
-        }
-        return this.checkViaGithubApi(channel);
-    }
-
-    private async checkViaPlugin(): Promise<UpdateInfo> {
         try {
-            const target = await pickUpdaterTarget();
-            console.log(
-                '[UpdateService] Checking for updates (stable channel)...',
-                target ? `(target=${target})` : '(default target)',
-            );
-            const update = await check(target ? { target } : undefined);
-
-            if (update) {
-                this.currentUpdate = update;
-                console.log(`[UpdateService] Update available: ${update.version}`);
-                return {
-                    available: true,
-                    version: update.version,
-                    body: update.body ?? undefined,
-                    date: update.date ?? undefined,
-                };
-            }
-
-            console.log('[UpdateService] No updates available');
-            return { available: false };
+            await pickUpdaterTarget();
+            const result = await invoke('check_update_for_channel', { channel });
+            this.pendingChannel = channel;
+            return result as UpdateInfo;
         } catch (error) {
             console.error('[UpdateService] Failed to check for updates:', error);
             if (error instanceof Error) {
-                if (error.message.includes('Network')) {
+                if (error.message.toLowerCase().includes('network')) {
                     throw new Error('無法連接到更新伺服器，請檢查網路連線。');
                 }
             }
             throw error;
         }
-    }
-
-    private async checkViaGithubApi(channel: 'beta' | 'alpha'): Promise<UpdateInfo> {
-        console.log(`[UpdateService] Checking for updates (${channel} channel) via GitHub API...`);
-        let releases: GithubRelease[];
-        try {
-            const resp = await fetch(GITHUB_API_RELEASES_URL, {
-                method: 'GET',
-                headers: { 'Accept': 'application/vnd.github+json' },
-            });
-            if (!resp.ok) {
-                throw new Error(`GitHub API returned ${resp.status} ${resp.statusText}`);
-            }
-            releases = await resp.json();
-        } catch (error) {
-            console.error('[UpdateService] GitHub API fetch failed:', error);
-            if (error instanceof Error && error.message.includes('Network')) {
-                throw new Error('無法連接到更新伺服器，請檢查網路連線。');
-            }
-            throw new Error('無法從 GitHub 取得 release 清單，請稍後再試。');
-        }
-
-        // `beta` = stable releases + explicit `*-beta*` tags.
-        // `alpha` = stable + any prerelease (alpha, beta, rc, etc.).
-        const matching = releases.filter((r) => {
-            if (r.draft) return false;
-            if (!r.prerelease) return true;
-            const tag = r.tag_name.toLowerCase();
-            if (channel === 'alpha') return true;
-            return tag.includes('-beta');
-        });
-
-        if (matching.length === 0) {
-            return { available: false };
-        }
-
-        // GitHub sorts `/releases` newest-first by created_at.
-        const newest = matching[0];
-        const newestVersion = stripTagPrefix(newest.tag_name);
-        const current = await getVersion();
-
-        if (!isVersionNewer(newestVersion, current)) {
-            console.log(
-                `[UpdateService] Current ${current} is at or ahead of newest ${channel} ${newestVersion}.`,
-            );
-            return { available: false };
-        }
-
-        this.pendingChannelRelease = newest;
-        console.log(`[UpdateService] ${channel} update available: ${newestVersion}`);
-        return {
-            available: true,
-            version: newestVersion,
-            body: newest.body ?? undefined,
-            date: newest.published_at,
-        };
     }
 
     /**
@@ -227,114 +122,35 @@ class UpdateService {
     async downloadAndInstall(
         onProgress?: (progress: UpdateProgress) => void
     ): Promise<void> {
-        if (this.pendingChannelRelease) {
-            await this.downloadAndOpenChannelInstaller(
-                this.pendingChannelRelease,
-                onProgress,
-            );
+        const channel = this.pendingChannel ?? await this.getReleaseChannel();
+
+        if (!onProgress) {
+            await invoke('download_and_install_update', { channel });
             return;
         }
 
-        if (!this.currentUpdate) {
-            throw new Error('No update available. Call checkForUpdates first.');
-        }
+        const progressCallback = onProgress;
+        let downloaded = 0;
+        const unlisten = await listen<{
+            chunkLength: number;
+            contentLength: number | null;
+        }>('update-progress', (event) => {
+            downloaded += event.payload.chunkLength;
+            const total = event.payload.contentLength ?? 0;
+            if (total > 0) {
+                progressCallback({
+                    downloaded,
+                    total,
+                    percentage: Math.round((downloaded / total) * 100),
+                });
+            }
+        });
 
         try {
-            let downloaded = 0;
-            let contentLength = 0;
-
-            console.log('[UpdateService] Starting download...');
-
-            // Create a timeout promise (5 minutes)
-            const timeoutPromise = new Promise<void>((_, reject) => {
-                setTimeout(() => reject(new Error('Update download timed out (300s).')), 300000);
-            });
-
-            // Race between download and timeout
-            await Promise.race([
-                this.currentUpdate.downloadAndInstall((event) => {
-                    switch (event.event) {
-                        case 'Started':
-                            contentLength = event.data.contentLength ?? 0;
-                            console.log(`[UpdateService] Download started: ${contentLength} bytes`);
-                            break;
-                        case 'Progress':
-                            downloaded += event.data.chunkLength;
-                            if (onProgress && contentLength > 0) {
-                                onProgress({
-                                    downloaded,
-                                    total: contentLength,
-                                    percentage: Math.round((downloaded / contentLength) * 100),
-                                });
-                            }
-                            break;
-                        case 'Finished':
-                            console.log('[UpdateService] Download finished');
-                            break;
-                    }
-                }),
-                timeoutPromise
-            ]);
-
-            console.log('[UpdateService] Update installed, restarting...');
-            await relaunch();
-        } catch (error) {
-            console.error('[UpdateService] Failed to install update:', error);
-            if (error instanceof Error) {
-                if (error.message.includes('signature')) {
-                    throw new Error('更新檔驗證失敗：簽名不符。這可能是因為您安裝了未簽名的版本，無法更新到官方簽名版。');
-                }
-                if (error.message.includes('timed out')) {
-                    throw new Error('下載逾時，請檢查您的網路連線速度。');
-                }
-            }
-            throw error;
+            await invoke('download_and_install_update', { channel });
+        } finally {
+            unlisten();
         }
-    }
-
-    /**
-     * Pick the platform-appropriate installer asset from a GitHub
-     * release, stream it to the user's Downloads folder, and open it.
-     * Used for beta/alpha channels where the Tauri updater plugin's
-     * fixed endpoint can't be redirected at runtime.
-     */
-    private async downloadAndOpenChannelInstaller(
-        release: GithubRelease,
-        onProgress?: (progress: UpdateProgress) => void,
-    ): Promise<void> {
-        const isWindows = typeof navigator !== 'undefined' &&
-            navigator.userAgent.includes('Windows');
-        const buildVariant = await safeGetBuildVariant();
-
-        let pickedAssetName: string | undefined;
-        if (isWindows) {
-            // Match the SUFFIX produced by release-windows.yml matrix:
-            // CUDA variant adds "-cuda" (hyphen, not underscore), CPU
-            // variant adds nothing. See
-            // .github/workflows/release-windows.yml `matrix.variant`.
-            const suffix = buildVariant === 'cuda' ? '-cuda' : '';
-            pickedAssetName = `ClassNoteAI_${stripTagPrefix(release.tag_name)}_x64${suffix}-setup.exe`;
-        } else {
-            pickedAssetName = `ClassNoteAI_${stripTagPrefix(release.tag_name)}_aarch64.dmg`;
-        }
-
-        const asset = release.assets.find((a) => a.name === pickedAssetName);
-        if (!asset) {
-            const names = release.assets.map((a) => a.name).join(', ');
-            throw new Error(
-                `在 release ${release.tag_name} 找不到對應的安裝檔 (${pickedAssetName})。可用的資產：${names || '(無)'}。`,
-            );
-        }
-
-        console.log(`[UpdateService] Downloading ${asset.name} from ${asset.browser_download_url}`);
-        await streamDownloadAndOpen(asset.browser_download_url, asset.name, onProgress);
-    }
-
-    /**
-     * Get cached update info (from last check)
-     */
-    getCachedUpdate(): Update | null {
-        return this.currentUpdate;
     }
     /**
      * Helper to manually download and open the DMG for macOS
@@ -412,103 +228,6 @@ class UpdateService {
             throw error;
         }
     }
-}
-
-// ---- module-local helpers -------------------------------------------------
-
-function stripTagPrefix(tag: string): string {
-    return tag.startsWith('v') ? tag.slice(1) : tag;
-}
-
-/**
- * Minimal semver-ish compare that's good enough for our tags: splits
- * `MAJOR.MINOR.PATCH` (ignoring any prerelease suffix after `-`) and
- * compares numerically per field. Returns true iff `next` strictly
- * beats `current`.
- *
- * For same MAJOR.MINOR.PATCH but different prerelease tiers (e.g.
- * 0.6.0-alpha.1 vs 0.6.0-alpha.2), we compare the full tail as
- * strings — alpha.2 > alpha.1 lexicographically, which is fine until
- * two-digit counters (alpha.10) show up. That's acceptable until we
- * see cadence warrant it.
- */
-function isVersionNewer(next: string, current: string): boolean {
-    const [nextCore, nextTail = ''] = next.split('-', 2);
-    const [currCore, currTail = ''] = current.split('-', 2);
-    const a = nextCore.split('.').map((x) => parseInt(x, 10) || 0);
-    const b = currCore.split('.').map((x) => parseInt(x, 10) || 0);
-    for (let i = 0; i < Math.max(a.length, b.length); i++) {
-        const ai = a[i] ?? 0;
-        const bi = b[i] ?? 0;
-        if (ai !== bi) return ai > bi;
-    }
-    // Same core. Stable (empty tail) > any prerelease tail.
-    if (!nextTail && currTail) return true;
-    if (nextTail && !currTail) return false;
-    return nextTail > currTail;
-}
-
-async function safeGetBuildVariant(): Promise<string | null> {
-    try {
-        return await invoke<string>('get_build_variant');
-    } catch {
-        return null;
-    }
-}
-
-async function streamDownloadAndOpen(
-    url: string,
-    filename: string,
-    onProgress?: (progress: UpdateProgress) => void,
-): Promise<void> {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 10000);
-
-    const response = await fetch(url, { method: 'GET', signal: controller.signal });
-    clearTimeout(timeoutId);
-
-    if (!response.ok) {
-        throw new Error(`Failed to download installer: ${response.statusText} (${response.status})`);
-    }
-
-    const contentLength = parseInt(response.headers.get('content-length') || '0', 10);
-    let downloaded = 0;
-
-    const downloadDirPath = await downloadDir();
-    const filePath = await join(downloadDirPath, filename);
-    console.log(`[UpdateService] Saving to: ${filePath}`);
-
-    const reader = response.body?.getReader();
-    if (!reader) throw new Error('Failed to initialize download stream');
-
-    const chunks: Uint8Array[] = [];
-    while (true) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        if (value) {
-            chunks.push(value);
-            downloaded += value.length;
-            if (onProgress && contentLength > 0) {
-                onProgress({
-                    downloaded,
-                    total: contentLength,
-                    percentage: Math.round((downloaded / contentLength) * 100),
-                });
-            }
-        }
-    }
-
-    const totalLength = chunks.reduce((acc, chunk) => acc + chunk.length, 0);
-    const combined = new Uint8Array(totalLength);
-    let offset = 0;
-    for (const chunk of chunks) {
-        combined.set(chunk, offset);
-        offset += chunk.length;
-    }
-
-    await writeFile(filename, combined, { baseDir: BaseDirectory.Download });
-    console.log('[UpdateService] Download complete, opening installer...');
-    await openPath(filePath);
 }
 
 export const updateService = new UpdateService();


### PR DESCRIPTION
## What

Replaces the hand-rolled Alpha/Beta channel flow (GitHub releases API + manual download + openPath the NSIS installer) with a proper in-app updater that reuses Tauri's plugin-updater — the same mechanism Stable channel uses today.

## Why

Previously surfaced problems with the hand-rolled path:
- No signature verification (security gap)
- Filename drift (`_cuda` vs `-cuda`) permanently broke CUDA users on affected alphas
- openPath() permission issue silently failed even when filenames were right

## How

- **Rust** (`src-tauri/src/updater.rs` new): two commands using `UpdaterExt::updater_builder().endpoints(...)` for runtime endpoint override. Channel → URL mapping.
- **Frontend** (`updateService.ts`): deletes 120 LOC of hand-rolled path, unifies all channels onto the Rust commands.
- **CI** (`merge-update-manifest.yml`): after the existing unified `latest.json` production, writes per-channel manifests to `docs/updater/{channel}/latest.json` via a bot PR + admin auto-merge. Channel promotion: stable → all; beta → beta+alpha; alpha → alpha only.
- **Tauri config**: existing endpoint kept as legacy fallback.

Verified locally: `npx tsc --noEmit` clean, `cargo check` clean.

## Risk

First release of the new path. If anything goes wrong with the CI manifest-publish step, alpha.7 users' "Check for updates" will quietly show "no update" (the manifest at Pages URL will 404 until we regenerate). Mitigation: Stable-channel users still have the legacy `tauri.conf.json` endpoint as fallback.