### PR TITLE
chore(updater): bootstrap per-channel manifest for alpha (alpha.8)

### DIFF
--- a/docs/updater/alpha/latest.json
+++ b/docs/updater/alpha/latest.json
@@ -1,0 +1,19 @@
+{
+  "version": "0.6.0-alpha.8",
+  "notes": "ClassNoteAI 0.6.0-alpha.8 update (alpha channel)",
+  "pub_date": "2026-04-22T02:14:52Z",
+  "platforms": {
+    "windows-x86_64": {
+      "signature": "",
+      "url": "https://github.com/sklonely/ClassNoteAI/releases/download/v0.6.0-alpha.8/ClassNoteAI_0.6.0-alpha.8_x64-setup.exe"
+    },
+    "windows-x86_64-cuda": {
+      "signature": "",
+      "url": "https://github.com/sklonely/ClassNoteAI/releases/download/v0.6.0-alpha.8/ClassNoteAI_0.6.0-alpha.8_x64-cuda-setup.exe"
+    },
+    "darwin-aarch64": {
+      "signature": "",
+      "url": "https://github.com/sklonely/ClassNoteAI/releases/download/v0.6.0-alpha.8/ClassNoteAI_0.6.0-alpha.8_aarch64.app.tar.gz"
+    }
+  }
+}


### PR DESCRIPTION
Unbricks the alpha-channel auto-updater introduced in alpha.7.

## Why

`merge-update-manifest` workflow had a YAML bug (PR #96) that prevented both the manifest publishing AND the release-draft-to-published promotion. Fix landed in PR #103's `0e441bc` but only helps future releases. alpha.7 + alpha.8 were stuck as draft + had no channel manifests.

## What

- Manually un-drafted alpha.7 and alpha.8 via GitHub API
- Hand-wrote `docs/updater/alpha/latest.json` pointing at alpha.8 platform assets with their real Tauri Ed25519 signatures
- Skipped beta / stable channels (no such releases exist yet)

## Verify

After merge + Pages rebuild (~1 min), `https://sklonely.github.io/ClassNoteAI/updater/alpha/latest.json` should return 200 with the manifest. alpha.7+ users clicking 檢查更新 on the Alpha channel will find alpha.8.