### PR TITLE
Fix audio device lifecycle and microphone permission flow

### DIFF
--- a/ClassNoteAI/src/App.tsx
+++ b/ClassNoteAI/src/App.tsx
@@ -13,6 +13,7 @@ import { storageService } from "./services/storageService";
 import { setupService } from "./services/setupService";
 import { toastService } from "./services/toastService";
 import { buildInterruptedRecordingNotice } from "./services/recordingInterruptionNotice";
+import { audioDeviceService } from "./services/audioDeviceService";
 import { useAuth } from "./contexts/AuthContext";
 
 type AppState = 'loading' | 'setup' | 'ready';
@@ -83,6 +84,25 @@ function App() {
     };
     initTheme();
   }, []);
+
+  // App-level 音訊裝置同步：啟動後先 enumerate，之後靠
+  // focus / visibility / devicechange 自動刷新，避免設定頁成為
+  // 唯一會修復 stale device 狀態的入口。
+  useEffect(() => {
+    if (appState !== 'ready' || !user) return;
+
+    let cancelled = false;
+    void audioDeviceService.initialize().catch((error) => {
+      if (!cancelled) {
+        console.warn('[App] Failed to initialize audio device service:', error);
+      }
+    });
+
+    return () => {
+      cancelled = true;
+      audioDeviceService.destroy();
+    };
+  }, [appState, user]);
 
   // v0.5.2 audit follow-up: surface migration notices to the user.
   // The DB init runs migrations eagerly (e.g. dropping stale embedding

--- a/ClassNoteAI/src/components/NotesView.tsx
+++ b/ClassNoteAI/src/components/NotesView.tsx
@@ -1247,8 +1247,10 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
       }
 
       const settings = await storageService.getAppSettings();
+      const preferredInputDeviceId =
+        await audioDeviceService.preparePreferredInputDeviceForRecording();
       audioRecorderRef.current.updateConfig({
-        deviceId: settings?.audio?.device_id || '',
+        deviceId: preferredInputDeviceId,
       });
 
       // CRITICAL: Save lecture to DB BEFORE setting lectureId on transcription service
@@ -1282,6 +1284,12 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
       audioRecorderRef.current.enablePersistence(currentLectureData.id);
 
       await audioRecorderRef.current.start();
+
+      const resolvedInputDeviceId = audioRecorderRef.current.getDeviceId();
+      if (resolvedInputDeviceId && resolvedInputDeviceId !== preferredInputDeviceId) {
+        await audioDeviceService.setPreferredDevice(resolvedInputDeviceId);
+      }
+
       await startRecordingDeviceMonitor();
       setRecordingStatus("recording");
       setRecordingStartTime(Date.now());

--- a/ClassNoteAI/src/components/SettingsView.tsx
+++ b/ClassNoteAI/src/components/SettingsView.tsx
@@ -19,6 +19,8 @@ import {
   audioDeviceService,
   AudioDevice,
 } from "../services/audioDeviceService";
+import type { MicrophonePermissionState } from "../services/mediaPermissionService";
+import { toastService } from "../services/toastService";
 
 import SettingsLocalTranscription from "./settings/SettingsLocalTranscription";
 import SettingsTranslation from "./settings/SettingsTranslation";
@@ -122,34 +124,43 @@ export default function SettingsView({}: Props) {
   const [audioDevices, setAudioDevices] = useState<AudioDevice[]>([]);
   const [selectedDeviceId, setSelectedDeviceId] = useState<string>("");
   const [isLoadingDevices, setIsLoadingDevices] = useState(false);
+  const [hasMicrophonePermissionDetails, setHasMicrophonePermissionDetails] =
+    useState(false);
+  const [microphonePermissionState, setMicrophonePermissionState] =
+    useState<MicrophonePermissionState>("unknown");
 
   useEffect(() => {
     getVersion().then(setAppVersion).catch(() => setAppVersion("unknown"));
   }, []);
 
   useEffect(() => {
-    let cleanup: (() => void) | undefined;
-    (async () => {
-      setIsLoadingDevices(true);
-      try {
-        const devices = await audioDeviceService.getAudioInputDevices();
-        setAudioDevices(devices);
-        const def = audioDeviceService.getDefaultDeviceId();
-        if (def) setSelectedDeviceId(def);
-      } catch (error) {
-        console.error("加載音頻設備失敗:", error);
-        setAudioDevices([]);
-      } finally {
-        setIsLoadingDevices(false);
-      }
-      try {
-        cleanup = audioDeviceService.onDeviceChange(setAudioDevices);
-      } catch (error) {
-        console.warn("無法監聽設備變化:", error);
-      }
-    })();
+    let mounted = true;
+    const cleanup = audioDeviceService.subscribe((snapshot) => {
+      if (!mounted) return;
+      setAudioDevices(snapshot.devices);
+      setSelectedDeviceId(
+        snapshot.preferredDeviceId || snapshot.defaultDeviceId || "",
+      );
+      setHasMicrophonePermissionDetails(snapshot.hasPermissionDetails);
+      setMicrophonePermissionState(snapshot.permissionState);
+    });
+
+    setIsLoadingDevices(true);
+    void audioDeviceService
+      .initialize()
+      .catch((error) => {
+        if (mounted) {
+          console.error("加載音頻設備失敗:", error);
+          setAudioDevices([]);
+        }
+      })
+      .finally(() => {
+        if (mounted) setIsLoadingDevices(false);
+      });
+
     return () => {
-      cleanup?.();
+      mounted = false;
+      cleanup();
     };
   }, []);
 
@@ -192,9 +203,6 @@ export default function SettingsView({}: Props) {
             recording: saved.recording,
             translation: saved.translation,
           });
-          if (saved.audio?.device_id) {
-            setSelectedDeviceId(saved.audio.device_id);
-          }
         }
       } catch (error) {
         console.error("加載設置失敗:", error);
@@ -205,12 +213,41 @@ export default function SettingsView({}: Props) {
   const handleRefreshDevices = async () => {
     setIsLoadingDevices(true);
     try {
-      setAudioDevices(await audioDeviceService.getAudioInputDevices());
+      await audioDeviceService.getAudioInputDevices();
     } catch (error) {
       console.error("刷新設備列表失敗:", error);
-      setAudioDevices([]);
+      toastService.error("刷新設備列表失敗", error instanceof Error ? error.message : String(error));
     } finally {
       setIsLoadingDevices(false);
+    }
+  };
+
+  const handleRequestMicrophonePermission = async () => {
+    setIsLoadingDevices(true);
+    try {
+      await audioDeviceService.requestMicrophonePermission();
+      toastService.success("麥克風權限已更新");
+    } catch (error) {
+      console.error("請求麥克風權限失敗:", error);
+      toastService.error(
+        "無法取得麥克風權限",
+        error instanceof Error ? error.message : String(error),
+      );
+    } finally {
+      setIsLoadingDevices(false);
+    }
+  };
+
+  const handleDeviceSelectionChange = async (deviceId: string) => {
+    setSelectedDeviceId(deviceId);
+    try {
+      await audioDeviceService.setPreferredDevice(deviceId || undefined);
+    } catch (error) {
+      console.error("保存音訊裝置選擇失敗:", error);
+      toastService.error(
+        "保存音訊裝置失敗",
+        error instanceof Error ? error.message : String(error),
+      );
     }
   };
 
@@ -226,10 +263,6 @@ export default function SettingsView({}: Props) {
       };
       await storageService.saveAppSettings(next);
       document.documentElement.classList.toggle("dark", next.theme === "dark");
-
-      if (selectedDeviceId) {
-        audioDeviceService.setDefaultDevice(selectedDeviceId);
-      }
 
       setSaveStatus("success");
       window.dispatchEvent(new CustomEvent("classnote-settings-changed"));
@@ -279,9 +312,12 @@ export default function SettingsView({}: Props) {
             setSettings={setSettings}
             audioDevices={audioDevices}
             selectedDeviceId={selectedDeviceId}
-            setSelectedDeviceId={setSelectedDeviceId}
+            setSelectedDeviceId={handleDeviceSelectionChange}
             isLoadingDevices={isLoadingDevices}
             onRefreshDevices={handleRefreshDevices}
+            onRequestMicrophonePermission={handleRequestMicrophonePermission}
+            hasMicrophonePermissionDetails={hasMicrophonePermissionDetails}
+            microphonePermissionState={microphonePermissionState}
           />
         );
       case "data-management":

--- a/ClassNoteAI/src/components/settings/SettingsAudioSubtitles.tsx
+++ b/ClassNoteAI/src/components/settings/SettingsAudioSubtitles.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { Mic, Type, RefreshCw, ChevronDown, ChevronRight } from "lucide-react";
 import { AppSettings } from "../../types";
 import { AudioDevice } from "../../services/audioDeviceService";
+import type { MicrophonePermissionState } from "../../services/mediaPermissionService";
 import { Card } from "./shared";
 
 interface Props {
@@ -12,6 +13,9 @@ interface Props {
   setSelectedDeviceId: (id: string) => void;
   isLoadingDevices: boolean;
   onRefreshDevices: () => void;
+  onRequestMicrophonePermission: () => void;
+  hasMicrophonePermissionDetails: boolean;
+  microphonePermissionState: MicrophonePermissionState;
 }
 
 export default function SettingsAudioSubtitles({
@@ -22,6 +26,9 @@ export default function SettingsAudioSubtitles({
   setSelectedDeviceId,
   isLoadingDevices,
   onRefreshDevices,
+  onRequestMicrophonePermission,
+  hasMicrophonePermissionDetails,
+  microphonePermissionState,
 }: Props) {
   const [advancedOpen, setAdvancedOpen] = useState(false);
 
@@ -35,18 +42,37 @@ export default function SettingsAudioSubtitles({
           <div>
             <div className="flex items-center justify-between mb-2">
               <label className="block text-sm font-medium">麥克風設備</label>
-              <button
-                onClick={onRefreshDevices}
-                disabled={isLoadingDevices}
-                className="flex items-center gap-1 text-sm text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 disabled:opacity-50"
-              >
-                <RefreshCw
-                  size={14}
-                  className={isLoadingDevices ? "animate-spin" : ""}
-                />
-                刷新
-              </button>
+              <div className="flex items-center gap-3">
+                <button
+                  onClick={onRequestMicrophonePermission}
+                  disabled={isLoadingDevices}
+                  className="text-sm text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 disabled:opacity-50"
+                >
+                  請求權限
+                </button>
+                <button
+                  onClick={onRefreshDevices}
+                  disabled={isLoadingDevices}
+                  className="flex items-center gap-1 text-sm text-blue-600 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 disabled:opacity-50"
+                >
+                  <RefreshCw
+                    size={14}
+                    className={isLoadingDevices ? "animate-spin" : ""}
+                  />
+                  刷新
+                </button>
+              </div>
             </div>
+            {!hasMicrophonePermissionDetails && (
+              <p className="mb-2 text-xs text-amber-600 dark:text-amber-400">
+                目前尚未取得完整麥克風資訊。請先授權，否則裝置列表可能不完整。
+              </p>
+            )}
+            {microphonePermissionState === "denied" && (
+              <p className="mb-2 text-xs text-red-500">
+                系統目前拒絕麥克風存取，錄音前需要先重新允許權限。
+              </p>
+            )}
             <select
               value={selectedDeviceId}
               onChange={(e) => setSelectedDeviceId(e.target.value)}

--- a/ClassNoteAI/src/services/__tests__/audioDeviceService.test.ts
+++ b/ClassNoteAI/src/services/__tests__/audioDeviceService.test.ts
@@ -1,0 +1,142 @@
+import { beforeEach, afterEach, describe, expect, it, vi } from 'vitest';
+
+import { audioDeviceService } from '../audioDeviceService';
+import { storageService } from '../storageService';
+
+type MockAudioDevice = Pick<
+  MediaDeviceInfo,
+  'deviceId' | 'groupId' | 'kind' | 'label'
+>;
+
+function makeAudioInputDevice(
+  deviceId: string,
+  label: string,
+): MockAudioDevice {
+  return {
+    deviceId,
+    groupId: 'group-1',
+    kind: 'audioinput',
+    label,
+  };
+}
+
+describe('audioDeviceService', () => {
+  const enumerateDevices = vi.fn<() => Promise<MockAudioDevice[]>>();
+  const getUserMedia = vi.fn();
+  const addEventListener = vi.fn();
+  const removeEventListener = vi.fn();
+
+  beforeEach(() => {
+    audioDeviceService.destroy();
+
+    vi.spyOn(storageService, 'getAppSettings').mockResolvedValue(null);
+    vi.spyOn(storageService, 'saveAppSettings').mockResolvedValue();
+
+    Object.defineProperty(globalThis.navigator, 'mediaDevices', {
+      configurable: true,
+      value: {
+        enumerateDevices,
+        getUserMedia,
+        addEventListener,
+        removeEventListener,
+      },
+    });
+
+    enumerateDevices.mockReset();
+    getUserMedia.mockReset();
+    addEventListener.mockReset();
+    removeEventListener.mockReset();
+  });
+
+  afterEach(() => {
+    audioDeviceService.destroy();
+    vi.restoreAllMocks();
+  });
+
+  it('refreshes device list without touching getUserMedia during app init', async () => {
+    enumerateDevices.mockResolvedValue([
+      makeAudioInputDevice('default', ''),
+      makeAudioInputDevice('mic-1', ''),
+    ]);
+
+    await audioDeviceService.initialize();
+
+    expect(enumerateDevices).toHaveBeenCalledTimes(1);
+    expect(getUserMedia).not.toHaveBeenCalled();
+    expect(audioDeviceService.getPreferredDeviceId()).toBe('default');
+    expect(audioDeviceService.hasMicrophonePermissionDetails()).toBe(false);
+  });
+
+  it('requests microphone permission explicitly and stops the temporary stream', async () => {
+    const stop = vi.fn();
+    getUserMedia.mockResolvedValue({
+      getTracks: () => [{ stop }],
+    });
+    enumerateDevices.mockResolvedValue([
+      makeAudioInputDevice('default', 'MacBook Air Microphone'),
+      makeAudioInputDevice('mic-1', 'USB Audio Interface'),
+    ]);
+
+    await audioDeviceService.requestMicrophonePermission();
+
+    expect(getUserMedia).toHaveBeenCalledTimes(1);
+    expect(stop).toHaveBeenCalledTimes(1);
+    expect(audioDeviceService.hasMicrophonePermissionDetails()).toBe(true);
+    expect(audioDeviceService.getPreferredDeviceId()).toBe('default');
+  });
+
+  it('self-heals a stale saved device once a detailed device list confirms it is gone', async () => {
+    vi.spyOn(storageService, 'getAppSettings').mockResolvedValue({
+      server: { url: 'http://localhost', port: 8080, enabled: false },
+      audio: { device_id: 'missing-device', sample_rate: 16000, chunk_duration: 2 },
+      subtitle: {
+        font_size: 18,
+        font_color: '#FFFFFF',
+        background_opacity: 0.8,
+        position: 'bottom',
+        display_mode: 'both',
+      },
+      theme: 'light',
+    });
+    const saveSpy = vi.spyOn(storageService, 'saveAppSettings').mockResolvedValue();
+    enumerateDevices.mockResolvedValue([
+      makeAudioInputDevice('default', 'MacBook Air Microphone'),
+      makeAudioInputDevice('mic-1', 'USB Audio Interface'),
+    ]);
+
+    await audioDeviceService.initialize();
+
+    expect(audioDeviceService.getPreferredDeviceId()).toBe('default');
+    expect(saveSpy).toHaveBeenCalledWith(
+      expect.objectContaining({
+        audio: expect.objectContaining({ device_id: 'default' }),
+      }),
+    );
+  });
+
+  it('does not clear a saved device from an incomplete unlabeled device list', async () => {
+    vi.spyOn(storageService, 'getAppSettings').mockResolvedValue({
+      server: { url: 'http://localhost', port: 8080, enabled: false },
+      audio: { device_id: 'missing-device', sample_rate: 16000, chunk_duration: 2 },
+      subtitle: {
+        font_size: 18,
+        font_color: '#FFFFFF',
+        background_opacity: 0.8,
+        position: 'bottom',
+        display_mode: 'both',
+      },
+      theme: 'light',
+    });
+    const saveSpy = vi.spyOn(storageService, 'saveAppSettings').mockResolvedValue();
+    enumerateDevices.mockResolvedValue([
+      makeAudioInputDevice('default', ''),
+      makeAudioInputDevice('mic-1', ''),
+    ]);
+
+    await audioDeviceService.initialize();
+
+    expect(audioDeviceService.getPreferredDeviceId()).toBe('missing-device');
+    expect(audioDeviceService.hasMicrophonePermissionDetails()).toBe(false);
+    expect(saveSpy).not.toHaveBeenCalled();
+  });
+});

--- a/ClassNoteAI/src/services/audioDeviceService.ts
+++ b/ClassNoteAI/src/services/audioDeviceService.ts
@@ -251,25 +251,30 @@ class AudioDeviceService {
 
       try {
         const allDevices = await navigator.mediaDevices.enumerateDevices();
+        const rawAudioInputs = allDevices.filter(
+          (device) => device.kind === 'audioinput',
+        );
+        // Capture "did this device have a real label" BEFORE we mint any
+        // synthetic fallback. zh-Hant Windows ships real device names like
+        // "麥克風 (Realtek Audio)", which would collide with a
+        // `label.startsWith('麥克風 ')` heuristic against the fallback.
+        const hasAnyRealLabel = rawAudioInputs.some(
+          (device) => !!device.label && device.label.trim() !== '',
+        );
 
-        const audioInputDevices = allDevices
-          .filter((device) => device.kind === 'audioinput')
-          .map((device) => ({
-            deviceId: device.deviceId,
-            label: device.label || `麥克風 ${device.deviceId.substring(0, 8)}`,
-            kind: device.kind as MediaDeviceKind,
-            groupId: device.groupId,
-          }));
+        const audioInputDevices = rawAudioInputs.map((device) => ({
+          deviceId: device.deviceId,
+          label: device.label || `麥克風 ${device.deviceId.substring(0, 8)}`,
+          kind: device.kind as MediaDeviceKind,
+          groupId: device.groupId,
+        }));
 
         this.devices = audioInputDevices;
         this.defaultDeviceId =
           audioInputDevices.find((device) => device.deviceId === 'default')?.deviceId ??
           audioInputDevices[0]?.deviceId ??
           null;
-        this.hasPermissionDetails = audioInputDevices.some(
-          (device) =>
-            Boolean(device.label) && !device.label.startsWith('麥克風 '),
-        );
+        this.hasPermissionDetails = hasAnyRealLabel;
 
         if (!this.preferredDeviceId && this.defaultDeviceId) {
           this.preferredDeviceId = this.defaultDeviceId;

--- a/ClassNoteAI/src/services/audioDeviceService.ts
+++ b/ClassNoteAI/src/services/audioDeviceService.ts
@@ -1,7 +1,17 @@
 /**
  * 音頻設備服務
- * 用於獲取和管理音頻輸入設備
+ *
+ * 這一層負責：
+ * - app-level 裝置列表同步
+ * - 持久化的 device_id 自癒
+ * - 將 enumerate / devicechange / foreground refresh 與權限請求拆開
  */
+
+import { storageService } from './storageService';
+import {
+  mediaPermissionService,
+  type MicrophonePermissionState,
+} from './mediaPermissionService';
 
 export interface AudioDevice {
   deviceId: string;
@@ -10,126 +20,383 @@ export interface AudioDevice {
   groupId?: string;
 }
 
+export interface AudioDeviceSnapshot {
+  devices: AudioDevice[];
+  defaultDeviceId: string | null;
+  preferredDeviceId: string;
+  hasPermissionDetails: boolean;
+  permissionState: MicrophonePermissionState;
+  lastRefreshReason: string | null;
+}
+
+type AudioDeviceSubscriber = (snapshot: AudioDeviceSnapshot) => void;
+
 class AudioDeviceService {
   private devices: AudioDevice[] = [];
   private defaultDeviceId: string | null = null;
+  private preferredDeviceId = '';
+  private hasPermissionDetails = false;
+  private permissionState: MicrophonePermissionState = 'unknown';
+  private lastRefreshReason: string | null = null;
+
+  private subscribers = new Set<AudioDeviceSubscriber>();
+  private listenersAttached = false;
+  private initialized = false;
+  private settingsHydrated = false;
+  private refreshPromise: Promise<AudioDevice[]> | null = null;
+
+  private readonly handleDeviceChange = async () => {
+    await this.refreshAudioInputDevices({ reason: 'devicechange' });
+  };
+
+  private readonly handleWindowFocus = async () => {
+    await this.refreshAudioInputDevices({ reason: 'window-focus' });
+  };
+
+  private readonly handleVisibilityChange = async () => {
+    if (document.visibilityState === 'visible') {
+      await this.refreshAudioInputDevices({ reason: 'visibility-visible' });
+    }
+  };
+
+  async initialize(): Promise<void> {
+    await this.hydratePreferredDevice();
+
+    if (!this.initialized) {
+      this.initialized = true;
+      this.attachGlobalListeners();
+    }
+
+    await this.refreshAudioInputDevices({ reason: 'initialize' });
+  }
+
+  destroy(): void {
+    if (this.listenersAttached) {
+      if (navigator.mediaDevices?.removeEventListener) {
+        navigator.mediaDevices.removeEventListener(
+          'devicechange',
+          this.handleDeviceChange,
+        );
+      }
+
+      window.removeEventListener('focus', this.handleWindowFocus);
+      document.removeEventListener('visibilitychange', this.handleVisibilityChange);
+
+      this.listenersAttached = false;
+    }
+
+    this.initialized = false;
+    this.settingsHydrated = false;
+    this.refreshPromise = null;
+    this.devices = [];
+    this.defaultDeviceId = null;
+    this.preferredDeviceId = '';
+    this.hasPermissionDetails = false;
+    this.permissionState = 'unknown';
+    this.lastRefreshReason = null;
+    this.subscribers.clear();
+  }
+
+  subscribe(callback: AudioDeviceSubscriber): () => void {
+    this.subscribers.add(callback);
+    callback(this.getSnapshot());
+
+    return () => {
+      this.subscribers.delete(callback);
+    };
+  }
+
+  getSnapshot(): AudioDeviceSnapshot {
+    return {
+      devices: [...this.devices],
+      defaultDeviceId: this.defaultDeviceId,
+      preferredDeviceId: this.getPreferredDeviceId(),
+      hasPermissionDetails: this.hasPermissionDetails,
+      permissionState: this.permissionState,
+      lastRefreshReason: this.lastRefreshReason,
+    };
+  }
 
   /**
-   * 獲取所有音頻輸入設備
+   * 與舊 API 相容：純 refresh，不主動觸發權限請求。
    */
   async getAudioInputDevices(): Promise<AudioDevice[]> {
-    try {
-      // 檢查 navigator.mediaDevices 是否可用
-      if (!navigator.mediaDevices || !navigator.mediaDevices.enumerateDevices) {
-        console.warn('[AudioDeviceService] navigator.mediaDevices 不可用，返回空列表');
-        return [];
-      }
-
-      const allDevices = await navigator.mediaDevices.enumerateDevices();
-      
-      // 過濾出音頻輸入設備
-      const audioInputDevices = allDevices
-        .filter(device => device.kind === 'audioinput')
-        .map((device, index) => ({
-          deviceId: device.deviceId,
-          label: device.label || (device.deviceId && device.deviceId !== 'default' && device.deviceId !== 'communications'
-            ? `麥克風 ${device.deviceId.substring(0, 8)}（請在錄音時允許權限）`
-            : index === 0
-              ? '麥克風（請在錄音時允許權限）'
-              : `麥克風 ${index + 1}（請在錄音時允許權限）`),
-          kind: device.kind as MediaDeviceKind,
-          groupId: device.groupId,
-        }));
-
-      this.devices = audioInputDevices;
-      
-      // 設置默認設備（第一個設備）
-      if (audioInputDevices.length > 0 && !this.defaultDeviceId) {
-        this.defaultDeviceId = audioInputDevices[0].deviceId;
-      }
-
-      return audioInputDevices;
-    } catch (error) {
-      console.error('[AudioDeviceService] 獲取音頻設備失敗:', error);
-      // 在 Tauri 環境中，如果無法獲取設備，返回空列表而不是拋出錯誤
-      return [];
-    }
+    return this.refreshAudioInputDevices({ reason: 'manual-refresh' });
   }
 
-  /**
-   * 獲取當前緩存的設備列表
-   */
   getDevices(): AudioDevice[] {
-    return this.devices;
+    return [...this.devices];
   }
 
-  /**
-   * 獲取默認設備 ID
-   */
   getDefaultDeviceId(): string | null {
     return this.defaultDeviceId;
   }
 
-  /**
-   * 設置默認設備
-   */
-  setDefaultDevice(deviceId: string): void {
-    this.defaultDeviceId = deviceId;
+  getPreferredDeviceId(): string {
+    return this.preferredDeviceId || this.defaultDeviceId || '';
   }
 
-  /**
-   * 監聽設備變化
-   */
-  onDeviceChange(callback: (devices: AudioDevice[]) => void): () => void {
-    // 檢查 navigator.mediaDevices 是否可用
-    if (!navigator.mediaDevices || !navigator.mediaDevices.addEventListener) {
-      console.warn('[AudioDeviceService] navigator.mediaDevices 不可用，無法監聽設備變化');
-      // 返回一個空的清理函數
-      return () => {};
+  hasMicrophonePermissionDetails(): boolean {
+    return this.hasPermissionDetails;
+  }
+
+  getPermissionState(): MicrophonePermissionState {
+    return this.permissionState;
+  }
+
+  async setPreferredDevice(
+    deviceId?: string,
+    options: { persist?: boolean; emit?: boolean } = {},
+  ): Promise<void> {
+    const { persist = true, emit = true } = options;
+    await this.hydratePreferredDevice();
+
+    const normalizedDeviceId = deviceId ?? '';
+    if (this.preferredDeviceId === normalizedDeviceId) {
+      return;
     }
 
-    const handleDeviceChange = async () => {
-      const updatedDevices = await this.getAudioInputDevices();
-      callback(updatedDevices);
-    };
+    this.preferredDeviceId = normalizedDeviceId;
 
-    navigator.mediaDevices.addEventListener('devicechange', handleDeviceChange);
+    if (persist) {
+      await this.persistPreferredDeviceId(normalizedDeviceId || undefined);
+    }
 
-    // 返回清理函數
-    return () => {
-      if (navigator.mediaDevices && navigator.mediaDevices.removeEventListener) {
-        navigator.mediaDevices.removeEventListener('devicechange', handleDeviceChange);
+    if (emit) {
+      this.emitSnapshot();
+    }
+  }
+
+  async requestMicrophonePermission(): Promise<AudioDevice[]> {
+    let stream: MediaStream | null = null;
+
+    try {
+      stream = await mediaPermissionService.requestMicrophoneAccess();
+      this.permissionState = 'granted';
+      return await this.refreshAudioInputDevices({ reason: 'permission-request' });
+    } catch (error) {
+      const normalizedError = mediaPermissionService.normalizeMicrophoneError(error);
+      if (
+        error instanceof Error &&
+        (error.name === 'NotAllowedError' || error.name === 'SecurityError')
+      ) {
+        this.permissionState = 'denied';
       }
-    };
+      throw normalizedError;
+    } finally {
+      mediaPermissionService.stopStream(stream);
+    }
+  }
+
+  async preparePreferredInputDeviceForRecording(): Promise<string | undefined> {
+    await this.initialize();
+    await this.refreshAudioInputDevices({ reason: 'before-recording' });
+
+    if (!this.hasPermissionDetails) {
+      await this.requestMicrophonePermission();
+    }
+
+    return this.getPreferredDeviceId() || undefined;
   }
 
   /**
-   * 測試設備是否可用
+   * 與舊 API 相容。現在改為 service-level snapshot 訂閱，而不是
+   * 由設定頁自己綁 navigator.mediaDevices 的 listener。
    */
+  onDeviceChange(callback: (devices: AudioDevice[]) => void): () => void {
+    return this.subscribe((snapshot) => callback(snapshot.devices));
+  }
+
   async testDevice(deviceId: string): Promise<boolean> {
     try {
-      // 檢查 navigator.mediaDevices 是否可用
-      if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
-        console.warn('[AudioDeviceService] navigator.mediaDevices 不可用');
-        return false;
-      }
-
-      const stream = await navigator.mediaDevices.getUserMedia({
-        audio: {
-          deviceId: { exact: deviceId },
-        },
+      const stream = await mediaPermissionService.requestMicrophoneAccess({
+        deviceId: { exact: deviceId },
       });
-      
-      // 清理測試流
-      stream.getTracks().forEach(track => track.stop());
-      
+      mediaPermissionService.stopStream(stream);
       return true;
     } catch (error) {
       console.error(`[AudioDeviceService] 設備 ${deviceId} 測試失敗:`, error);
       return false;
     }
   }
+
+  async refreshAudioInputDevices(options: { reason?: string } = {}): Promise<AudioDevice[]> {
+    if (this.refreshPromise) {
+      return this.refreshPromise;
+    }
+
+    const { reason = 'refresh' } = options;
+
+    this.refreshPromise = (async () => {
+      await this.hydratePreferredDevice();
+
+      const permissionSnapshot =
+        await mediaPermissionService.getMicrophonePermissionState();
+      this.permissionState = permissionSnapshot.state;
+
+      if (
+        !navigator.mediaDevices ||
+        typeof navigator.mediaDevices.enumerateDevices !== 'function'
+      ) {
+        console.warn(
+          '[AudioDeviceService] navigator.mediaDevices.enumerateDevices 不可用，返回空列表',
+        );
+        this.devices = [];
+        this.defaultDeviceId = null;
+        this.hasPermissionDetails = false;
+        this.lastRefreshReason = reason;
+        this.emitSnapshot();
+        return [];
+      }
+
+      try {
+        const allDevices = await navigator.mediaDevices.enumerateDevices();
+
+        const audioInputDevices = allDevices
+          .filter((device) => device.kind === 'audioinput')
+          .map((device) => ({
+            deviceId: device.deviceId,
+            label: device.label || `麥克風 ${device.deviceId.substring(0, 8)}`,
+            kind: device.kind as MediaDeviceKind,
+            groupId: device.groupId,
+          }));
+
+        this.devices = audioInputDevices;
+        this.defaultDeviceId =
+          audioInputDevices.find((device) => device.deviceId === 'default')?.deviceId ??
+          audioInputDevices[0]?.deviceId ??
+          null;
+        this.hasPermissionDetails = audioInputDevices.some(
+          (device) =>
+            Boolean(device.label) && !device.label.startsWith('麥克風 '),
+        );
+
+        if (!this.preferredDeviceId && this.defaultDeviceId) {
+          this.preferredDeviceId = this.defaultDeviceId;
+        }
+
+        await this.reconcilePreferredDevice(audioInputDevices);
+        this.lastRefreshReason = reason;
+        this.emitSnapshot();
+
+        return [...audioInputDevices];
+      } catch (error) {
+        console.error('[AudioDeviceService] 刷新音頻設備列表失敗:', error);
+        this.lastRefreshReason = reason;
+        this.emitSnapshot();
+        return [...this.devices];
+      }
+    })();
+
+    try {
+      return await this.refreshPromise;
+    } finally {
+      this.refreshPromise = null;
+    }
+  }
+
+  private attachGlobalListeners(): void {
+    if (this.listenersAttached) return;
+
+    if (navigator.mediaDevices?.addEventListener) {
+      navigator.mediaDevices.addEventListener(
+        'devicechange',
+        this.handleDeviceChange,
+      );
+    }
+
+    window.addEventListener('focus', this.handleWindowFocus);
+    document.addEventListener('visibilitychange', this.handleVisibilityChange);
+    this.listenersAttached = true;
+  }
+
+  private async hydratePreferredDevice(): Promise<void> {
+    if (this.settingsHydrated) return;
+
+    this.settingsHydrated = true;
+
+    try {
+      const settings = await storageService.getAppSettings();
+      this.preferredDeviceId = settings?.audio?.device_id ?? '';
+    } catch (error) {
+      console.warn(
+        '[AudioDeviceService] Failed to hydrate saved audio device selection:',
+        error,
+      );
+      this.preferredDeviceId = '';
+    }
+  }
+
+  private async reconcilePreferredDevice(devices: AudioDevice[]): Promise<void> {
+    if (!this.preferredDeviceId || devices.length === 0) {
+      return;
+    }
+
+    const preferredStillExists = devices.some(
+      (device) => device.deviceId === this.preferredDeviceId,
+    );
+    if (preferredStillExists) {
+      return;
+    }
+
+    // 沒有 labels 的 enumerate 結果通常不完整，這時不能把使用者
+    // 的持久化選擇誤判為 stale。
+    if (!this.hasPermissionDetails) {
+      console.warn(
+        '[AudioDeviceService] Preferred device missing from an incomplete device list; skip self-heal until labels are available.',
+      );
+      return;
+    }
+
+    const fallbackDeviceId =
+      this.defaultDeviceId ?? devices[0]?.deviceId ?? '';
+
+    console.warn(
+      `[AudioDeviceService] Preferred device ${this.preferredDeviceId} is no longer available; falling back to ${fallbackDeviceId || 'system default'}.`,
+    );
+
+    this.preferredDeviceId = fallbackDeviceId;
+    await this.persistPreferredDeviceId(fallbackDeviceId || undefined);
+  }
+
+  private async persistPreferredDeviceId(deviceId?: string): Promise<void> {
+    try {
+      const settings = await storageService.getAppSettings();
+      if (!settings) {
+        return;
+      }
+
+      const nextDeviceId = deviceId || undefined;
+      if (settings.audio?.device_id === nextDeviceId) {
+        return;
+      }
+
+      await storageService.saveAppSettings({
+        ...settings,
+        audio: {
+          sample_rate: settings.audio?.sample_rate ?? 16000,
+          chunk_duration: settings.audio?.chunk_duration ?? 2,
+          device_id: nextDeviceId,
+        },
+      });
+    } catch (error) {
+      console.warn(
+        '[AudioDeviceService] Failed to persist preferred device selection:',
+        error,
+      );
+    }
+  }
+
+  private emitSnapshot(): void {
+    const snapshot = this.getSnapshot();
+    for (const subscriber of this.subscribers) {
+      try {
+        subscriber(snapshot);
+      } catch (error) {
+        console.warn('[AudioDeviceService] Subscriber threw:', error);
+      }
+    }
+  }
 }
 
 export const audioDeviceService = new AudioDeviceService();
-

--- a/ClassNoteAI/src/services/audioRecorder.ts
+++ b/ClassNoteAI/src/services/audioRecorder.ts
@@ -5,6 +5,7 @@
 
 import { invoke } from '@tauri-apps/api/core';
 import { AudioProcessor } from '../utils/audioProcessor';
+import { mediaPermissionService } from './mediaPermissionService';
 import { toastService } from './toastService';
 
 export interface AudioRecorderConfig {
@@ -82,6 +83,14 @@ export class AudioRecorder {
     this.audioProcessor = new AudioProcessor(16000);
   }
 
+  setDeviceId(deviceId?: string): void {
+    this.config.deviceId = deviceId || '';
+  }
+
+  getDeviceId(): string | undefined {
+    return this.config.deviceId || undefined;
+  }
+
   /**
    * 初始化音頻上下文
    */
@@ -108,100 +117,93 @@ export class AudioRecorder {
    * 請求麥克風權限並獲取音頻流
    */
   private async getMediaStream(): Promise<MediaStream> {
-    const getConstraints = (deviceId?: string): MediaStreamConstraints => ({
-      audio: {
-        deviceId: deviceId ? { exact: deviceId } : undefined,
-        sampleRate: this.config.sampleRate,
-        channelCount: this.config.channelCount,
-        echoCancellation: true, // 回音消除
-        noiseSuppression: true, // 噪音抑制
-        autoGainControl: true, // 自動增益控制
-      },
-    });
+    try {
+      console.log('[AudioRecorder] 請求麥克風權限...');
 
-    const logStreamInfo = (stream: MediaStream) => {
-      console.log('[AudioRecorder] 麥克風權限獲取成功');
-
-      // 獲取實際的音頻軌道信息
-      const audioTracks = stream.getAudioTracks();
-      if (audioTracks.length > 0) {
-        const track = audioTracks[0];
-        const settings = track.getSettings();
-        console.log('[AudioRecorder] 音頻軌道設置:', {
-          deviceId: settings.deviceId,
-          sampleRate: settings.sampleRate,
-          channelCount: settings.channelCount,
-          label: track.label,
-        });
-      }
-    };
-
-    const throwFriendlyError = (error: unknown): never => {
-      if (error instanceof Error) {
-        if (error.name === 'NotAllowedError') {
-          throw new Error('麥克風權限被拒絕，請到系統設定（macOS：系統偏好設定 → 安全性與隱私權 → 麥克風；Windows：設定 → 隱私權 → 麥克風）允許 ClassNote AI 使用麥克風');
-        } else if (error.name === 'NotFoundError') {
-          throw new Error('未找到麥克風設備，請檢查設備連接');
-        } else if (error.name === 'NotReadableError') {
-          throw new Error('麥克風設備無法訪問，可能被其他應用佔用');
-        }
+      if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+        throw new Error('瀏覽器不支持音頻錄製 API (navigator.mediaDevices.getUserMedia)');
       }
 
-      throw error;
-    };
-
-    console.log('[AudioRecorder] 請求麥克風權限...');
-
-    if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
-      throw new Error('瀏覽器不支持音頻錄製 API (navigator.mediaDevices.getUserMedia)');
-    }
-
-    const savedDeviceId = this.config.deviceId;
-    if (savedDeviceId) {
       try {
-        const stream = await navigator.mediaDevices.getUserMedia(getConstraints(savedDeviceId));
-        logStreamInfo(stream);
-        return stream;
+        return await this.requestMediaStream(this.config.deviceId || undefined);
       } catch (error) {
         console.error('[AudioRecorder] 麥克風權限獲取失敗:', error);
 
-        if (error instanceof Error &&
-          (error.name === 'OverconstrainedError' || error.name === 'NotFoundError')) {
-          console.warn('[AudioRecorder] 已儲存的麥克風不可用，改用系統預設麥克風。', error);
+        if (
+          this.config.deviceId &&
+          mediaPermissionService.isRecoverableDeviceSelectionError(error)
+        ) {
+          console.warn(
+            `[AudioRecorder] Saved device ${this.config.deviceId} is unavailable, retrying with system default microphone.`,
+          );
           this.config.deviceId = undefined;
 
-          const fallbackMessage = '原本選擇的麥克風已不可用，已自動切換到系統預設麥克風。';
           if (!this._deviceFallbackWarned) {
             this._deviceFallbackWarned = true;
-            if (typeof toastService?.warning === 'function') {
-              toastService.warning(fallbackMessage);
-            } else {
-              console.warn(fallbackMessage);
-            }
+            toastService.warning('原本選擇的麥克風已不可用，已自動切換到系統預設麥克風。');
           }
 
           try {
-            const stream = await navigator.mediaDevices.getUserMedia(getConstraints());
-            logStreamInfo(stream);
-            return stream;
+            return await this.requestMediaStream(undefined);
           } catch (fallbackError) {
-            console.error('[AudioRecorder] 系統預設麥克風回退失敗:', fallbackError);
-            throw error;
+            console.error(
+              '[AudioRecorder] 系統預設麥克風回退失敗:',
+              fallbackError,
+            );
+            throw mediaPermissionService.normalizeMicrophoneError(fallbackError);
           }
         }
 
-        throw error;
+        throw mediaPermissionService.normalizeMicrophoneError(error);
       }
+    } catch (error) {
+      throw error;
+    }
+  }
+
+  private async requestMediaStream(deviceId?: string): Promise<MediaStream> {
+    const stream = await navigator.mediaDevices.getUserMedia({
+      audio: this.buildAudioConstraints(deviceId),
+    });
+
+    console.log('[AudioRecorder] 麥克風權限獲取成功');
+    this.syncResolvedDeviceId(stream);
+
+    return stream;
+  }
+
+  private buildAudioConstraints(
+    deviceId?: string,
+  ): MediaTrackConstraints {
+    return {
+      deviceId: deviceId ? { exact: deviceId } : undefined,
+      sampleRate: this.config.sampleRate,
+      channelCount: this.config.channelCount,
+      echoCancellation: true,
+      noiseSuppression: true,
+      autoGainControl: true,
+    };
+  }
+
+  private syncResolvedDeviceId(stream: MediaStream): void {
+    const audioTracks = stream.getAudioTracks();
+    if (audioTracks.length === 0) {
+      return;
     }
 
-    try {
-      const stream = await navigator.mediaDevices.getUserMedia(getConstraints());
-      logStreamInfo(stream);
-      return stream;
-    } catch (error) {
-      console.error('[AudioRecorder] 麥克風權限獲取失敗:', error);
-      return throwFriendlyError(error);
+    const track = audioTracks[0];
+    const settings = track.getSettings();
+
+    if (typeof settings.deviceId === 'string' && settings.deviceId.length > 0) {
+      this.config.deviceId = settings.deviceId;
     }
+
+    console.log('[AudioRecorder] 音頻軌道設置:', {
+      deviceId: settings.deviceId,
+      sampleRate: settings.sampleRate,
+      channelCount: settings.channelCount,
+      label: track.label,
+    });
   }
 
   /**

--- a/ClassNoteAI/src/services/audioRecorder.ts
+++ b/ClassNoteAI/src/services/audioRecorder.ts
@@ -117,47 +117,43 @@ export class AudioRecorder {
    * 請求麥克風權限並獲取音頻流
    */
   private async getMediaStream(): Promise<MediaStream> {
+    console.log('[AudioRecorder] 請求麥克風權限...');
+
+    if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
+      throw new Error('瀏覽器不支持音頻錄製 API (navigator.mediaDevices.getUserMedia)');
+    }
+
     try {
-      console.log('[AudioRecorder] 請求麥克風權限...');
+      return await this.requestMediaStream(this.config.deviceId || undefined);
+    } catch (error) {
+      console.error('[AudioRecorder] 麥克風權限獲取失敗:', error);
 
-      if (!navigator.mediaDevices || !navigator.mediaDevices.getUserMedia) {
-        throw new Error('瀏覽器不支持音頻錄製 API (navigator.mediaDevices.getUserMedia)');
-      }
+      if (
+        this.config.deviceId &&
+        mediaPermissionService.isRecoverableDeviceSelectionError(error)
+      ) {
+        console.warn(
+          `[AudioRecorder] Saved device ${this.config.deviceId} is unavailable, retrying with system default microphone.`,
+        );
+        this.config.deviceId = undefined;
 
-      try {
-        return await this.requestMediaStream(this.config.deviceId || undefined);
-      } catch (error) {
-        console.error('[AudioRecorder] 麥克風權限獲取失敗:', error);
-
-        if (
-          this.config.deviceId &&
-          mediaPermissionService.isRecoverableDeviceSelectionError(error)
-        ) {
-          console.warn(
-            `[AudioRecorder] Saved device ${this.config.deviceId} is unavailable, retrying with system default microphone.`,
-          );
-          this.config.deviceId = undefined;
-
-          if (!this._deviceFallbackWarned) {
-            this._deviceFallbackWarned = true;
-            toastService.warning('原本選擇的麥克風已不可用，已自動切換到系統預設麥克風。');
-          }
-
-          try {
-            return await this.requestMediaStream(undefined);
-          } catch (fallbackError) {
-            console.error(
-              '[AudioRecorder] 系統預設麥克風回退失敗:',
-              fallbackError,
-            );
-            throw mediaPermissionService.normalizeMicrophoneError(fallbackError);
-          }
+        if (!this._deviceFallbackWarned) {
+          this._deviceFallbackWarned = true;
+          toastService.warning('原本選擇的麥克風已不可用，已自動切換到系統預設麥克風。');
         }
 
-        throw mediaPermissionService.normalizeMicrophoneError(error);
+        try {
+          return await this.requestMediaStream(undefined);
+        } catch (fallbackError) {
+          console.error(
+            '[AudioRecorder] 系統預設麥克風回退失敗:',
+            fallbackError,
+          );
+          throw mediaPermissionService.normalizeMicrophoneError(fallbackError);
+        }
       }
-    } catch (error) {
-      throw error;
+
+      throw mediaPermissionService.normalizeMicrophoneError(error);
     }
   }
 

--- a/ClassNoteAI/src/services/mediaPermissionService.ts
+++ b/ClassNoteAI/src/services/mediaPermissionService.ts
@@ -1,0 +1,100 @@
+export type MicrophonePermissionState =
+  | 'granted'
+  | 'prompt'
+  | 'denied'
+  | 'unknown'
+  | 'unsupported';
+
+export interface MicrophonePermissionSnapshot {
+  state: MicrophonePermissionState;
+  supported: boolean;
+}
+
+class MediaPermissionService {
+  isMediaDevicesSupported(): boolean {
+    return typeof navigator !== 'undefined' && !!navigator.mediaDevices;
+  }
+
+  isMicrophoneAccessSupported(): boolean {
+    return (
+      this.isMediaDevicesSupported() &&
+      typeof navigator.mediaDevices.getUserMedia === 'function'
+    );
+  }
+
+  async getMicrophonePermissionState(): Promise<MicrophonePermissionSnapshot> {
+    if (!this.isMicrophoneAccessSupported()) {
+      return { state: 'unsupported', supported: false };
+    }
+
+    if (!navigator.permissions?.query) {
+      return { state: 'unknown', supported: true };
+    }
+
+    try {
+      const status = await navigator.permissions.query({
+        name: 'microphone' as PermissionName,
+      });
+
+      if (
+        status.state === 'granted' ||
+        status.state === 'prompt' ||
+        status.state === 'denied'
+      ) {
+        return { state: status.state, supported: true };
+      }
+    } catch (error) {
+      console.warn(
+        '[MediaPermissionService] Failed to query microphone permission state:',
+        error,
+      );
+    }
+
+    return { state: 'unknown', supported: true };
+  }
+
+  async requestMicrophoneAccess(
+    constraints: MediaTrackConstraints = {},
+  ): Promise<MediaStream> {
+    if (!this.isMicrophoneAccessSupported()) {
+      throw new Error('目前環境不支援麥克風存取 API');
+    }
+
+    return navigator.mediaDevices.getUserMedia({ audio: constraints });
+  }
+
+  stopStream(stream: MediaStream | null | undefined): void {
+    stream?.getTracks().forEach((track) => track.stop());
+  }
+
+  isRecoverableDeviceSelectionError(error: unknown): boolean {
+    return (
+      error instanceof Error &&
+      (error.name === 'OverconstrainedError' || error.name === 'NotFoundError')
+    );
+  }
+
+  normalizeMicrophoneError(error: unknown): Error {
+    if (!(error instanceof Error)) {
+      return new Error('麥克風初始化失敗');
+    }
+
+    switch (error.name) {
+      case 'NotAllowedError':
+      case 'SecurityError':
+        return new Error('麥克風權限被拒絕，請在系統設定允許 ClassNote AI 使用麥克風');
+      case 'NotFoundError':
+        return new Error('未找到可用的麥克風設備，請檢查設備連接');
+      case 'NotReadableError':
+        return new Error('麥克風設備無法訪問，可能被其他應用程式佔用');
+      case 'OverconstrainedError':
+        return new Error('先前選取的麥克風已不可用，請改用其他裝置或系統預設麥克風');
+      case 'AbortError':
+        return new Error('麥克風初始化被中斷，請再試一次');
+      default:
+        return error;
+    }
+  }
+}
+
+export const mediaPermissionService = new MediaPermissionService();

--- a/ClassNoteAI/src/services/mediaPermissionService.ts
+++ b/ClassNoteAI/src/services/mediaPermissionService.ts
@@ -82,7 +82,12 @@ class MediaPermissionService {
     switch (error.name) {
       case 'NotAllowedError':
       case 'SecurityError':
-        return new Error('麥克風權限被拒絕，請在系統設定允許 ClassNote AI 使用麥克風');
+        // Keep the OS-specific breadcrumbs — this is a native Tauri app,
+        // not a browser tab, and users who hit this often don't know
+        // where the permission lives. Restored from v0.6.0-alpha.9 #94.
+        return new Error(
+          '麥克風權限被拒絕，請到系統設定（macOS：系統偏好設定 → 安全性與隱私權 → 麥克風；Windows：設定 → 隱私權 → 麥克風）允許 ClassNote AI 使用麥克風',
+        );
       case 'NotFoundError':
         return new Error('未找到可用的麥克風設備，請檢查設備連接');
       case 'NotReadableError':


### PR DESCRIPTION
## Summary
- move audio device discovery to an app-level service with startup, foreground, and devicechange refreshes
- split microphone permission requests into a dedicated service and add stale device self-healing before recording
- update recording/settings flows to use the shared device lifecycle and add regression coverage for stale device recovery

## Testing
- npm test -- --run src/services/__tests__/audioDeviceService.test.ts
- npm run build