### PR TITLE
feat(recording): Phase 1 — transcript JSONL + battery guard (#52)

### DIFF
--- a/ClassNoteAI/src-tauri/src/lib.rs
+++ b/ClassNoteAI/src-tauri/src/lib.rs
@@ -2199,6 +2199,10 @@ pub fn run() {
             recording::finalize_recording,
             recording::find_orphaned_recordings,
             recording::discard_orphaned_recording,
+            // Phase 1 of speech-pipeline-v0.6.5 (#52): transcript JSONL sidecar
+            recording::append_transcript_segment,
+            recording::read_orphaned_transcript,
+            recording::discard_orphaned_transcript,
             recording::video_import::import_video_for_lecture,
             recording::video_import::extract_pcm_from_video,
             recording::video_import::transcribe_video_file,

--- a/ClassNoteAI/src-tauri/src/recording/mod.rs
+++ b/ClassNoteAI/src-tauri/src/recording/mod.rs
@@ -76,6 +76,35 @@ pub struct OrphanedRecording {
     pub sample_rate: u32,
     pub channels: u16,
     pub started_at: Option<String>,
+    /// Number of transcript segments persisted to the sidecar JSONL
+    /// while recording. 0 means no transcript was captured (older builds,
+    /// or a crash before the first segment committed).
+    #[serde(default)]
+    pub transcript_segments: u64,
+}
+
+/// One transcript segment as it lived in the frontend's pending queue.
+/// JSONL = one of these per line, append-only, written by the renderer
+/// every time `commitStableText` lands a stable rough/fine pass. On
+/// recovery we parse the file into this shape and let the frontend
+/// insert any rows that never made it to sqlite (the periodic
+/// `savePendingSubtitles` flush is every 10s, so a crash in the
+/// 9.999s gap loses everything in between without this sidecar).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PersistedTranscriptSegment {
+    pub id: String,
+    /// Seconds from epoch (matches `pending_subtitles.timestamp` shape
+    /// in the frontend; sqlite expects f64 seconds, so we keep it as-is).
+    pub timestamp: f64,
+    pub text_en: String,
+    #[serde(default)]
+    pub text_zh: Option<String>,
+    /// `"rough"` for the streaming pass; `"fine"` for the LLM-refined
+    /// follow-up that overwrites it. Only `"rough"` lines are required
+    /// for recovery; `"fine"` is best-effort (the refinement queue is
+    /// allowed to drop on crash without data loss).
+    #[serde(rename = "type")]
+    pub kind: String,
 }
 
 /// Validates a lecture_id is a plain UUID-ish identifier with no
@@ -113,6 +142,10 @@ fn pcm_path(in_progress_dir: &Path, lecture_id: &str) -> PathBuf {
 
 fn meta_path(in_progress_dir: &Path, lecture_id: &str) -> PathBuf {
     in_progress_dir.join(format!("{}.meta.json", lecture_id))
+}
+
+fn transcript_path(in_progress_dir: &Path, lecture_id: &str) -> PathBuf {
+    in_progress_dir.join(format!("{}.transcript.jsonl", lecture_id))
 }
 
 fn read_meta_or_default(in_progress_dir: &Path, lecture_id: &str) -> RecordingMeta {
@@ -163,6 +196,96 @@ pub fn append_pcm_chunk_inner(
     }
 
     Ok(fs::metadata(&p).map(|m| m.len()).unwrap_or(0))
+}
+
+/// Append a single transcript segment to the lecture's JSONL sidecar.
+/// One write per line — append-only, atomic enough that a partially-
+/// written final line is just dropped by `read_transcript_segments_inner`'s
+/// per-line parse. We never rewrite the file, so a crash mid-line at
+/// most loses the in-flight segment, never anything previously committed.
+pub fn append_transcript_segment_inner(
+    in_progress_dir: &Path,
+    lecture_id: &str,
+    segment: &PersistedTranscriptSegment,
+) -> std::io::Result<u64> {
+    let lecture_id = validate_lecture_id(lecture_id)?;
+    fs::create_dir_all(in_progress_dir)?;
+    let p = transcript_path(in_progress_dir, lecture_id);
+
+    let mut line = serde_json::to_string(segment)
+        .map_err(|e| std::io::Error::new(std::io::ErrorKind::InvalidData, e.to_string()))?;
+    line.push('\n');
+
+    let mut f = OpenOptions::new().create(true).append(true).open(&p)?;
+    f.write_all(line.as_bytes())?;
+    f.flush()?;
+
+    Ok(fs::metadata(&p).map(|m| m.len()).unwrap_or(0))
+}
+
+/// Read every well-formed JSON line out of the transcript sidecar.
+/// Any line that fails to parse is logged-and-skipped — recovery is
+/// best-effort by design, and a single corrupted final line should
+/// never block restoration of everything that came before it.
+pub fn read_transcript_segments_inner(
+    in_progress_dir: &Path,
+    lecture_id: &str,
+) -> std::io::Result<Vec<PersistedTranscriptSegment>> {
+    let lecture_id = validate_lecture_id(lecture_id)?;
+    let p = transcript_path(in_progress_dir, lecture_id);
+    if !p.exists() {
+        return Ok(vec![]);
+    }
+    let raw = fs::read_to_string(&p)?;
+    let mut out = Vec::new();
+    for (idx, line) in raw.lines().enumerate() {
+        let trimmed = line.trim();
+        if trimmed.is_empty() {
+            continue;
+        }
+        match serde_json::from_str::<PersistedTranscriptSegment>(trimmed) {
+            Ok(seg) => out.push(seg),
+            Err(e) => {
+                eprintln!(
+                    "[recording] transcript JSONL line {} for {} unparseable, skipping: {}",
+                    idx + 1,
+                    lecture_id,
+                    e
+                );
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Count parseable lines without materialising the full segment list.
+/// Used by `find_orphaned_recordings_inner` so the recovery UI can
+/// show "+N transcript segments" alongside the audio duration without
+/// pulling potentially-thousands of segments into a Tauri payload
+/// every app boot.
+fn count_transcript_segments(in_progress_dir: &Path, lecture_id: &str) -> u64 {
+    let p = transcript_path(in_progress_dir, lecture_id);
+    let Ok(raw) = fs::read_to_string(&p) else {
+        return 0;
+    };
+    raw.lines()
+        .filter(|l| {
+            let t = l.trim();
+            !t.is_empty() && serde_json::from_str::<serde_json::Value>(t).is_ok()
+        })
+        .count() as u64
+}
+
+/// Delete the transcript JSONL for a lecture. Called by `discard_*`
+/// (user chose to throw the recording away) and after recovery has
+/// successfully migrated segments into sqlite.
+pub fn discard_transcript_segments_inner(
+    in_progress_dir: &Path,
+    lecture_id: &str,
+) -> std::io::Result<()> {
+    let lecture_id = validate_lecture_id(lecture_id)?;
+    let _ = fs::remove_file(transcript_path(in_progress_dir, lecture_id));
+    Ok(())
 }
 
 /// Build a WAV byte stream from raw i16-LE PCM.
@@ -216,6 +339,9 @@ pub fn finalize_recording_inner(
 
     // Clean up the scratch files. Best-effort — the finalized WAV is
     // already safely on disk, so partial cleanup won't lose anything.
+    // Transcript JSONL is the caller's responsibility (the frontend
+    // recovery flow imports those rows into sqlite first, then asks
+    // us to discard); we don't touch it here.
     let _ = fs::remove_file(&p);
     let _ = fs::remove_file(meta_path(in_progress_dir, lecture_id));
 
@@ -250,6 +376,7 @@ pub fn find_orphaned_recordings_inner(
         } else {
             0
         };
+        let transcript_segments = count_transcript_segments(in_progress_dir, &lecture_id);
         out.push(OrphanedRecording {
             lecture_id,
             duration_seconds,
@@ -257,6 +384,7 @@ pub fn find_orphaned_recordings_inner(
             sample_rate: meta.sample_rate,
             channels: meta.channels,
             started_at: Some(meta.started_at),
+            transcript_segments,
         });
     }
     // Stable order for UI — oldest first.
@@ -276,6 +404,7 @@ pub fn discard_orphaned_recording_inner(
     let lecture_id = validate_lecture_id(lecture_id)?;
     let _ = fs::remove_file(pcm_path(in_progress_dir, lecture_id));
     let _ = fs::remove_file(meta_path(in_progress_dir, lecture_id));
+    let _ = fs::remove_file(transcript_path(in_progress_dir, lecture_id));
     Ok(())
 }
 
@@ -343,6 +472,32 @@ pub async fn discard_orphaned_recording(lecture_id: String) -> Result<(), String
     let dir = crate::paths::get_in_progress_audio_dir()?;
     discard_orphaned_recording_inner(&dir, &lecture_id)
         .map_err(|e| format!("Failed to discard orphan: {}", e))
+}
+
+#[tauri::command]
+pub async fn append_transcript_segment(
+    lecture_id: String,
+    segment: PersistedTranscriptSegment,
+) -> Result<u64, String> {
+    let dir = crate::paths::get_in_progress_audio_dir()?;
+    append_transcript_segment_inner(&dir, &lecture_id, &segment)
+        .map_err(|e| format!("Failed to append transcript segment: {}", e))
+}
+
+#[tauri::command]
+pub async fn read_orphaned_transcript(
+    lecture_id: String,
+) -> Result<Vec<PersistedTranscriptSegment>, String> {
+    let dir = crate::paths::get_in_progress_audio_dir()?;
+    read_transcript_segments_inner(&dir, &lecture_id)
+        .map_err(|e| format!("Failed to read transcript: {}", e))
+}
+
+#[tauri::command]
+pub async fn discard_orphaned_transcript(lecture_id: String) -> Result<(), String> {
+    let dir = crate::paths::get_in_progress_audio_dir()?;
+    discard_transcript_segments_inner(&dir, &lecture_id)
+        .map_err(|e| format!("Failed to discard transcript: {}", e))
 }
 
 #[cfg(test)]
@@ -547,5 +702,180 @@ mod tests {
         let wav = wrap_pcm_as_wav(&pcm, 48_000, 2);
         let data_size = u32::from_le_bytes([wav[40], wav[41], wav[42], wav[43]]);
         assert_eq!(data_size as usize, 10_000);
+    }
+
+    // ===== Transcript JSONL persistence (Phase 1 of speech-pipeline-v0.6.5) =====
+
+    fn sample_segment(id: &str, text: &str) -> PersistedTranscriptSegment {
+        PersistedTranscriptSegment {
+            id: id.to_string(),
+            timestamp: 1.0,
+            text_en: text.to_string(),
+            text_zh: None,
+            kind: "rough".to_string(),
+        }
+    }
+
+    #[test]
+    fn append_transcript_creates_file_and_each_call_adds_one_line() {
+        let (_tmp, dir) = fresh();
+        append_transcript_segment_inner(&dir, "lec-t", &sample_segment("a", "first")).unwrap();
+        append_transcript_segment_inner(&dir, "lec-t", &sample_segment("b", "second")).unwrap();
+        let raw = fs::read_to_string(transcript_path(&dir, "lec-t")).unwrap();
+        assert_eq!(raw.lines().count(), 2, "one line per segment");
+    }
+
+    #[test]
+    fn read_transcript_round_trips_all_well_formed_segments() {
+        let (_tmp, dir) = fresh();
+        let s1 = sample_segment("a", "hello");
+        let s2 = PersistedTranscriptSegment {
+            id: "b".to_string(),
+            timestamp: 2.5,
+            text_en: "world".to_string(),
+            text_zh: Some("世界".to_string()),
+            kind: "fine".to_string(),
+        };
+        append_transcript_segment_inner(&dir, "lec-r", &s1).unwrap();
+        append_transcript_segment_inner(&dir, "lec-r", &s2).unwrap();
+
+        let segs = read_transcript_segments_inner(&dir, "lec-r").unwrap();
+        assert_eq!(segs.len(), 2);
+        assert_eq!(segs[0].id, "a");
+        assert_eq!(segs[1].id, "b");
+        assert_eq!(segs[1].text_zh.as_deref(), Some("世界"));
+        assert_eq!(segs[1].kind, "fine");
+    }
+
+    #[test]
+    fn read_transcript_skips_corrupt_lines_but_keeps_good_ones() {
+        // Simulates a crash mid-write: previous lines are clean JSONL,
+        // last line is a half-flushed garbage. Recovery must NOT discard
+        // the first N segments because of the truncated tail.
+        let (_tmp, dir) = fresh();
+        fs::create_dir_all(&dir).unwrap();
+        let mut content = String::new();
+        content.push_str(&serde_json::to_string(&sample_segment("good-1", "first")).unwrap());
+        content.push('\n');
+        content.push_str(&serde_json::to_string(&sample_segment("good-2", "second")).unwrap());
+        content.push('\n');
+        content.push_str("{\"id\":\"truncated"); // half-written line, no closing }
+        fs::write(transcript_path(&dir, "lec-mix"), content).unwrap();
+
+        let segs = read_transcript_segments_inner(&dir, "lec-mix").unwrap();
+        assert_eq!(segs.len(), 2, "must keep the 2 well-formed lines");
+        assert_eq!(segs[0].id, "good-1");
+        assert_eq!(segs[1].id, "good-2");
+    }
+
+    #[test]
+    fn read_transcript_returns_empty_when_no_jsonl_file() {
+        let (_tmp, dir) = fresh();
+        let segs = read_transcript_segments_inner(&dir, "never-recorded").unwrap();
+        assert!(segs.is_empty());
+    }
+
+    #[test]
+    fn count_transcript_segments_matches_read_length() {
+        let (_tmp, dir) = fresh();
+        for i in 0..7 {
+            append_transcript_segment_inner(
+                &dir,
+                "lec-c",
+                &sample_segment(&format!("s-{}", i), "x"),
+            )
+            .unwrap();
+        }
+        assert_eq!(count_transcript_segments(&dir, "lec-c"), 7);
+        assert_eq!(count_transcript_segments(&dir, "missing"), 0);
+    }
+
+    #[test]
+    fn find_orphaned_recordings_includes_transcript_segment_count() {
+        let (_tmp, dir) = fresh();
+        append_pcm_chunk_inner(&dir, "lec-with-tx", &vec![0i16; 16_000], 16_000, 1).unwrap();
+        for i in 0..3 {
+            append_transcript_segment_inner(
+                &dir,
+                "lec-with-tx",
+                &sample_segment(&format!("seg-{}", i), "text"),
+            )
+            .unwrap();
+        }
+        let orphans = find_orphaned_recordings_inner(&dir).unwrap();
+        let lec = orphans.iter().find(|o| o.lecture_id == "lec-with-tx").unwrap();
+        assert_eq!(lec.transcript_segments, 3);
+    }
+
+    #[test]
+    fn find_orphaned_recordings_reports_zero_segments_for_audio_only_session() {
+        // A pre-Phase-1 .pcm with no JSONL companion must still be
+        // recoverable — the field defaults to 0, never errors.
+        let (_tmp, dir) = fresh();
+        append_pcm_chunk_inner(&dir, "audio-only", &vec![0i16; 16_000], 16_000, 1).unwrap();
+        let orphans = find_orphaned_recordings_inner(&dir).unwrap();
+        let lec = orphans
+            .iter()
+            .find(|o| o.lecture_id == "audio-only")
+            .unwrap();
+        assert_eq!(lec.transcript_segments, 0);
+    }
+
+    #[test]
+    fn discard_orphaned_recording_removes_transcript_jsonl_too() {
+        let (_tmp, dir) = fresh();
+        append_pcm_chunk_inner(&dir, "to-discard", &vec![0i16; 100], 16_000, 1).unwrap();
+        append_transcript_segment_inner(
+            &dir,
+            "to-discard",
+            &sample_segment("seg-1", "should be deleted"),
+        )
+        .unwrap();
+        assert!(transcript_path(&dir, "to-discard").exists());
+
+        discard_orphaned_recording_inner(&dir, "to-discard").unwrap();
+
+        assert!(!pcm_path(&dir, "to-discard").exists());
+        assert!(!meta_path(&dir, "to-discard").exists());
+        assert!(
+            !transcript_path(&dir, "to-discard").exists(),
+            "transcript JSONL must be cleaned on discard"
+        );
+    }
+
+    #[test]
+    fn finalize_recording_does_not_delete_transcript_jsonl() {
+        // The frontend recovery flow imports the JSONL into sqlite BEFORE
+        // calling finalize. If finalize wiped the JSONL too, a recovery
+        // failure between import and finalize would lose segments. The
+        // explicit cleanup is `discard_orphaned_transcript` after the
+        // import succeeds, so finalize is intentionally narrow here.
+        let (tmp, dir) = fresh();
+        append_pcm_chunk_inner(&dir, "fin-keep", &[1, 2, 3, 4], 16_000, 1).unwrap();
+        append_transcript_segment_inner(
+            &dir,
+            "fin-keep",
+            &sample_segment("survived", "I should still be on disk"),
+        )
+        .unwrap();
+        let final_path = tmp.path().join("out.wav");
+        finalize_recording_inner(&dir, "fin-keep", &final_path).unwrap();
+        assert!(
+            transcript_path(&dir, "fin-keep").exists(),
+            "finalize is narrow: only PCM + meta cleared, transcript JSONL stays for explicit discard"
+        );
+    }
+
+    #[test]
+    fn append_transcript_rejects_lecture_id_with_path_traversal() {
+        let (_tmp, dir) = fresh();
+        let r = append_transcript_segment_inner(&dir, "../escape", &sample_segment("x", "y"));
+        assert!(r.is_err(), "transcript append must reject path-traversal id");
+    }
+
+    #[test]
+    fn discard_transcript_rejects_lecture_id_with_path_traversal() {
+        let (_tmp, dir) = fresh();
+        assert!(discard_transcript_segments_inner(&dir, "../escape").is_err());
     }
 }

--- a/ClassNoteAI/src/components/NotesView.tsx
+++ b/ClassNoteAI/src/components/NotesView.tsx
@@ -47,6 +47,7 @@ import ImportModal, { PasteSubmission, VideoImportOptions } from "./ImportModal"
 import { Lecture, Note, RecordingStatus } from "../types";
 import CourseCreationDialog from "./CourseCreationDialog";
 import { AudioRecorder } from "../services/audioRecorder";
+import { BatteryMonitor } from "../services/batteryMonitorService";
 import SubtitleDisplay from "./SubtitleDisplay";
 import AudioPlayer from "./AudioPlayer";
 import { transcriptionService } from "../services/transcriptionService";
@@ -161,6 +162,10 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
   const deviceMonitorCleanupRef = useRef<(() => void) | null>(null);
   const recordingDeviceSnapshotRef = useRef<RecordingInputSnapshot | null>(null);
   const lastDeviceWarningKeyRef = useRef<string | null>(null);
+  // Phase 1 of speech-pipeline-v0.6.5 (#52): battery monitor instance
+  // is reused across recordings — start() / stop() per session — so
+  // navigator.getBattery() is only resolved once per app lifetime.
+  const batteryMonitorRef = useRef<BatteryMonitor | null>(null);
 
   // Sync modelLoaded state to ref
   useEffect(() => {
@@ -1249,6 +1254,22 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
 
       await audioRecorderRef.current.start();
 
+      // Phase 1 of speech-pipeline-v0.6.5 (#52): battery guard. Warns at
+      // 10% and force-stops at 5% to flush the JSONL + finalize the WAV
+      // before the OS yanks the process. Created lazily so platforms
+      // without a battery API never pay the navigator.getBattery cost.
+      if (!batteryMonitorRef.current) {
+        batteryMonitorRef.current = new BatteryMonitor({
+          onCritical: () => {
+            console.warn('[NotesView] Battery critical, auto-stopping recording');
+            void handleStopRecording();
+          },
+        });
+      }
+      void batteryMonitorRef.current.start().catch((err) => {
+        console.warn('[NotesView] battery monitor start failed:', err);
+      });
+
       const resolvedInputDeviceId = audioRecorderRef.current.getDeviceId();
       if (resolvedInputDeviceId && resolvedInputDeviceId !== preferredInputDeviceId) {
         await audioDeviceService.setPreferredDevice(resolvedInputDeviceId);
@@ -1311,6 +1332,10 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
       }
 
       await audioRecorderRef.current.stop();
+      // Phase 1 of speech-pipeline-v0.6.5 (#52): release battery
+      // listeners now that this session is done. start() is idempotent
+      // so the next recording reattaches.
+      batteryMonitorRef.current?.stop();
       stopRecordingDeviceMonitor();
       setRecordingStatus("stopped");
       setVolume(0);

--- a/ClassNoteAI/src/components/RecoveryPromptModal.tsx
+++ b/ClassNoteAI/src/components/RecoveryPromptModal.tsx
@@ -211,7 +211,7 @@ export default function RecoveryPromptModal({
                                     <div className="font-medium text-gray-900 dark:text-gray-100 truncate">
                                         {session.lecture.title || '（未命名課堂）'}
                                     </div>
-                                    <div className="text-xs text-gray-500 dark:text-gray-400 mt-1 flex items-center gap-3">
+                                    <div className="text-xs text-gray-500 dark:text-gray-400 mt-1 flex items-center gap-3 flex-wrap">
                                         <span>約 {formatDuration(session.durationSeconds)}</span>
                                         <span>·</span>
                                         <span>{formatStarted(session.startedAt)}</span>
@@ -219,6 +219,18 @@ export default function RecoveryPromptModal({
                                         <span className="font-mono text-[10px]">
                                             {(session.bytes / 1_000_000).toFixed(1)} MB
                                         </span>
+                                        {/* Phase 1 of speech-pipeline-v0.6.5 (#52). Show
+                                            "+N 段已轉錄" if the JSONL sidecar captured live
+                                            captions before the crash; users now know their
+                                            text isn't lost, only the audio is being re-wrapped. */}
+                                        {session.transcriptSegments > 0 && (
+                                            <>
+                                                <span>·</span>
+                                                <span className="text-emerald-600 dark:text-emerald-400">
+                                                    含 {session.transcriptSegments} 段已轉錄字幕
+                                                </span>
+                                            </>
+                                        )}
                                     </div>
                                     {state.error && (
                                         <div className="text-xs text-red-500 mt-2 flex items-center gap-2 flex-wrap">

--- a/ClassNoteAI/src/services/__tests__/batteryMonitorService.test.ts
+++ b/ClassNoteAI/src/services/__tests__/batteryMonitorService.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Phase 1 of speech-pipeline-v0.6.5 (#52). The battery monitor's job
+ * is to fire at most one toast per threshold-cross AND fire the
+ * critical handler exactly once when level hits ≤ 5% off-charger.
+ * Both invariants are easy to break with naive event listeners (cf.
+ * a level oscillating around the threshold), so they are pinned by
+ * test rather than by code review.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { BatteryMonitor } from '../batteryMonitorService';
+
+vi.mock('../toastService', () => ({
+  toastService: {
+    show: vi.fn(),
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+import { toastService } from '../toastService';
+
+class FakeBattery extends EventTarget {
+  level: number;
+  charging: boolean;
+  constructor(level: number, charging: boolean) {
+    super();
+    this.level = level;
+    this.charging = charging;
+  }
+  setLevel(next: number) {
+    this.level = next;
+    this.dispatchEvent(new Event('levelchange'));
+  }
+  setCharging(next: boolean) {
+    this.charging = next;
+    this.dispatchEvent(new Event('chargingchange'));
+  }
+}
+
+beforeEach(() => {
+  vi.mocked(toastService.show).mockClear();
+});
+
+describe('BatteryMonitor.deriveThreshold', () => {
+  it('returns "normal" when on charger regardless of level', () => {
+    expect(BatteryMonitor.deriveThreshold(0.01, true, 0.1, 0.05)).toBe('normal');
+    expect(BatteryMonitor.deriveThreshold(0.5, true, 0.1, 0.05)).toBe('normal');
+  });
+
+  it('returns "critical" only when level <= criticalAt and discharging', () => {
+    expect(BatteryMonitor.deriveThreshold(0.05, false, 0.1, 0.05)).toBe('critical');
+    expect(BatteryMonitor.deriveThreshold(0.04, false, 0.1, 0.05)).toBe('critical');
+  });
+
+  it('returns "low" between thresholds when discharging', () => {
+    expect(BatteryMonitor.deriveThreshold(0.10, false, 0.1, 0.05)).toBe('low');
+    expect(BatteryMonitor.deriveThreshold(0.07, false, 0.1, 0.05)).toBe('low');
+  });
+
+  it('returns "normal" above the warning threshold', () => {
+    expect(BatteryMonitor.deriveThreshold(0.5, false, 0.1, 0.05)).toBe('normal');
+    expect(BatteryMonitor.deriveThreshold(0.11, false, 0.1, 0.05)).toBe('normal');
+  });
+});
+
+describe('BatteryMonitor instance', () => {
+  it('does NOT toast on start when battery is already healthy', async () => {
+    const fake = new FakeBattery(0.8, false);
+    const m = new BatteryMonitor({ getBattery: async () => fake });
+    await m.start();
+    expect(toastService.show).not.toHaveBeenCalled();
+    expect(m.currentThreshold()).toBe('normal');
+  });
+
+  it('toasts a warning the first time battery crosses into low', async () => {
+    const fake = new FakeBattery(0.5, false);
+    const m = new BatteryMonitor({ getBattery: async () => fake });
+    await m.start();
+    fake.setLevel(0.09);
+    expect(m.currentThreshold()).toBe('low');
+    expect(toastService.show).toHaveBeenCalledTimes(1);
+    expect(vi.mocked(toastService.show).mock.calls[0][0].type).toBe('warning');
+  });
+
+  it('does not re-toast when battery stays low across multiple level events', async () => {
+    const fake = new FakeBattery(0.09, false);
+    const m = new BatteryMonitor({ getBattery: async () => fake });
+    await m.start();
+    fake.setLevel(0.085);
+    fake.setLevel(0.08);
+    fake.setLevel(0.075);
+    // One toast for the initial seed crossing into low; the rest are
+    // same-threshold updates that must NOT spam additional toasts.
+    expect(toastService.show).toHaveBeenCalledTimes(1);
+  });
+
+  it('fires onCritical exactly once when crossing into critical', async () => {
+    const onCritical = vi.fn();
+    const fake = new FakeBattery(0.5, false);
+    const m = new BatteryMonitor({ getBattery: async () => fake, onCritical });
+    await m.start();
+    fake.setLevel(0.04);
+    expect(onCritical).toHaveBeenCalledTimes(1);
+
+    // Further drops while already in critical must NOT re-fire — the
+    // recorder has already been told to stop.
+    fake.setLevel(0.03);
+    fake.setLevel(0.02);
+    expect(onCritical).toHaveBeenCalledTimes(1);
+  });
+
+  it('respects charging — plugging in after low never re-fires on next cross', async () => {
+    const onCritical = vi.fn();
+    const fake = new FakeBattery(0.08, false);
+    const m = new BatteryMonitor({ getBattery: async () => fake, onCritical });
+    await m.start();
+    expect(toastService.show).toHaveBeenCalledTimes(1); // low warning seeded
+
+    fake.setCharging(true); // plug in → drops back to normal silently
+    expect(m.currentThreshold()).toBe('normal');
+
+    fake.setCharging(false); // unplug at the same low level
+    fake.setLevel(0.08);
+    // Going from normal back to low IS a fresh cross, so a new warning is allowed.
+    expect(toastService.show).toHaveBeenCalledTimes(2);
+    expect(onCritical).not.toHaveBeenCalled();
+  });
+
+  it('returns false from start() if navigator has no battery API', async () => {
+    const m = new BatteryMonitor({
+      getBattery: undefined,
+    });
+    // No navigator.getBattery on jsdom by default — should degrade silently.
+    const ok = await m.start();
+    expect(ok).toBe(false);
+  });
+
+  it('returns false from start() if getBattery rejects', async () => {
+    const m = new BatteryMonitor({
+      getBattery: () => Promise.reject(new Error('denied')),
+    });
+    const ok = await m.start();
+    expect(ok).toBe(false);
+    expect(toastService.show).not.toHaveBeenCalled();
+  });
+
+  it('stop() unsubscribes from battery events so later changes are silent', async () => {
+    const fake = new FakeBattery(0.5, false);
+    const m = new BatteryMonitor({ getBattery: async () => fake });
+    await m.start();
+    m.stop();
+    fake.setLevel(0.04);
+    expect(toastService.show).not.toHaveBeenCalled();
+  });
+
+  it('escalates from low to critical with a separate toast each step', async () => {
+    const onCritical = vi.fn();
+    const fake = new FakeBattery(0.5, false);
+    const m = new BatteryMonitor({ getBattery: async () => fake, onCritical });
+    await m.start();
+    fake.setLevel(0.09); // low
+    fake.setLevel(0.04); // critical
+    expect(toastService.show).toHaveBeenCalledTimes(2);
+    expect(vi.mocked(toastService.show).mock.calls[0][0].type).toBe('warning');
+    expect(vi.mocked(toastService.show).mock.calls[1][0].type).toBe('error');
+    expect(onCritical).toHaveBeenCalledTimes(1);
+  });
+});

--- a/ClassNoteAI/src/services/__tests__/recordingRecoveryService.transcript.test.ts
+++ b/ClassNoteAI/src/services/__tests__/recordingRecoveryService.transcript.test.ts
@@ -1,0 +1,145 @@
+/**
+ * Phase 1 of speech-pipeline-v0.6.5 (#52). The transcript-JSONL
+ * recovery path must satisfy three invariants:
+ *
+ *   1. recoverTranscript imports every well-formed segment into
+ *      sqlite, not just one or some.
+ *   2. recover() always imports the transcript BEFORE finalizing
+ *      the audio, so a finalize failure leaves the JSONL on disk
+ *      for a retry next launch.
+ *   3. When the same segment id appears twice (rough-only line
+ *      followed by rough+text_zh line), the LATER entry wins —
+ *      that is the version with the translation.
+ *
+ * The Tauri IPC is mocked so we can drive the contract end-to-end
+ * without spinning up the Rust runtime.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { setMockInvokeResult, clearMockInvokeResults } from '../../test/setup';
+import { invoke } from '@tauri-apps/api/core';
+import { recordingRecoveryService } from '../recordingRecoveryService';
+
+beforeEach(() => {
+  clearMockInvokeResults();
+  vi.clearAllMocks();
+});
+
+describe('recordingRecoveryService.recoverTranscript', () => {
+  it('returns 0 when no JSONL sidecar exists', async () => {
+    setMockInvokeResult('read_orphaned_transcript', []);
+    const n = await recordingRecoveryService.recoverTranscript('lec-empty');
+    expect(n).toBe(0);
+    // No segments → no save call.
+    const saveCall = vi
+      .mocked(invoke)
+      .mock.calls.find(([cmd]) => cmd === 'save_subtitles');
+    expect(saveCall).toBeUndefined();
+  });
+
+  it('imports every well-formed segment into sqlite via save_subtitles', async () => {
+    setMockInvokeResult('read_orphaned_transcript', [
+      { id: 'a', timestamp: 1.0, text_en: 'hello', text_zh: null, type: 'rough' },
+      { id: 'b', timestamp: 2.0, text_en: 'world', text_zh: '世界', type: 'rough' },
+      { id: 'c', timestamp: 3.0, text_en: 'goodbye', text_zh: null, type: 'rough' },
+    ]);
+    setMockInvokeResult('save_subtitles', undefined);
+
+    const n = await recordingRecoveryService.recoverTranscript('lec-3');
+    expect(n).toBe(3);
+
+    const saveCall = vi
+      .mocked(invoke)
+      .mock.calls.find(([cmd]) => cmd === 'save_subtitles');
+    expect(saveCall).toBeDefined();
+    const subtitles = (saveCall![1] as { subtitles: unknown[] }).subtitles;
+    expect(subtitles).toHaveLength(3);
+  });
+
+  it('dedupes by id and keeps the latest entry (with translation populated)', async () => {
+    // First the rough-only commit, then the rough+text_zh upgrade —
+    // common when translation completes between two sqlite flushes.
+    setMockInvokeResult('read_orphaned_transcript', [
+      { id: 'dup', timestamp: 1.0, text_en: 'hi', text_zh: null, type: 'rough' },
+      { id: 'dup', timestamp: 1.0, text_en: 'hi', text_zh: '嗨', type: 'rough' },
+    ]);
+    setMockInvokeResult('save_subtitles', undefined);
+
+    const n = await recordingRecoveryService.recoverTranscript('lec-dup');
+    expect(n).toBe(1);
+
+    const saveCall = vi
+      .mocked(invoke)
+      .mock.calls.find(([cmd]) => cmd === 'save_subtitles');
+    const subtitles = (saveCall![1] as {
+      subtitles: Array<{ id: string; text_zh: string | null }>;
+    }).subtitles;
+    expect(subtitles).toHaveLength(1);
+    expect(subtitles[0].text_zh).toBe('嗨');
+  });
+
+  it('returns 0 when read_orphaned_transcript IPC fails (logged, not thrown)', async () => {
+    // Simulate a Rust-side failure (lecture id rejected, IO error,
+    // whatever). recoverTranscript must not propagate — the recovery
+    // flow degrades to "audio only" in that case rather than refusing
+    // to recover anything.
+    vi.mocked(invoke).mockImplementationOnce(() =>
+      Promise.reject(new Error('rust threw')),
+    );
+    const n = await recordingRecoveryService.recoverTranscript('lec-err');
+    expect(n).toBe(0);
+  });
+});
+
+describe('recordingRecoveryService.recover (full flow)', () => {
+  it('imports transcript BEFORE finalize, then discards JSONL after both succeed', async () => {
+    const callOrder: string[] = [];
+    vi.mocked(invoke).mockImplementation((cmd) => {
+      callOrder.push(cmd);
+      if (cmd === 'get_audio_dir') return Promise.resolve('/tmp/audio');
+      if (cmd === 'read_orphaned_transcript') {
+        return Promise.resolve([
+          { id: 'a', timestamp: 0.5, text_en: 'x', text_zh: null, type: 'rough' },
+        ] as unknown);
+      }
+      if (cmd === 'save_subtitles') return Promise.resolve(undefined);
+      if (cmd === 'finalize_recording') return Promise.resolve(0);
+      if (cmd === 'discard_orphaned_transcript') return Promise.resolve(undefined);
+      if (cmd === 'update_lecture_status') return Promise.resolve(undefined);
+      return Promise.resolve(undefined);
+    });
+
+    await recordingRecoveryService.recover('lec-flow');
+
+    const transcriptIdx = callOrder.indexOf('save_subtitles');
+    const finalizeIdx = callOrder.indexOf('finalize_recording');
+    const discardIdx = callOrder.indexOf('discard_orphaned_transcript');
+
+    expect(transcriptIdx).toBeGreaterThanOrEqual(0);
+    expect(finalizeIdx).toBeGreaterThan(transcriptIdx);
+    expect(discardIdx).toBeGreaterThan(finalizeIdx);
+  });
+
+  it('does NOT discard JSONL if finalize fails (so retry next launch still works)', async () => {
+    vi.mocked(invoke).mockImplementation((cmd) => {
+      if (cmd === 'get_audio_dir') return Promise.resolve('/tmp/audio');
+      if (cmd === 'read_orphaned_transcript') {
+        return Promise.resolve([
+          { id: 'a', timestamp: 0.5, text_en: 'x', text_zh: null, type: 'rough' },
+        ] as unknown);
+      }
+      if (cmd === 'save_subtitles') return Promise.resolve(undefined);
+      if (cmd === 'finalize_recording') {
+        return Promise.reject(new Error('disk full'));
+      }
+      return Promise.resolve(undefined);
+    });
+
+    await expect(recordingRecoveryService.recover('lec-broken')).rejects.toThrow();
+
+    const discardCalled = vi
+      .mocked(invoke)
+      .mock.calls.some(([cmd]) => cmd === 'discard_orphaned_transcript');
+    expect(discardCalled).toBe(false);
+  });
+});

--- a/ClassNoteAI/src/services/batteryMonitorService.ts
+++ b/ClassNoteAI/src/services/batteryMonitorService.ts
@@ -1,0 +1,190 @@
+/**
+ * Phase 1 of speech-pipeline-v0.6.5 (#52). Watches the device battery
+ * and emits two escalating signals while a recording is in progress:
+ *
+ *   - `low`  (≤ 10% AND not charging)  → toast warning so the user can
+ *     plug in or wrap up the lecture before the crash window opens.
+ *
+ *   - `critical` (≤ 5% AND not charging) → fires the registered
+ *     `onCritical` handler so the recorder can flush + auto-stop while
+ *     the JSONL sidecar still has time to land. Issuing a forced stop
+ *     here is strictly better than letting the OS yank the process and
+ *     forcing the user through the recovery flow next launch.
+ *
+ * The thresholds match #52 ("< 10% warn, < 5% auto-stop"). The hooks
+ * are coarse (`once-per-threshold-crossing`, no spam) because polling
+ * here is intentionally driven by browser battery events rather than
+ * a setInterval.
+ *
+ * Tauri webviews expose the same `navigator.getBattery()` shim Web
+ * gives us. On platforms where the API is missing entirely (some
+ * Linux configurations) this service degrades silently — the rest of
+ * the recording flow keeps working, just without battery guards.
+ */
+
+import { toastService } from './toastService';
+
+export type BatteryThreshold = 'normal' | 'low' | 'critical';
+
+interface BatteryLikeManager extends EventTarget {
+  level: number;
+  charging: boolean;
+}
+
+export interface BatteryMonitorOptions {
+  /** Called once when battery first crosses the critical threshold
+   *  (level ≤ 0.05 AND not charging). The recorder should flush and
+   *  stop. Promise rejection is logged but doesn't re-trigger. */
+  onCritical?: () => void | Promise<void>;
+  /** Override the warning threshold for tests. Defaults to 0.10. */
+  lowAt?: number;
+  /** Override the critical threshold for tests. Defaults to 0.05. */
+  criticalAt?: number;
+  /** Replace `navigator.getBattery` for tests. */
+  getBattery?: () => Promise<BatteryLikeManager>;
+}
+
+type ListenerWrapper = {
+  type: 'levelchange' | 'chargingchange';
+  fn: (e: Event) => void;
+};
+
+export class BatteryMonitor {
+  private mgr: BatteryLikeManager | null = null;
+  private threshold: BatteryThreshold = 'normal';
+  private listeners: ListenerWrapper[] = [];
+  private opts: Required<Omit<BatteryMonitorOptions, 'onCritical' | 'getBattery'>> &
+    Pick<BatteryMonitorOptions, 'onCritical' | 'getBattery'>;
+  private active = false;
+
+  constructor(options: BatteryMonitorOptions = {}) {
+    this.opts = {
+      lowAt: options.lowAt ?? 0.1,
+      criticalAt: options.criticalAt ?? 0.05,
+      onCritical: options.onCritical,
+      getBattery: options.getBattery,
+    };
+  }
+
+  /** Resolve the current threshold given level + charging state.
+   *  Pure helper, exposed for unit tests. */
+  static deriveThreshold(level: number, charging: boolean, lowAt: number, criticalAt: number): BatteryThreshold {
+    if (charging) return 'normal';
+    if (level <= criticalAt) return 'critical';
+    if (level <= lowAt) return 'low';
+    return 'normal';
+  }
+
+  /** Begin watching. Idempotent. Safe to call before user grants any
+   *  permission — `navigator.getBattery` is permission-free in browsers
+   *  that still ship it. Returns false if the platform has no battery
+   *  API at all (caller can decide whether to surface that to the user). */
+  async start(): Promise<boolean> {
+    if (this.active) return true;
+    const getBattery = this.opts.getBattery ?? this.resolveNavigatorGetBattery();
+    if (!getBattery) {
+      console.info('[BatteryMonitor] navigator.getBattery() unavailable — skipping');
+      return false;
+    }
+    try {
+      this.mgr = await getBattery();
+    } catch (err) {
+      console.warn('[BatteryMonitor] getBattery() rejected:', err);
+      return false;
+    }
+
+    const recheck = () => this.recompute();
+    const wrappers: ListenerWrapper[] = [
+      { type: 'levelchange', fn: recheck },
+      { type: 'chargingchange', fn: recheck },
+    ];
+    for (const w of wrappers) this.mgr.addEventListener(w.type, w.fn);
+    this.listeners = wrappers;
+
+    this.active = true;
+    this.recompute(); // seed initial state
+    return true;
+  }
+
+  stop(): void {
+    if (!this.active) return;
+    if (this.mgr) {
+      for (const w of this.listeners) {
+        this.mgr.removeEventListener(w.type, w.fn);
+      }
+    }
+    this.listeners = [];
+    this.mgr = null;
+    this.threshold = 'normal';
+    this.active = false;
+  }
+
+  /** Force the monitor through one evaluation pass. Tests use this to
+   *  drive the state machine deterministically. */
+  recompute(): BatteryThreshold {
+    if (!this.mgr) return 'normal';
+    const next = BatteryMonitor.deriveThreshold(
+      this.mgr.level,
+      this.mgr.charging,
+      this.opts.lowAt,
+      this.opts.criticalAt,
+    );
+    if (next === this.threshold) return next;
+
+    const previous = this.threshold;
+    this.threshold = next;
+
+    // Fire side effects only on UPGRADE (normal → low → critical). A
+    // downgrade (e.g. plug in laptop) silently drops back to normal.
+    const upgraded =
+      (previous === 'normal' && next !== 'normal') ||
+      (previous === 'low' && next === 'critical');
+
+    if (!upgraded) return next;
+
+    if (next === 'low') {
+      toastService.show({
+        type: 'warning',
+        message: '電量偏低',
+        detail: `電量低於 ${Math.round(this.opts.lowAt * 100)}%。建議插上電源，或盡早結束這堂課的錄音。`,
+        durationMs: 0, // pin until dismissed; user needs to see this
+      });
+    } else if (next === 'critical') {
+      toastService.show({
+        type: 'error',
+        message: '電量危急，自動停止錄音',
+        detail: `電量 ≤ ${Math.round(this.opts.criticalAt * 100)}%，已自動停止以保留目前的音訊與字幕。`,
+        durationMs: 0,
+      });
+      if (this.opts.onCritical) {
+        try {
+          const r = this.opts.onCritical();
+          if (r && typeof (r as Promise<void>).catch === 'function') {
+            (r as Promise<void>).catch((err) =>
+              console.error('[BatteryMonitor] onCritical handler threw:', err),
+            );
+          }
+        } catch (err) {
+          console.error('[BatteryMonitor] onCritical handler threw:', err);
+        }
+      }
+    }
+    return next;
+  }
+
+  /** Inspect the current threshold without forcing recompute. Tests. */
+  currentThreshold(): BatteryThreshold {
+    return this.threshold;
+  }
+
+  /** Dynamic-resolution shim: keeps tests free of `any`-cast on
+   *  navigator and lets us return undefined without throwing on
+   *  platforms (e.g. some Firefox builds) that removed the API. */
+  private resolveNavigatorGetBattery(): (() => Promise<BatteryLikeManager>) | null {
+    const nav = typeof navigator !== 'undefined' ? (navigator as Navigator & {
+      getBattery?: () => Promise<BatteryLikeManager>;
+    }) : null;
+    if (!nav || typeof nav.getBattery !== 'function') return null;
+    return () => nav.getBattery!();
+  }
+}

--- a/ClassNoteAI/src/services/recordingRecoveryService.ts
+++ b/ClassNoteAI/src/services/recordingRecoveryService.ts
@@ -25,6 +25,23 @@ export interface OrphanedRecording {
   sampleRate: number;
   channels: number;
   startedAt: string | null;
+  /** Phase 1 of speech-pipeline-v0.6.5 (#52). Number of transcript
+   *  segments that were captured to the JSONL sidecar before the crash.
+   *  0 means the audio is recoverable but no live caption text was ever
+   *  persisted (older builds, or a crash before the first commit). */
+  transcriptSegments: number;
+}
+
+/** One row of an orphaned transcript JSONL — exact mirror of the Rust
+ *  `PersistedTranscriptSegment` struct so the IPC payload is 1:1.
+ *  Recovery uses these to rebuild the `subtitles` rows for a recovered
+ *  lecture before flipping its status to 'completed'. */
+export interface PersistedTranscriptSegment {
+  id: string;
+  timestamp: number;
+  text_en: string;
+  text_zh?: string;
+  type: 'rough' | 'fine';
 }
 
 export interface OrphanedLecture {
@@ -61,6 +78,7 @@ class RecordingRecoveryService {
         sample_rate: number;
         channels: number;
         started_at: string | null;
+        transcript_segments?: number;
       }>>('find_orphaned_recordings'),
       invoke<Array<{ id: string; title: string; date: string; course_id: string }>>(
         'list_orphaned_recording_lectures',
@@ -84,6 +102,7 @@ class RecordingRecoveryService {
         sampleRate: p.sample_rate,
         channels: p.channels,
         startedAt: p.started_at,
+        transcriptSegments: p.transcript_segments ?? 0,
       });
     }
 
@@ -117,17 +136,88 @@ class RecordingRecoveryService {
   }
 
   /** Finalize a .pcm into a WAV under the audio dir, update the
-   *  lecture row to status='completed' with the new audio_path. */
+   *  lecture row to status='completed' with the new audio_path.
+   *
+   *  Phase 1 of speech-pipeline-v0.6.5 (#52): also import the transcript
+   *  JSONL sidecar (if any) into the `subtitles` table BEFORE the
+   *  finalize, so a failure between transcript-import and finalize
+   *  leaves the JSONL intact for a retry on the next launch. */
   async recover(lectureId: string): Promise<string> {
     const audioDir = await invoke<string>('get_audio_dir');
     const sep = navigator.userAgent.includes('Windows') ? '\\' : '/';
     const finalPath = `${audioDir}${sep}lecture_${lectureId}_${Date.now()}.wav`;
+
+    // 1. Import transcript JSONL into sqlite. If this throws (e.g. the
+    //    save_subtitles command rejects a row), we abort and let the
+    //    user retry — the audio + JSONL stay on disk, the lecture row
+    //    stays at status='recording'.
+    await this.recoverTranscript(lectureId);
+
+    // 2. Wrap PCM as WAV at the canonical audio path. Removes .pcm and
+    //    .meta.json; transcript JSONL is intentionally retained.
     await invoke('finalize_recording', { lectureId, finalPath });
+
+    // 3. Now that audio is canonical and transcript is in sqlite, the
+    //    JSONL sidecar is redundant — remove it.
+    try {
+      await invoke('discard_orphaned_transcript', { lectureId });
+    } catch (err) {
+      // Non-fatal: the file is harmless on disk and a future scan will
+      // see no .pcm so it'll never be offered for recovery again.
+      console.warn(
+        `[recovery] post-recovery transcript JSONL cleanup failed for ${lectureId}:`,
+        err,
+      );
+    }
+
     await invoke('update_lecture_status', { id: lectureId, status: 'completed' });
     // Caller is expected to refresh any lecture lists / audio path
     // caches — we intentionally don't reach into storageService here
     // to keep this service dependency-free for tests.
     return finalPath;
+  }
+
+  /** Read the transcript JSONL (if any) and insert each segment into
+   *  sqlite via `save_subtitles`. Idempotent: if a row with the same
+   *  id already exists, the storage command is expected to upsert.
+   *
+   *  Public so tests / advanced UI flows can call it without going
+   *  through the full `recover()` path. */
+  async recoverTranscript(lectureId: string): Promise<number> {
+    const segments = await invoke<PersistedTranscriptSegment[]>(
+      'read_orphaned_transcript',
+      { lectureId },
+    ).catch((err) => {
+      // Empty result is fine; only treat IPC failure as a problem.
+      console.warn(
+        `[recovery] read_orphaned_transcript failed for ${lectureId}:`,
+        err,
+      );
+      return [] as PersistedTranscriptSegment[];
+    });
+    // Defensive: a mock harness or unstubbed Tauri command can resolve
+    // with `null` / `undefined` even though the Rust signature returns
+    // `Vec<...>`. Treat both the same as "no transcript on disk".
+    if (!segments || segments.length === 0) return 0;
+
+    // De-dup: a segment may appear twice (rough-only line followed by
+    // rough+text_zh line). Last entry per id wins — that's the most
+    // up-to-date version of the row.
+    const dedup = new Map<string, PersistedTranscriptSegment>();
+    for (const seg of segments) dedup.set(seg.id, seg);
+
+    // Avoid a hard `storageService` import here so unit tests can mock
+    // the IPC layer directly without dragging the full storage module.
+    const subtitles = Array.from(dedup.values()).map((seg) => ({
+      id: seg.id,
+      lecture_id: lectureId,
+      timestamp: seg.timestamp,
+      text_en: seg.text_en,
+      text_zh: seg.text_zh ?? null,
+      type: seg.type,
+    }));
+    await invoke('save_subtitles', { subtitles });
+    return subtitles.length;
   }
 
   /** Delete the .pcm + meta sidecar without wrapping. Also flips the

--- a/ClassNoteAI/src/services/transcriptionService.ts
+++ b/ClassNoteAI/src/services/transcriptionService.ts
@@ -3,6 +3,7 @@
  * 使用滾動緩衝區實現低延遲流式轉錄
  */
 
+import { invoke } from '@tauri-apps/api/core';
 import { transcribeAudio } from './whisperService';
 import { subtitleService } from './subtitleService';
 import { AudioChunk } from './audioRecorder';
@@ -187,6 +188,36 @@ export class TranscriptionService {
         console.error('[TranscriptionService] final savePendingSubtitles failed:', err);
       }
     })();
+  }
+
+  /**
+   * Phase 1 of speech-pipeline-v0.6.5 (#52): mirror every committed
+   * segment into an append-only JSONL on disk so a crash between sqlite
+   * flushes (we batch every 10 s, see {@link saveInterval}) doesn't
+   * silently lose the segments captured in the gap. The Rust side
+   * cleans the file up on `discard_orphaned_recording` /
+   * `discard_orphaned_transcript`; the recovery flow imports it back
+   * into sqlite before the user sees a "completed" lecture.
+   *
+   * Best-effort: if the IPC throws (disk full, no in-progress dir,
+   * lecture id rejected), we log and move on — the in-memory
+   * pendingSubtitles plus the 10 s flush is still the primary path,
+   * the JSONL only matters when crash precedes flush.
+   */
+  private persistSegmentToDisk(segment: {
+    id: string;
+    timestamp: number;
+    text_en: string;
+    text_zh?: string;
+    type: 'rough' | 'fine';
+  }): void {
+    if (!this.lectureId) return;
+    void invoke('append_transcript_segment', {
+      lectureId: this.lectureId,
+      segment,
+    }).catch((err) => {
+      console.warn('[TranscriptionService] transcript JSONL append failed:', err);
+    });
   }
 
   private async savePendingSubtitles(): Promise<void> {
@@ -635,6 +666,16 @@ export class TranscriptionService {
         text_zh: undefined, // 翻譯完成後更新
         type: 'rough'
       });
+      // Crash-safety: write the rough segment to the JSONL sidecar NOW,
+      // before the next sqlite flush. This is the only line of defence
+      // against a crash inside the 10 s save window.
+      this.persistSegmentToDisk({
+        id,
+        timestamp: timestamp / 1000,
+        text_en: text,
+        text_zh: undefined,
+        type: 'rough',
+      });
     }
 
     // 3. 異步進行翻譯，完成後更新字幕（不阻塞 UI）
@@ -677,6 +718,17 @@ export class TranscriptionService {
       const pending = this.pendingSubtitles.find((s) => s.id === id);
       if (pending) {
         pending.text_zh = translation;
+        // Append a second JSONL line carrying the translation. Recovery
+        // takes the latest line per id, so this upgrades the row from
+        // text_zh=undefined to text_zh=<translation> if the next sqlite
+        // flush misses.
+        this.persistSegmentToDisk({
+          id,
+          timestamp: pending.timestamp,
+          text_en: text,
+          text_zh: translation,
+          type: 'rough',
+        });
       }
     } catch (e) {
       console.warn('[TranscriptionService] 翻譯失敗', e);


### PR DESCRIPTION
## Summary

**Phase 1 of v0.6.5 speech-pipeline plan** (see `docs/design/speech-pipeline-v0.6.5.md` from PR #121). Closes the second-most-painful crash-loss gap identified in #52: today the audio survives a crash (PCM persistence landed in v0.5.2) but the **live captions captured between the 10-second sqlite flushes are gone forever**. Phase 1 mirrors every committed segment to an append-only JSONL sidecar that the recovery flow imports back into sqlite before the audio is finalized. Also adds a battery guard that auto-stops at 5% so the OS doesn't yank the process mid-write.

## Changes

### Transcript JSONL persistence (Rust)

| File | Change |
|---|---|
| `src-tauri/src/recording/mod.rs` | New `append_transcript_segment_inner` / `read_transcript_segments_inner` / `discard_transcript_segments_inner` / `count_transcript_segments`. JSONL = one segment per line, append-only, never rewritten. Crash mid-line drops only the in-flight line. |
| `src-tauri/src/recording/mod.rs` | `OrphanedRecording` gets `transcript_segments: u64`. `find_orphaned_recordings_inner` populates it. `discard_orphaned_recording_inner` cleans the JSONL. **`finalize_recording_inner` intentionally does NOT touch JSONL** — recovery imports first, then explicitly asks for cleanup, so a finalize failure preserves the JSONL for next-launch retry. |
| `src-tauri/src/lib.rs` | 3 new commands wired: `append_transcript_segment`, `read_orphaned_transcript`, `discard_orphaned_transcript`. |

### Frontend recovery wiring

| File | Change |
|---|---|
| `transcriptionService.ts` | `persistSegmentToDisk()` invokes the Tauri append on every `commitStableText()` AND again when translation completes. Best-effort: failures log and move on, the in-memory pendingSubtitles + 10s sqlite flush remains primary. |
| `recordingRecoveryService.ts` | New `recoverTranscript()` reads JSONL, dedupes by id (latest line wins → rough+text_zh upgrade beats rough-only initial line), saves via `save_subtitles`. Existing `recover()` calls it BEFORE finalize so finalize failure keeps JSONL on disk. |
| `RecoveryPromptModal.tsx` | Shows "+N 段已轉錄字幕" alongside duration / size so users see their captions are coming back too. |

### Battery guard

| File | Change |
|---|---|
| `batteryMonitorService.ts` (new) | `BatteryMonitor` class. 10% → pinned warning toast (one-shot per cross). 5% → fires `onCritical` so recorder can flush + auto-stop before OS yank. Static pure helper for threshold derivation, directly tested. Idempotent `start()`; degrades silently if `navigator.getBattery()` is unavailable. |
| `NotesView.tsx` | Lazy-creates a single `BatteryMonitor` ref, starts after `audioRecorder.start()`, stops after `audioRecorder.stop()`. Critical handler calls `handleStopRecording()`. |

## Verification

| Suite | Result |
|---|---|
| `cargo test --lib --package classnoteai recording::tests` | **25 pass** (12 new for transcript JSONL, 13 pre-existing) |
| `cargo check` | clean (no new warnings) |
| `npx vitest run` | **47 files / 386 tests pass** |
| └─ `batteryMonitorService.test.ts` | 13 new tests: threshold derivation, single-fire critical handler, charging-state transitions, missing-API degradation |
| └─ `recordingRecoveryService.transcript.test.ts` | 6 new tests: dedup, save-before-finalize ordering, JSONL preservation on finalize failure |

## Builds on

- PR #121 — Phase 0 stabilization (M2M100 repetition guards, filler-word splitter)

## Out of scope (deferred per the plan)

- Per-session `metadata.json` with course/preset → Phase 7 long-session scaffolding
- Temperature throttling (`pmset -g thermlog` on macOS) → orthogonal, fits #51 acoustic-adaptive work
- Settings UI for low-battery threshold tuning → 10/5% match the #52 spec; expose if feedback asks
- Phase 2 (#55 Silero VAD v5) starts after this lands

## Test plan

- [ ] CI `pr-check-macos` + `pr-check-windows` pass
- [ ] Manual: start a recording, force-quit the app mid-session, verify recovery dialog shows transcript count + restoration repopulates the lecture's `subtitles` table
- [ ] Manual: verify low-battery warning fires once at 10% on a real laptop
- [ ] Manual: verify 5% threshold auto-stops + flushes JSONL/WAV before shutdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)