### PR TITLE
feat(speech): v0.6.5 plan + Phase 0 stabilization (#67, #71)

### DIFF
--- a/ClassNoteAI/src-tauri/src/translation/ctranslate2.rs
+++ b/ClassNoteAI/src-tauri/src/translation/ctranslate2.rs
@@ -188,8 +188,13 @@ impl CT2Translator {
             patience: 1.0,
             length_penalty: 1.0,
             coverage_penalty: 0.0,
-            repetition_penalty: 1.0,
-            no_repeat_ngram_size: 0,
+            // Phase 0 of speech-pipeline-v0.6.5: M2M100 with no repetition
+            // controls runs into greedy-loop pathology on disfluent input
+            // (filler words, hesitations) — observed `我认为` × 26 in #67.
+            // 1.3 / 4 are conservative defaults; full streaming context window
+            // arrives in Phase 5. See docs/design/speech-pipeline-v0.6.5.md.
+            repetition_penalty: 1.3,
+            no_repeat_ngram_size: 4,
             disable_unk: false,
             suppress_sequences: Vec::new(),
             prefix_bias_beta: 0.0,
@@ -306,7 +311,51 @@ fn clean_translation(raw: &str, target_lang: &str) -> String {
             s = s[i..].trim().to_string();
         }
     }
-    s
+
+    // Step 3: defense-in-depth against M2M100 repetition loops. Even with
+    // decoder-time repetition_penalty + no_repeat_ngram_size set, edge
+    // cases (very short patterns under beam_size=4) can still leak through.
+    // See #67 example 2: `我认为，我认为，... × 26`.
+    collapse_repetitions(&s)
+}
+
+/// If the same short substring (1–4 characters) repeats consecutively
+/// 4+ times, collapse the run to a single occurrence. Conservative on
+/// purpose — only catches the regression-loop pathology, not legitimate
+/// repetition (e.g. "ha ha ha" or "very, very").
+fn collapse_repetitions(s: &str) -> String {
+    let chars: Vec<char> = s.chars().collect();
+    if chars.len() < 8 {
+        return s.to_string();
+    }
+    let mut out = String::with_capacity(s.len());
+    let mut i = 0;
+    while i < chars.len() {
+        let mut collapsed = false;
+        for n in 1..=4usize {
+            if i + n * 4 > chars.len() {
+                continue;
+            }
+            let pat = &chars[i..i + n];
+            let mut k = 1;
+            while i + n * (k + 1) <= chars.len()
+                && &chars[i + n * k..i + n * (k + 1)] == pat
+            {
+                k += 1;
+            }
+            if k >= 4 {
+                out.extend(pat.iter());
+                i += n * k;
+                collapsed = true;
+                break;
+            }
+        }
+        if !collapsed {
+            out.push(chars[i]);
+            i += 1;
+        }
+    }
+    out
 }
 
 /// Map ISO-ish language codes to the M2M100 language token used by
@@ -409,5 +458,33 @@ mod tests {
     fn test_translator_creation() {
         let translator = CT2Translator::new();
         assert!(!translator.is_loaded());
+    }
+
+    #[test]
+    fn collapse_repetitions_handles_observed_67_pathology() {
+        // Real failure mode from #67 example 2: 26× `我认为，` collapse to one.
+        let raw: String = "我认为，".repeat(26);
+        let collapsed = collapse_repetitions(&raw);
+        assert_eq!(collapsed, "我认为，");
+    }
+
+    #[test]
+    fn collapse_repetitions_preserves_normal_text() {
+        let normal = "今天天气真好，我们去散步吧。";
+        assert_eq!(collapse_repetitions(normal), normal);
+    }
+
+    #[test]
+    fn collapse_repetitions_below_threshold_untouched() {
+        // 3 repeats — below the 4× threshold, should NOT collapse.
+        let three = "abcabcabc";
+        assert_eq!(collapse_repetitions(three), three);
+    }
+
+    #[test]
+    fn collapse_repetitions_collapses_mid_string_run() {
+        let mixed = format!("hello {} world", "x".repeat(10));
+        let out = collapse_repetitions(&mixed);
+        assert_eq!(out, "hello x world");
     }
 }

--- a/ClassNoteAI/src/services/__tests__/transcriptionService.test.ts
+++ b/ClassNoteAI/src/services/__tests__/transcriptionService.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   normalizeCommittedText,
   shouldSkipDuplicateCommit,
+  isCommittableSentenceEnd,
 } from '../transcriptionService';
 
 describe('transcriptionService commit dedup', () => {
@@ -67,5 +68,37 @@ describe('transcriptionService commit dedup', () => {
     expect(normalizeCommittedText('')).toBe('');
     expect(normalizeCommittedText('   ')).toBe('');
     expect(normalizeCommittedText('\n\t  \r\n')).toBe('');
+  });
+});
+
+// Phase 0 of speech-pipeline-v0.6.5 (#71). Whisper sometimes emits a
+// trailing period after disfluency tokens; the previous regex treated
+// every "." as a sentence end and the smart-split chopped clauses in
+// half. The helper now refuses to commit at filler endings so the
+// chunker waits for a real sentence boundary.
+describe('isCommittableSentenceEnd — filler-aware sentence end (#71)', () => {
+  it('accepts proper sentence endings', () => {
+    expect(isCommittableSentenceEnd('We will use gradient descent.')).toBe(true);
+    expect(isCommittableSentenceEnd('Why is that?')).toBe(true);
+    expect(isCommittableSentenceEnd('看一下這張圖。')).toBe(true);
+    expect(isCommittableSentenceEnd('真的嗎？')).toBe(true);
+  });
+
+  it('rejects non-terminated text', () => {
+    expect(isCommittableSentenceEnd('this is incomplete')).toBe(false);
+    expect(isCommittableSentenceEnd('上半句沒講完')).toBe(false);
+  });
+
+  it('rejects English filler tails masquerading as sentence ends', () => {
+    expect(isCommittableSentenceEnd('I think, um.')).toBe(false);
+    expect(isCommittableSentenceEnd('and so, you know.')).toBe(false);
+    expect(isCommittableSentenceEnd('uhh.')).toBe(false);
+    expect(isCommittableSentenceEnd('I mean.')).toBe(false);
+    expect(isCommittableSentenceEnd('well.')).toBe(false);
+  });
+
+  it('still accepts substantive content that contains a filler word earlier', () => {
+    // "you know" appearing mid-sentence is fine — only trailing fillers block.
+    expect(isCommittableSentenceEnd('you know what I mean by that.')).toBe(true);
   });
 });

--- a/ClassNoteAI/src/services/transcriptionService.ts
+++ b/ClassNoteAI/src/services/transcriptionService.ts
@@ -38,6 +38,21 @@ export function normalizeCommittedText(text: string): string {
   return text.trim().replace(/\s+/g, ' ');
 }
 
+// Phase 0 of speech-pipeline-v0.6.5 (#71): Whisper occasionally inserts a
+// period after disfluency tokens like "um.", "uh.", "you know.", "I mean."
+// — the punctuation regex alone treats those as sentence ends and triggers
+// a smart-split mid-thought, fragmenting downstream translation context.
+// Conservative list — only obvious fillers; "like." is NOT included
+// because in lectures it can legitimately end a clause.
+const STRONG_PUNCT_END = /[.?!。？！]$/;
+const FILLER_END = /(?:^|[\s,])(?:um+|uh+|you know|i mean|so+|well)[.?!]\s*$/i;
+
+export function isCommittableSentenceEnd(segText: string): boolean {
+  if (!STRONG_PUNCT_END.test(segText)) return false;
+  if (FILLER_END.test(segText)) return false;
+  return true;
+}
+
 export function shouldSkipDuplicateCommit(
   normalizedText: string,
   lastCommitSnapshot: LastCommitSnapshot | null,
@@ -315,14 +330,14 @@ export class TranscriptionService {
 
       if (!hasSpeech) {
         this.silenceCounter++;
-        // v0.5.2: bumped the silence commit threshold from 2 → 3 ticks
-        // (≈ 1.6s → 2.4s) so a speaker taking a natural mid-sentence
-        // breath no longer causes us to cut and commit a half-clause.
-        // User feedback: the rough M2M100 translation quality tracks
-        // segmentation quality; fragmented inputs produce garbage
-        // translations. Letting slightly-longer pauses accumulate
-        // yields complete sentences and much better translations.
-        if (this.silenceCounter > 3 && this.lastPartialText) {
+        // Phase 0 of speech-pipeline-v0.6.5: bumped silence commit
+        // threshold 3 → 4 ticks (≈ +800ms) — #71 reports lecturers
+        // pausing to think mid-sentence still get cut at 2.4s. Phase 4
+        // (smart segmentation) replaces this counter with a multi-signal
+        // decision; this is the bandaid until then.
+        // History: v0.5.2 bumped 2 → 3 for the same reason.
+        // See docs/design/speech-pipeline-v0.6.5.md.
+        if (this.silenceCounter > 4 && this.lastPartialText) {
           this.commitStableText(this.lastPartialText);
           this.lastPartialText = '';
           // 清空緩衝區，準備下一句話
@@ -403,8 +418,8 @@ export class TranscriptionService {
         for (let i = result.segments.length - 1; i >= 0; i--) {
           const seg = result.segments[i];
           const segText = seg.text?.trim() || '';
-          // 如果這個 segment 以句子結束符號結尾
-          if (/[.?!。？！]$/.test(segText)) {
+          // 如果這個 segment 以句子結束符號結尾且不是 filler 收尾
+          if (isCommittableSentenceEnd(segText)) {
             splitIndex = i;
             splitEndMs = seg.end_ms;
             break;

--- a/docs/design/speech-pipeline-v0.6.5.md
+++ b/docs/design/speech-pipeline-v0.6.5.md
@@ -1,0 +1,291 @@
+# Speech Pipeline v0.6.5 — Overhaul Plan
+
+**Status**: Draft (2026-04-22)
+**Scope**: Consolidates issues #67, #71, #74 (epic), #57, #55, #53, #56, #58, #62, #52, #54, #59
+**Owner**: TBD when sprint opens
+
+---
+
+## 1. Background
+
+Three independent failure modes are biting users today:
+
+1. **#71 — Over-aggressive sentence splitting** — punctuation regex + 2.4s silence threshold cuts mid-sentence on natural pauses, fragmenting translation context.
+2. **#67 — Translation collapse** — M2M100 with `repetition_penalty: 1.0` and `no_repeat_ngram_size: 0` produces "我认为×26" loops; cross-chunk context is also lost (no rolling window).
+3. **#74 epic** — owner already noted that fixing these in isolation rebreaks the others; needs coordinated redesign with VAD upgrade (#55), hallucination guards (#53), code-switching (#56), and diarization (#57).
+
+This document captures the unified plan agreed before sprint open.
+
+---
+
+## 2. User scenarios driving the design
+
+ClassNoteAI users are Taiwanese university students recording lectures. The design pivots on these realities:
+
+| Dimension | Distribution | Implication |
+|---|---|---|
+| Hardware | MacBook M-series ~60% / Windows laptop ~40% | Must run on pure CPU; no required discrete GPU |
+| RAM | 8–16 GB common | No unbounded buffers |
+| Mic | Built-in ~70% / AirPods ~25% / external ~5% | Robust to far-field + noise |
+| Lecture lang | Pure-zh / pure-en / **code-switched (most common in EMI)** | Single-language locking breaks 1/3 of users |
+| Length | 50/75 min typical, 3 hr seminar | No leaks; recoverable on crash |
+| Environment | Lecture hall / classroom / online Zoom | Adaptive without explicit calibration UI |
+| Speaker mix | Prof monologue 70% / Q&A 20% / discussion 10% | Multi-speaker must not jumble |
+
+### Failure mode → scenario mapping (drives priority)
+
+| Scenario | Today's failure | Pain | Issue |
+|---|---|---|---|
+| EMI 90-min, built-in mic | "我认为×26" repetition | **immediate uninstall** | #67 |
+| EMI 90-min, built-in mic | "Thank you for watching" hallucination | high | #53 |
+| Any length, 2.5s thinking pause | Sentence cut mid-clause | high (every lecture) | #71 |
+| Code-switched ML/CS | One language correct, other garbled | **every class breaks** | #56 |
+| Q&A / discussion | Student speech mixed into prof transcript | medium | #57 |
+| 3 hr seminar | OOM / slowdown / lag accumulation | medium | #62 |
+| Any length, on crash | **All audio lost** | **catastrophic — trust → 0** | #52 |
+| STEM | Formulas as prose, code as paragraphs | medium (specific cohort) | #59 |
+
+---
+
+## 3. Target architecture: `SpeechPipeline` in Rust
+
+Today: `TranscriptionService.ts` (frontend) makes VAD/chunking decisions, calls Rust for Whisper, then `translationService.ts` calls Rust for M2M100. Decision logic scattered across the IPC boundary makes it untestable and hard to evolve.
+
+Target: a single Rust state machine owns everything from audio frames to committed segments. Frontend subscribes to events and renders.
+
+```
+Audio I/O ─► AudioGate ─► Silero VAD v5 ─► (Optional) LID/Diarize ─► Target Selector
+                                                                          │
+                                                                          ▼
+                                                                  Whisper Decoder
+                                                              (with halluc guards)
+                                                                          │
+                                                                          ▼
+                                                              LocalAgreement-2 Commit
+                                                                          │
+                                                                          ▼
+                                                               Sentence Boundary
+                                                          (logprob+speaker+semantic+len)
+                                                                          │
+                                                                          ▼
+                                                            Glossary Substitution
+                                                                          │
+                                                                          ▼
+                                                          Streaming Translation
+                                                       (M2M100 + 3-seg rolling ctx
+                                                          + repetition guards)
+                                                                          │
+                                                                          ▼
+                                                       Persist (sqlite + WAV chunks)
+                                                                          │
+                                                                          ▼ Tauri events
+Frontend: subscribe-only — LiveCaption / TimelineView / PostLectureView
+```
+
+Key principles:
+- **One state machine, one owner** — all chunking/commit/context decisions in one Rust struct, fully unit-testable, fixture-replayable.
+- **Frontend is a renderer**, not a decision-maker.
+- **Persistence first** — crash recovery is a precondition for trusting any other improvement.
+
+---
+
+## 4. Phased delivery — every phase independently shippable
+
+### Phase 0 — Emergency stabilization (~1 day, 1 PR)
+Issues: #67 (acute), #71 (palliative)
+
+| Change | File | LOC | Effect |
+|---|---|---|---|
+| `repetition_penalty: 1.3`, `no_repeat_ngram_size: 4` | `ctranslate2.rs` | 2 | Kills "我认为×26" at decode time |
+| `collapse_repetitions()` post-process | `ctranslate2.rs` | ~30 | Defense-in-depth net |
+| Silence commit threshold 3 → 4 ticks | `transcriptionService.ts` | 1 | Less mid-sentence cutting on natural pauses |
+| Filler-word-aware sentence end (`um.`, `you know.` not committable) | `transcriptionService.ts` | ~10 | Reduce false sentence boundaries |
+
+**Acceptance**: #67 lossless fixture no longer produces repetition; mid-sentence cuts measurably reduced.
+
+### Phase 1 — Crash recovery foundation (~3 days, 1 PR)
+Issue: #52
+
+Without this, every later improvement risks "user lost their lecture" overshadowing it.
+
+- Streaming WAV append-only write, flush every 10s
+- Append-only transcript JSONL per segment
+- App boot scans for orphan sessions → recovery dialog
+- Battery-aware: < 10% warn, < 5% auto-stop+flush
+
+**Acceptance**: kill -9 mid-recording → restart can recover; 3 hr simulated session has no data loss.
+
+### Phase 2 — Silero VAD v5 (~3 days, 1 PR)
+Issue: #55 — foundation for #71/#53/#56/#57
+
+- Add `ort` crate (ONNX Runtime) bindings
+- Bundle Silero v5 ONNX (~2 MB) in `src-tauri/resources/`
+- Rewrite `vad/mod.rs`, keep `SpeechSegment` API for backward compat
+- Hysteresis (start: N consecutive frames > thr; stop: M frames < thr); 200 ms padding both sides
+- Keep hidden state across chunks — write a fixture test that `process_one_pass(audio)` == `concat(process_chunked(audio))`
+
+v5 is 3× faster (TorchScript) / 10% faster (ONNX) than v4, accuracy 0.96 vs 0.89, model 2 MB vs 1 MB. v5 introduces context passing — must preserve hidden state at chunk boundaries.
+
+**Acceptance**: classroom-noise fixture, false-trigger rate down > 70%.
+
+### Phase 3 — Hallucination guards (~2 days, 1 PR)
+Issue: #53
+
+With cleaner VAD chunks, layer Whisper guards:
+
+- Read `avg_logprob` and `compression_ratio` from segment metadata
+- Drop segment if `avg_logprob < -1.0` OR `compression_ratio > 2.4` (Whisper-recommended)
+- N-gram (n=3..5) detector: ≥3 consecutive repeats → truncate
+- Blacklist: `["thank you for watching", "请订阅", "字幕组", ...]` exact-match drop
+- Silence-suppression: VAD-marked non-speech chunks bypass decode entirely
+
+**Acceptance**: classroom-silence fixture produces no "Thank you for watching".
+
+### Phase 4 — Smart segmentation (~4 days, 1 PR)
+Issue: #71
+
+Replace punctuation regex with multi-signal weighted decision:
+
+```rust
+fn should_commit_at(seg: &Segment, ctx: &Ctx) -> bool {
+    let signals = [
+        seg.ends_with_strong_punct(),
+        seg.confidence > 0.85,
+        seg.word_count >= 5,
+        ctx.silence_after_ms >= 1500,
+        ctx.speaker_changed,            // Phase 8 wire-up
+        ctx.semantic_complete,          // optional LM probe
+    ];
+    signals.iter().filter(|x| **x).count() >= 3
+}
+```
+
+Plus: hold even at sentence boundary while buffer < 70% (gather more context); filler-word endings never committable.
+
+**Acceptance**: #67 fixture, sentence-boundary alignment vs ground truth improves > 50% over baseline.
+
+### Phase 5 — Translation rolling context + LA-2 (~4 days, 1 PR)
+Issues: #58 (core), #67 (structural fix)
+
+The real #67 fix, not the Phase 0 bandaid.
+
+- New `translation/streaming.rs` with 3-segment rolling window: `[prev_prev, prev, current]` → M2M100, output sliced to current
+- LocalAgreement-2 commit: prefix-match between consecutive partials; matched prefix = confirmed (solid caption), tail = provisional (faded caption)
+- Glossary placeholder substitution scaffolding (people/term names → preserve original)
+- Cache key unchanged (per-text); context-augmented translations bypass cache
+
+References: [whisper_streaming](https://github.com/ufal/whisper_streaming) (Macháček 2023, LA-2 reference impl, 3.3 s p95 latency); [WhisperLiveKit LocalAgreement backend](https://deepwiki.com/QuentinFuxa/WhisperLiveKit/3.2-localagreement-backend) (production reference).
+
+**Acceptance**: #67 example-1 scenario (3 sentences → independently translated, 2 lost) produces 3 complete output sentences; caption rewrite-rate p95 < 1 per sentence.
+
+### Phase 6 — Code-switching support (~5 days, 1 PR)
+Issue: #56
+
+- Settings: `course.language_profile` = `{ primary, secondary[], mode: locked|hybrid }`
+- Per-VAD-segment LID (lightweight CPU model, few-ms inference)
+- LID confidence > 0.85 → lock Whisper to that language; otherwise PromptingWhisper dual-token initial prompt
+- Per-course glossary feeds Whisper `initial_prompt` (mind 224-token cap)
+
+References: [PromptingWhisper (arXiv 2311.17382)](https://arxiv.org/abs/2311.17382) for SEAME zh/en CS; [Encoding Refining + Language-Aware Decoding (arXiv 2412.16507)](https://arxiv.org/html/2412.16507v2) as later research direction.
+
+**Acceptance**: "So this is gradient descent，就是梯度下降" both halves correctly recognized.
+
+### Phase 7 — Long-session safety (~3 days, 1 PR)
+Issue: #62 — builds on Phase 1
+
+- WAV chunked file split (one file per 10 min); UI queries to reconstruct timeline
+- Rolling memory: only last 5 min transcript in RAM, older flushed to sqlite
+- Whisper queue backpressure: queue depth > 30s → degrade large-v3 → turbo, tiny corner indicator
+- Auto-stop policies: low battery, overheat, forget-mode (4 hr without user activity)
+
+**Acceptance**: 3 hr continuous recording memory stays flat; force-killed app can recover.
+
+### Phase 8 — Diarization + AudioTrack (multi-PR epic, ~3 weeks)
+Issue: #57 — heaviest piece, defer to its own milestone (v0.7)
+
+- Layer 1: TSE / dominant-cluster (lock professor) → live caption gating
+- Layer 2: full diarization (pyannote 3.1 ONNX or NeMo Sortformer) → background transcript
+- Layer 3: babble + near-field detection → discussion mode
+- AudioTrack schema: `{ speaker_id, confidence, is_target }` per segment
+- Live UI distinguishes professor vs others
+
+**Acceptance**: see #57's 7 sub-criteria.
+
+### Phase 9 — Post-lecture LLM cleanup (~3 days, 1 PR)
+Issue: #59 — batch job, no impact on live path
+
+- Slide OCR injection (user uploads PDF/PPT → extract formulas/vars → inject into Whisper `initial_prompt`)
+- LLM post-processing: spoken formula → LaTeX, code → fenced block, Greek words → symbols
+- Original transcript preserved as source of truth
+
+---
+
+## 5. Tech selections + rejected alternatives
+
+| Pick | Rationale | Rejected option (why) |
+|---|---|---|
+| **Whisper-large-v3** stays | Still strongest open ASR for zh/en code-switching | Parakeet V3 (fast but weak Chinese); Canary (no zh/en CS) |
+| **Silero VAD v5** | 2 MB ONNX, < 1 ms CPU, 6000+ langs, 0.96 vs 0.89 quality | WebRTC VAD (legacy); Cobra (commercial license) |
+| **M2M100** stays (short-term) | Apache, deployed, Phase 0 + Phase 5 changes make it sufficient | NLLB-200 (better quality, **CC-BY-NC blocks commercial — blocker**); MADLAD-400 (evaluate post-Phase 5) |
+| **LocalAgreement-2** for streaming | Simple, proven, `whisper_streaming` 3.3s p95 verified | Wait-k (fixed latency, worse quality); MMA (training complexity) |
+| **pyannote 3.x ONNX** for diarization | Privacy-preserving, mature open-source | NeMo Sortformer (newer, Rust integration immature) |
+| Translation NOT routed to cloud LLM | Privacy, cost, offline-first | Reserve cloud LLM for #59 fine-refinement only |
+
+---
+
+## 6. Acceptance: regression fixture set
+
+Build `evals/speech-pipeline/` from #67 owner-supplied lossless package + new captures:
+
+| Fixture | Content |
+|---|---|
+| `pure-en-lecture-90min.wav` | EMI English monologue |
+| `pure-zh-lecture-50min.wav` | Mandarin lecture |
+| `code-switched-ml.wav` | zh/en mixed ML class |
+| `stem-physics.wav` | Formula-dense |
+| `discussion-3speakers.wav` | Multi-speaker Q&A |
+| `noisy-classroom.wav` | Noise baseline |
+
+Per-fixture metrics:
+- WER (per chunk + overall)
+- Translation chrF / BLEU vs reference
+- Caption rewrite-rate
+- End-to-end p50 / p95 latency (utterance → on-screen)
+- RAM / CPU at 60-min mark
+- Hallucination rate (per minute)
+
+CI runs subset; > 5% regression auto-fails.
+
+---
+
+## 7. Risk register
+
+| Risk | Mitigation |
+|---|---|
+| ONNX Runtime missing on Windows | `ort` crate `download-binaries` feature; static-link |
+| Silero v5 hidden-state corruption at chunk seams | Unit fixture: `one_pass(audio) == concat(chunked(audio))` byte-for-byte tolerance |
+| LA-2 + 3-seg context exceeds 3s latency budget | Budget guard with emergency-path fallback (no context) |
+| pyannote CPU cost on 8 GB Intel laptops | Diarization opt-in; lightweight fallback heuristic |
+| MADLAD-400 quantization missing Metal backend on M-series | Evaluate-only, do not block main path |
+| Multi-Phase PR conflicts | Strict sequential merge; trunk-based short branches per project convention |
+
+---
+
+## 8. Out-of-scope for v0.6.5
+
+- iOS companion (#64)
+- System audio capture for Zoom/Teams/Meet (#60) — separate stream
+- Settings UI redesign (#48) — orthogonal
+- HTTP client unification (#50) — orthogonal infra
+
+---
+
+## 9. References
+
+- [Silero VAD GitHub](https://github.com/snakers4/silero-vad) and [v4 vs v5 quality metrics](https://github.com/snakers4/silero-vad/wiki/Quality-Metrics)
+- [whisper_streaming (LA-2 ref impl, Macháček 2023)](https://github.com/ufal/whisper_streaming) and [paper](https://aclanthology.org/2023.ijcnlp-demo.3.pdf)
+- [WhisperLiveKit LocalAgreement backend](https://deepwiki.com/QuentinFuxa/WhisperLiveKit/3.2-localagreement-backend)
+- [PromptingWhisper for zh/en CS (arXiv 2311.17382)](https://arxiv.org/abs/2311.17382)
+- [Encoding Refining + Language-Aware Decoding for Whisper CS (arXiv 2412.16507)](https://arxiv.org/html/2412.16507v2)
+- [Open-source STT 2026 benchmarks (Northflank)](https://northflank.com/blog/best-open-source-speech-to-text-stt-model-in-2026-benchmarks)
+- [On-device translation models — NLLB licensing trap, MADLAD-400 (Picovoice)](https://picovoice.ai/blog/open-source-translation/)


### PR DESCRIPTION
## Summary

Two things in one PR:

1. **Design doc** at `docs/design/speech-pipeline-v0.6.5.md` — unified plan for the v0.6.5 speech-pipeline overhaul, integrating issues **#74 (epic), #67, #71, #57, #55, #53, #56, #58, #62, #52, #54, #59**. 10 phases, each independently shippable. Captures user scenarios (Taiwan EMI students, MacBook M-series majority, code-switched lectures), target architecture (single Rust `SpeechPipeline` state machine), tech selections + rejected alternatives (Whisper vs Parakeet/Canary; M2M100 short-term vs NLLB licensing trap; Silero v5 vs WebRTC; LA-2 vs Wait-k), regression-fixture acceptance criteria, and risk register. Replaces ad-hoc patching with the coordinated redesign #74 calls for.

2. **Phase 0 (emergency stabilization)** — four small changes that eliminate the worst user-visible failures from #67 and #71 *today*, without waiting for the larger architectural work in later phases.

## Phase 0 changes

| File | Change | Effect |
|---|---|---|
| `ctranslate2.rs:186-217` | M2M100 `repetition_penalty` 1.0 → 1.3, `no_repeat_ngram_size` 0 → 4 | Kills the observed `我认为` × 26 loop in #67 example 2 at decode time |
| `ctranslate2.rs:clean_translation` | `collapse_repetitions()` post-process | Defense-in-depth net — collapses 1–4 char patterns repeated 4+ times. Conservative; does not touch normal text |
| `transcriptionService.ts:325` | Silence commit threshold 3 → 4 ticks | +800 ms tolerance for natural mid-sentence pauses (#71). Phase 4 replaces with multi-signal segmentation |
| `transcriptionService.ts` | New `isCommittableSentenceEnd()` helper | Whisper appends `.` to fillers (`um.`, `you know.`, `i mean.`); these no longer count as sentence ends → less smart-split mid-thought |

## Verification

- **Frontend**: `npx vitest run` → 42 files / 343 tests pass (4 new helper tests for `isCommittableSentenceEnd`)
- **Rust**: `cargo test translation::ctranslate2::tests::` → 5 pass (4 new `collapse_repetitions` tests, **including the literal #67 `我认为` × 26 fixture**)

## Out of scope for Phase 0 (deferred per the plan)

| Phase | Issue | When |
|---|---|---|
| 1 | #52 Crash recovery | next PR |
| 2 | #55 Silero VAD v5 | after Phase 1 |
| 3 | #53 Hallucination guards | after Phase 2 |
| 4 | #71 Smart segmentation (multi-signal) | after Phase 3 |
| 5 | #58 / #67 Translation rolling context + LA-2 | after Phase 4 |
| 6 | #56 Code-switching support | after Phase 5 |
| 7 | #62 Long-session safety | after Phase 6 |
| 8 | #57 Diarization | defer to v0.7 |
| 9 | #59 LLM post-cleanup | parallel-safe |

## Test plan

- [ ] CI `pr-check-macos` + `pr-check-windows` pass
- [ ] CodeQL static analysis pass
- [ ] Manually replay #67 lossless audio package → verify `我认为` repetition gone, sentence boundaries less aggressive

🤖 Generated with [Claude Code](https://claude.com/claude-code)