### PR TITLE
fix(ort): bundle pinned onnxruntime + ORT_DYLIB_PATH override (#55 follow-up)

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -162,6 +162,20 @@ jobs:
       - name: Hydrate vendor/
         run: bash src-tauri/scripts/bootstrap-vendor.sh
 
+      # Phase 2 of speech-pipeline-v0.6.5 (#55): the Silero VAD path
+      # depends on onnxruntime.dll/.dylib being bundled via the
+      # `resources/ort/*` glob in tauri.conf.json. If we don't stage
+      # anything into that dir, tauri-build fails at validation time
+      # with "glob pattern ... didn't match any files". Release builds
+      # fetch the real binary; pr-check runs `cargo check` which
+      # doesn't actually bundle, but tauri-build still walks the glob
+      # on every compile. Staging an empty file is the cheapest way to
+      # make the glob happy without downloading ~14 MB on every PR.
+      - name: Stub ONNX Runtime bundle placeholder
+        run: |
+          mkdir -p ClassNoteAI/src-tauri/resources/ort
+          echo "placeholder for pr-check; real onnxruntime.dll fetched by release workflows" > ClassNoteAI/src-tauri/resources/ort/PLACEHOLDER.txt
+
       # Uses ci-check profile (inherits dev, debug=0). Strips debuginfo
       # from both rustc AND the C/C++ build scripts via cc-rs (which
       # reads cargo's DEBUG env, set by the profile). Closes #119.
@@ -256,6 +270,15 @@ jobs:
       - name: Hydrate vendor/
         shell: bash
         run: bash src-tauri/scripts/bootstrap-vendor.sh
+
+      # See macOS job for rationale. tauri-build's glob validation
+      # fails on an empty `resources/ort/` — real binary is fetched
+      # in release workflows.
+      - name: Stub ONNX Runtime bundle placeholder
+        shell: bash
+        run: |
+          mkdir -p ClassNoteAI/src-tauri/resources/ort
+          echo "placeholder for pr-check; real onnxruntime.dll fetched by release workflows" > ClassNoteAI/src-tauri/resources/ort/PLACEHOLDER.txt
 
       - name: cargo check
         shell: cmd

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -173,8 +173,8 @@ jobs:
       # make the glob happy without downloading ~14 MB on every PR.
       - name: Stub ONNX Runtime bundle placeholder
         run: |
-          mkdir -p ClassNoteAI/src-tauri/resources/ort
-          echo "placeholder for pr-check; real onnxruntime.dll fetched by release workflows" > ClassNoteAI/src-tauri/resources/ort/PLACEHOLDER.txt
+          mkdir -p src-tauri/resources/ort
+          echo "placeholder for pr-check; real onnxruntime.dll fetched by release workflows" > src-tauri/resources/ort/PLACEHOLDER.txt
 
       # Uses ci-check profile (inherits dev, debug=0). Strips debuginfo
       # from both rustc AND the C/C++ build scripts via cc-rs (which
@@ -277,8 +277,8 @@ jobs:
       - name: Stub ONNX Runtime bundle placeholder
         shell: bash
         run: |
-          mkdir -p ClassNoteAI/src-tauri/resources/ort
-          echo "placeholder for pr-check; real onnxruntime.dll fetched by release workflows" > ClassNoteAI/src-tauri/resources/ort/PLACEHOLDER.txt
+          mkdir -p src-tauri/resources/ort
+          echo "placeholder for pr-check; real onnxruntime.dll fetched by release workflows" > src-tauri/resources/ort/PLACEHOLDER.txt
 
       - name: cargo check
         shell: cmd

--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -104,6 +104,14 @@ jobs:
       - name: Hydrate vendor/ (no-op patches on macOS)
         run: bash src-tauri/scripts/bootstrap-vendor.sh
 
+      # Phase 2 of speech-pipeline-v0.6.5 (#55) follow-up: fetch the
+      # pinned libonnxruntime for Silero VAD v5. See release-windows.yml
+      # for the rationale — on macOS the same mechanism just ships a
+      # .dylib next to the bundled app so `ORT_DYLIB_PATH` points at
+      # a known-good 1.23.0 instead of whatever else might be on path.
+      - name: Fetch bundled ONNX Runtime (Silero VAD dep)
+        run: bash src-tauri/scripts/fetch-onnxruntime.sh
+
       # ===== 安裝 npm 依賴 =====
       - name: Install dependencies
         run: npm ci --prefer-offline

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -155,6 +155,16 @@ jobs:
         shell: bash
         run: bash src-tauri/scripts/bootstrap-vendor.sh
 
+      # Phase 2 of speech-pipeline-v0.6.5 (#55) follow-up: fetch the
+      # pinned onnxruntime.dll (1.23.0) that Silero VAD v5 needs. The
+      # Rust crate `ort = "2.0.0-rc.9"` is built with `load-dynamic`,
+      # and the setup() hook in lib.rs points `ORT_DYLIB_PATH` at this
+      # bundled copy at runtime — bypassing the older system DLLs that
+      # Office / Edge / Copilot tend to leave on end-user PATH.
+      - name: Fetch bundled ONNX Runtime (Silero VAD dep)
+        shell: bash
+        run: bash src-tauri/scripts/fetch-onnxruntime.sh
+
       - name: Install dependencies
         run: npm ci --prefer-offline
 

--- a/.gitignore
+++ b/.gitignore
@@ -59,6 +59,14 @@ model_packages/
 *.mp3
 *.zip
 
+# Native ONNX Runtime — fetched by scripts/fetch-onnxruntime.sh at
+# build time (or by the release CI workflow). ~14 MB .dll / ~25 MB
+# .dylib; too large to version in git.
+ClassNoteAI/src-tauri/resources/ort/onnxruntime.dll
+ClassNoteAI/src-tauri/resources/ort/onnxruntime.dylib
+ClassNoteAI/src-tauri/resources/ort/libonnxruntime*.so*
+ClassNoteAI/src-tauri/resources/ort/libonnxruntime*.dylib
+
 # Test files
 test_translation*.py
 test_translation*.ts

--- a/ClassNoteAI/src-tauri/Cargo.toml
+++ b/ClassNoteAI/src-tauri/Cargo.toml
@@ -146,6 +146,17 @@ dirs = "5"
 toml = { version = "0.8", default-features = false, features = ["parse", "display"] }
 tauri-plugin-http = "2"
 tauri-plugin-process = "2"
+# `load-dynamic` is mandatory here: ort-sys with `download-binaries`
+# statically links its own protobuf, which collides with the protobuf
+# already statically linked by sentencepiece-sys (a transitive dep of
+# ct2rs). Linker error on Windows is LNK2005 on every `WireFormatLite`
+# / `FieldSkipper` symbol followed by LNK1169. The only way both
+# crates can coexist in this binary is with `load-dynamic` on the ort
+# side so it finds onnxruntime's protobuf copy at runtime, not link
+# time. See docs/design/speech-pipeline-v0.6.5.md — the DLL-version
+# mismatch on end-user Windows machines has to be solved via release-
+# workflow bundling (ship a pinned onnxruntime.dll next to the exe
+# and point `ORT_DYLIB_PATH` at it) rather than via `download-binaries`.
 ort = { version = "2.0.0-rc.9", features = ["load-dynamic"] }
 ndarray = "0.15"
 # Phase 3 of speech-pipeline-v0.6.5 (#53): compression-ratio guard

--- a/ClassNoteAI/src-tauri/scripts/fetch-onnxruntime.sh
+++ b/ClassNoteAI/src-tauri/scripts/fetch-onnxruntime.sh
@@ -1,0 +1,75 @@
+#!/usr/bin/env bash
+# Fetch the pinned ONNX Runtime binary for the Phase 2 Silero VAD v5
+# integration. Runs in two contexts:
+#
+#   1. Release CI workflow — before `cargo tauri build` so the
+#      bundled .dll / .dylib / .so lands in the installer next to the
+#      Silero ONNX model in resources/silero/.
+#
+#   2. Local dev — run once after cloning if you want Silero to
+#      actually initialise in a `cargo tauri dev` / `cargo run` build.
+#      Without it, the adaptive VAD dispatcher falls back to the
+#      energy VAD (which works fine for day-to-day dev but you won't
+#      see Phase 2's quality improvements).
+#
+# Version is pinned to 1.23.0 because `ort = "2.0.0-rc.9"` rejects
+# older binaries. Bumping ort → bump this URL to match the supported
+# range (see the ort release notes).
+#
+# Usage (from repo root or src-tauri):
+#     bash src-tauri/scripts/fetch-onnxruntime.sh
+
+set -euo pipefail
+
+ORT_VERSION="1.23.0"
+
+# Resolve paths relative to this script so it works from any cwd.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SRC_TAURI_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+OUT_DIR="$SRC_TAURI_DIR/resources/ort"
+mkdir -p "$OUT_DIR"
+
+# Detect platform. The triples match what Microsoft publishes on the
+# onnxruntime release page. ARM macs ship a universal dylib under the
+# `osx-universal2` asset; we prefer it for a single shipping artifact
+# across Intel + Apple Silicon.
+case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*) PLATFORM="win-x64"; ARCHIVE_EXT="zip"; LIB_NAME="onnxruntime.dll" ;;
+    Linux)                PLATFORM="linux-x64"; ARCHIVE_EXT="tgz"; LIB_NAME="libonnxruntime.so.${ORT_VERSION}" ;;
+    Darwin)               PLATFORM="osx-universal2"; ARCHIVE_EXT="tgz"; LIB_NAME="libonnxruntime.${ORT_VERSION}.dylib" ;;
+    *) echo "Unsupported OS: $(uname -s)"; exit 1 ;;
+esac
+
+ASSET="onnxruntime-${PLATFORM}-${ORT_VERSION}.${ARCHIVE_EXT}"
+URL="https://github.com/microsoft/onnxruntime/releases/download/v${ORT_VERSION}/${ASSET}"
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+echo "[onnxruntime] Fetching $URL"
+curl -sSfL -o "$TMP/$ASSET" "$URL"
+
+echo "[onnxruntime] Extracting $ASSET"
+if [ "$ARCHIVE_EXT" = "zip" ]; then
+    unzip -q "$TMP/$ASSET" -d "$TMP"
+else
+    tar -xzf "$TMP/$ASSET" -C "$TMP"
+fi
+
+# Microsoft's archive layout: onnxruntime-<platform>-<ver>/lib/<libfile>.
+EXTRACTED_LIB="$(find "$TMP" -type f -name "$LIB_NAME" | head -n1)"
+if [ -z "$EXTRACTED_LIB" ]; then
+    echo "Could not find $LIB_NAME inside the archive — layout may have changed"
+    exit 1
+fi
+
+cp -f "$EXTRACTED_LIB" "$OUT_DIR/$(basename "$EXTRACTED_LIB")"
+# On Linux the file is named libonnxruntime.so.1.23.0 but the `ort`
+# crate's load-dynamic looks for `libonnxruntime.so`. Create a
+# stable symlink alongside so either name resolves.
+if [ "$(uname -s)" = "Linux" ]; then
+    ln -sf "libonnxruntime.so.${ORT_VERSION}" "$OUT_DIR/libonnxruntime.so"
+fi
+
+echo "[onnxruntime] Installed to $OUT_DIR/"
+ls -l "$OUT_DIR/"

--- a/ClassNoteAI/src-tauri/src/lib.rs
+++ b/ClassNoteAI/src-tauri/src/lib.rs
@@ -2074,6 +2074,41 @@ pub fn run() {
             // 前端可透過 invoke 呼叫開啟
             // 不再自動開啟
 
+            // Phase 2 follow-up: point ORT at the bundled onnxruntime
+            // binary BEFORE init_onnx(). Without this override the
+            // `ort` crate's `load-dynamic` walks PATH and typically
+            // picks up whatever older onnxruntime.dll Office / Edge /
+            // Copilot left on a Windows box (1.17.x), which fails
+            // ort-rc.9's ≥1.23.x version check and silently disables
+            // Silero VAD. Setting ORT_DYLIB_PATH to our pinned 1.23.0
+            // copy makes this deterministic — `ort::init()` checks
+            // that env var first, before any PATH lookup.
+            //
+            // Bundled file is fetched into `resources/ort/` by
+            // `scripts/fetch-onnxruntime.sh` at release build time.
+            // Missing file on local dev is fine — we just fall
+            // through to the normal PATH search.
+            if let Ok(resource_dir) = app.handle().path().resource_dir() {
+                let ort_dir = resource_dir.join("resources").join("ort");
+                let dll_name = if cfg!(target_os = "windows") {
+                    "onnxruntime.dll"
+                } else if cfg!(target_os = "macos") {
+                    "libonnxruntime.1.23.0.dylib"
+                } else {
+                    "libonnxruntime.so.1.23.0"
+                };
+                let bundled = ort_dir.join(dll_name);
+                if bundled.exists() {
+                    std::env::set_var("ORT_DYLIB_PATH", &bundled);
+                    println!("[ORT] ORT_DYLIB_PATH set to bundled {:?}", bundled);
+                } else {
+                    eprintln!(
+                        "[ORT] Bundled onnxruntime not found at {:?} — falling back to system PATH search",
+                        bundled
+                    );
+                }
+            }
+
             // Initialize ONNX Runtime
             utils::onnx::init_onnx();
 

--- a/ClassNoteAI/src-tauri/tauri.conf.json
+++ b/ClassNoteAI/src-tauri/tauri.conf.json
@@ -53,7 +53,8 @@
     ],
     "resources": {
       "resources/cuda/*": "./",
-      "resources/silero/*": "./resources/silero/"
+      "resources/silero/*": "./resources/silero/",
+      "resources/ort/*": "./resources/ort/"
     },
     "macOS": {
       "entitlements": null,


### PR DESCRIPTION
Phase 2 follow-up from PR #125. Closes the gap that was flagged as "will actually activate in production?" — today the answer is **no** on most Windows boxes because `ort`'s `load-dynamic` picks up whatever older onnxruntime.dll Office / Edge / Copilot left on PATH (typically 1.17.x), fails ort-rc.9's ≥1.23.x version check, and silently falls through to energy VAD.

## Fix

### Set `ORT_DYLIB_PATH` in the Tauri setup hook

`lib.rs::run()` now checks `resource_dir/resources/ort/` for a platform-appropriate onnxruntime binary (`.dll` / `.dylib` / `.so`). If present, `ORT_DYLIB_PATH` is set BEFORE `utils::onnx::init_onnx()`, so `ort::init()` uses our pinned copy instead of PATH. Missing file is fine — falls through to the normal PATH search (dev-build friendly).

### Bundle pipeline

- `scripts/fetch-onnxruntime.sh` — cross-platform download helper, pins onnxruntime 1.23.0.
- `tauri.conf.json` — new `"resources/ort/*"` entry next to the Silero model bundle.
- `.github/workflows/release-windows.yml` + `release-macos.yml` — invoke the fetch script after `bootstrap-vendor.sh`, before `npm ci`. ~3 s of curl per build.
- `.gitignore` — bundled binaries (14 MB Windows DLL / ~25 MB macOS dylib) too big for git; rebuilt on demand.

## Alternative rejected: `ort download-binaries`

Tried first. `ort-sys` and `sentencepiece-sys` (transitive via `ct2rs` for M2M100) both statically link protobuf, so linker fires **LNK2005 on every `google::protobuf::internal::WireFormatLite::*` symbol** + LNK1169 on the final binary. `load-dynamic` sidesteps it because ort finds onnxruntime's protobuf at dlopen time, not link time.

## Verified on this Windows machine

- `bash src-tauri/scripts/fetch-onnxruntime.sh` → downloads 14 MB DLL to `resources/ort/`
- `cargo check` → clean
- `cargo build --release --example phase2_vad_eval` → builds
- Phase 2 eval with bundled paths → **Silero detects 11 segs / 74.5 s speech** (vs 9 / 71.0 s for energy), byte-for-byte identical to the original Phase 2 eval report. Bundling approach reproduces the quality win.

## Follow-up (not blocking)

Full installer verification needs a `cargo tauri build` on a clean Windows box. CI pr-check does `cargo build` but not the Tauri bundler. Dry-run once before the next release tag.

## Test plan

- [ ] CI pr-check-windows + pr-check-macos pass
- [ ] Manual: `cargo tauri build --release` on Windows, install, verify `[ORT] ORT_DYLIB_PATH set to bundled ...` in logs + caption segmentation matches Silero behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)