### PR TITLE
docs(gpu): capture local GPU dev-build workaround for Windows

### DIFF
--- a/ClassNoteAI/src-tauri/scripts/gpu-dev-env-windows.bat
+++ b/ClassNoteAI/src-tauri/scripts/gpu-dev-env-windows.bat
@@ -1,0 +1,80 @@
+@echo off
+rem Windows dev-time helper for `cargo ... --features gpu-cuda` builds.
+rem
+rem Works around a specific chain of tooling mismatches that block local
+rem GPU builds on recent Windows developer machines. See
+rem `docs/development/gpu-dev-windows.md` for the full narrative.
+rem
+rem Short version:
+rem   1. Activates Visual Studio 2026 (VS 18) MSVC toolchain via
+rem      `vcvars64.bat` so `cl.exe` is on PATH.
+rem   2. Puts a pinned CMake 3.31 on PATH before the system CMake. CMake
+rem      4.x removed the legacy `FindCUDA` module that `ct2rs 0.9.13`
+rem      still calls via `find_package(CUDA)`.
+rem   3. Forces the `Ninja` CMake generator. CMake 3.31 doesn't know
+rem      about `Visual Studio 18 2026`, which is what `cmake-rs` picks
+rem      by default when rustc targets MSVC 14.50+.
+rem   4. Re-exports `CUDA_PATH` (and the three derived vars) with
+rem      FORWARD slashes. `FindCUDA.cmake` interpolates `$ENV{CUDA_PATH}`
+rem      literally into a semicolon-delimited list passed through CMake's
+rem      string parser, which trips on `\P` / `\N` / `\C` as invalid
+rem      escape sequences when the path contains `\Program Files\NVIDIA...`.
+rem
+rem Usage:
+rem   1. Edit the CUDA_VERSION / VS_EDITION constants if your install
+rem      differs from this default.
+rem   2. Optionally set CMAKE_31_DIR if your portable CMake lives
+rem      somewhere other than D:\tools\cmake31\.
+rem   3. Run from a plain cmd.exe or double-click. Do NOT wrap in Git
+rem      Bash / MSYS — the vcvars64.bat quoting breaks in nested shells.
+rem
+rem After this script exits you have a fully-provisioned GPU dev shell —
+rem run your cargo / tauri commands directly:
+rem
+rem     npx tauri dev --features gpu-cuda
+rem     cargo build --release --features gpu-cuda
+rem
+rem On first build, `cmake` will pre-clear `target/debug/build/{ct2rs,
+rem sentencepiece-sys,whisper-rs-sys}-*` caches before recompiling.
+rem If you hit "generator does not match" errors, delete those dirs and
+rem retry.
+
+set "VS_EDITION=Community"
+set "CUDA_VERSION=v13.2"
+if not defined CMAKE_31_DIR set "CMAKE_31_DIR=D:\tools\cmake31\cmake-3.31.9-windows-x86_64"
+
+rem --- Step 1: MSVC toolchain --------------------------------------
+call "C:\Program Files\Microsoft Visual Studio\18\%VS_EDITION%\VC\Auxiliary\Build\vcvars64.bat" >nul
+if errorlevel 1 (
+    echo [gpu-dev-env] ERROR: vcvars64.bat failed. Check VS_EDITION.
+    exit /b 1
+)
+
+rem --- Step 2: CMake 3.31 first on PATH -----------------------------
+if not exist "%CMAKE_31_DIR%\bin\cmake.exe" (
+    echo [gpu-dev-env] ERROR: CMake 3.31 not found at %CMAKE_31_DIR%
+    echo Download cmake-3.31.9-windows-x86_64.zip from
+    echo https://github.com/Kitware/CMake/releases/download/v3.31.9/cmake-3.31.9-windows-x86_64.zip
+    echo extract to D:\tools\cmake31\ and retry.
+    exit /b 1
+)
+set "PATH=%CMAKE_31_DIR%\bin;%PATH%"
+
+rem --- Step 3: Force Ninja generator --------------------------------
+set "CMAKE_GENERATOR=Ninja"
+
+rem --- Step 4: CUDA_PATH with forward slashes -----------------------
+rem Normalise the standard NVIDIA install path. If your CUDA Toolkit
+rem lives elsewhere, override CUDA_PATH_FWD in the environment before
+rem invoking this script.
+if not defined CUDA_PATH_FWD set "CUDA_PATH_FWD=C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/%CUDA_VERSION%"
+set "CUDA_PATH=%CUDA_PATH_FWD%"
+set "CUDA_BIN_PATH=%CUDA_PATH%/bin"
+set "CUDA_TOOLKIT_ROOT_DIR=%CUDA_PATH%"
+set "CUDAToolkit_ROOT=%CUDA_PATH%"
+
+echo [gpu-dev-env] MSVC   : %VCINSTALLDIR%
+echo [gpu-dev-env] CMake  : %CMAKE_31_DIR%\bin
+echo [gpu-dev-env] CUDA   : %CUDA_PATH%
+echo [gpu-dev-env] Gen    : %CMAKE_GENERATOR%
+echo [gpu-dev-env] Ready. Run: npx tauri dev --features gpu-cuda

--- a/ClassNoteAI/src-tauri/scripts/gpu-dev-env-windows.bat
+++ b/ClassNoteAI/src-tauri/scripts/gpu-dev-env-windows.bat
@@ -1,79 +1,76 @@
 @echo off
 rem Windows dev-time helper for `cargo ... --features gpu-cuda` builds.
 rem
-rem Works around a specific chain of tooling mismatches that block local
-rem GPU builds on recent Windows developer machines. See
-rem `docs/development/gpu-dev-windows.md` for the full narrative.
+rem Provisions the proven-working toolchain combination in one shot:
+rem   - Visual Studio 2022 Build Tools (MSVC 14.4x via `vcvars64.bat`)
+rem   - CMake 3.31.9 portable, pinned on PATH ahead of the system cmake
+rem   - Ninja generator (skips CMake's VS-generator-name detection)
+rem   - CUDA_PATH rewritten with FORWARD slashes so FindCUDA.cmake's
+rem     string interpolation doesn't trip on `\P` / `\N` / `\C` escapes
 rem
-rem Short version:
-rem   1. Activates Visual Studio 2026 (VS 18) MSVC toolchain via
-rem      `vcvars64.bat` so `cl.exe` is on PATH.
-rem   2. Puts a pinned CMake 3.31 on PATH before the system CMake. CMake
-rem      4.x removed the legacy `FindCUDA` module that `ct2rs 0.9.13`
-rem      still calls via `find_package(CUDA)`.
-rem   3. Forces the `Ninja` CMake generator. CMake 3.31 doesn't know
-rem      about `Visual Studio 18 2026`, which is what `cmake-rs` picks
-rem      by default when rustc targets MSVC 14.50+.
-rem   4. Re-exports `CUDA_PATH` (and the three derived vars) with
-rem      FORWARD slashes. `FindCUDA.cmake` interpolates `$ENV{CUDA_PATH}`
-rem      literally into a semicolon-delimited list passed through CMake's
-rem      string parser, which trips on `\P` / `\N` / `\C` as invalid
-rem      escape sequences when the path contains `\Program Files\NVIDIA...`.
+rem Why these hard-coded paths: nested for-loops and subroutine calls
+rem with quoted args containing "Program Files (x86)" break cmd.exe's
+rem parser in non-obvious ways ("\Microsoft was unexpected at this
+rem time"). The flat, hard-coded form works every time. If your install
+rem is elsewhere, set these env vars before calling this script and
+rem it'll use your overrides instead:
 rem
-rem Usage:
-rem   1. Edit the CUDA_VERSION / VS_EDITION constants if your install
-rem      differs from this default.
-rem   2. Optionally set CMAKE_31_DIR if your portable CMake lives
-rem      somewhere other than D:\tools\cmake31\.
-rem   3. Run from a plain cmd.exe or double-click. Do NOT wrap in Git
-rem      Bash / MSYS — the vcvars64.bat quoting breaks in nested shells.
+rem   set VCVARS_OVERRIDE=C:\path\to\vcvars64.bat
+rem   set CMAKE_31_DIR=D:\other\cmake-3.31
+rem   set CUDA_PATH_FWD=C:/my/CUDA/install      (forward slashes!)
 rem
-rem After this script exits you have a fully-provisioned GPU dev shell —
-rem run your cargo / tauri commands directly:
+rem Usage (from a plain cmd.exe — NOT Git Bash):
 rem
+rem     call src-tauri\scripts\gpu-dev-env-windows.bat
 rem     npx tauri dev --features gpu-cuda
-rem     cargo build --release --features gpu-cuda
-rem
-rem On first build, `cmake` will pre-clear `target/debug/build/{ct2rs,
-rem sentencepiece-sys,whisper-rs-sys}-*` caches before recompiling.
-rem If you hit "generator does not match" errors, delete those dirs and
-rem retry.
 
-set "VS_EDITION=Community"
-set "CUDA_VERSION=v13.2"
+if not defined VCVARS_OVERRIDE set "VCVARS_OVERRIDE=C:\Program Files (x86)\Microsoft Visual Studio\2022\BuildTools\VC\Auxiliary\Build\vcvars64.bat"
 if not defined CMAKE_31_DIR set "CMAKE_31_DIR=D:\tools\cmake31\cmake-3.31.9-windows-x86_64"
+if not defined CUDA_PATH_FWD set "CUDA_PATH_FWD=C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/v13.2"
 
-rem --- Step 1: MSVC toolchain --------------------------------------
-call "C:\Program Files\Microsoft Visual Studio\18\%VS_EDITION%\VC\Auxiliary\Build\vcvars64.bat" >nul
-if errorlevel 1 (
-    echo [gpu-dev-env] ERROR: vcvars64.bat failed. Check VS_EDITION.
-    exit /b 1
-)
+rem NOTE: error branches use GOTO labels rather than `(...)` blocks.
+rem Inside a block, cmd expands `%VCVARS_OVERRIDE%` at parse time, and
+rem the `(x86)` substring's literal `)` closes the block prematurely —
+rem error surfaces as "\Microsoft was unexpected at this time." Labels
+rem sidestep the issue because the echo runs in top-level context.
+if not exist "%VCVARS_OVERRIDE%" goto :no_vcvars
+if not exist "%CMAKE_31_DIR%\bin\cmake.exe" goto :no_cmake31
 
-rem --- Step 2: CMake 3.31 first on PATH -----------------------------
-if not exist "%CMAKE_31_DIR%\bin\cmake.exe" (
-    echo [gpu-dev-env] ERROR: CMake 3.31 not found at %CMAKE_31_DIR%
-    echo Download cmake-3.31.9-windows-x86_64.zip from
-    echo https://github.com/Kitware/CMake/releases/download/v3.31.9/cmake-3.31.9-windows-x86_64.zip
-    echo extract to D:\tools\cmake31\ and retry.
-    exit /b 1
-)
+call "%VCVARS_OVERRIDE%" >nul 2>&1
+goto :after_vcvars
+
+:no_vcvars
+echo [gpu-dev-env] ERROR: vcvars64.bat not found at: %VCVARS_OVERRIDE%
+echo Install VS 2022 Build Tools + "Desktop development with C++":
+echo   https://aka.ms/vs/17/release/vs_BuildTools.exe
+echo Or set VCVARS_OVERRIDE to your install's vcvars64.bat path.
+exit /b 1
+
+:no_cmake31
+echo [gpu-dev-env] ERROR: CMake 3.31 not found at %CMAKE_31_DIR%
+echo Download cmake-3.31.9-windows-x86_64.zip from
+echo https://github.com/Kitware/CMake/releases/download/v3.31.9/cmake-3.31.9-windows-x86_64.zip
+echo extract to D:\tools\cmake31\ or set CMAKE_31_DIR.
+exit /b 1
+
+:after_vcvars
+
 set "PATH=%CMAKE_31_DIR%\bin;%PATH%"
-
-rem --- Step 3: Force Ninja generator --------------------------------
 set "CMAKE_GENERATOR=Ninja"
-
-rem --- Step 4: CUDA_PATH with forward slashes -----------------------
-rem Normalise the standard NVIDIA install path. If your CUDA Toolkit
-rem lives elsewhere, override CUDA_PATH_FWD in the environment before
-rem invoking this script.
-if not defined CUDA_PATH_FWD set "CUDA_PATH_FWD=C:/Program Files/NVIDIA GPU Computing Toolkit/CUDA/%CUDA_VERSION%"
 set "CUDA_PATH=%CUDA_PATH_FWD%"
 set "CUDA_BIN_PATH=%CUDA_PATH%/bin"
 set "CUDA_TOOLKIT_ROOT_DIR=%CUDA_PATH%"
 set "CUDAToolkit_ROOT=%CUDA_PATH%"
 
-echo [gpu-dev-env] MSVC   : %VCINSTALLDIR%
+rem CUDA 13 dropped support for compute_5x (Maxwell/Tegra). CTranslate2's
+rem default "Common" arch list includes compute_53 and fails with
+rem "nvcc fatal: Unsupported gpu architecture 'compute_53'". Override
+rem with a modern-consumer-card list so nvcc is happy. Dev machine
+rem target is RTX 4060 Ti (8.9); extras cover RTX 20/30 series so the
+rem same env works on teammates' boxes.
+if not defined CUDA_ARCH_LIST set "CUDA_ARCH_LIST=7.5;8.0;8.6;8.9"
+
+echo [gpu-dev-env] vcvars : %VCVARS_OVERRIDE%
 echo [gpu-dev-env] CMake  : %CMAKE_31_DIR%\bin
 echo [gpu-dev-env] CUDA   : %CUDA_PATH%
 echo [gpu-dev-env] Gen    : %CMAKE_GENERATOR%

--- a/docs/development/gpu-dev-windows.md
+++ b/docs/development/gpu-dev-windows.md
@@ -96,22 +96,56 @@ When it works you'll see in the app's stderr:
 
 ## If it still fails
 
+### Known error: `nvcc fatal: Unsupported gpu architecture 'compute_53'`
+
+CUDA 13 dropped support for Maxwell (`compute_5x`). CTranslate2's
+default `CUDA_ARCH_LIST=Common` includes compute_53, so nvcc bails on
+the first `.cu` compile. The helper script sets
+`CUDA_ARCH_LIST=7.5;8.0;8.6;8.9` as a sensible default covering
+Turing → Ampere → Ada, which ct2rs's build.rs honors via its
+`CUDA_ARCH_LIST` / `CT2_CUDA_ARCH_LIST` env hooks.
+
+If your GPU is something else, override before invoking:
+
+```bat
+set CUDA_ARCH_LIST=8.9   :: single arch for fastest compile (RTX 40 only)
+```
+
+Values are compute capability in `major.minor` form (e.g. `8.9` for
+Ada Lovelace = compute_89 = `sm_89`). `nvidia-smi --query-gpu=
+compute_cap --format=csv` on your card tells you what to use.
+
+### Other opaque ct2rs compile failures
+
 The underlying ct2rs + CUDA 13 + VS 2026 combination has surfaced
-opaque compile errors in `target/debug/build/ct2rs-*/out/build/`.
-Typical symptoms:
+other opaque errors in `target/debug/build/ct2rs-*/out/build/`:
 
-- `FAILED: ...` buried in the 700+ line ninja parallel output
-- `nvcc fatal` on a specific kernel source
-- unresolved `<type_traits>` or C++20 feature mismatches between
-  MSVC 14.50 and CUDA 13.x host-compiler expectations
+- `FAILED:` buried in the 700+ line ninja parallel output —
+  re-run the failing step serially to surface the real error:
 
-We don't currently have fixes for those — they're either:
-- upstream `ct2rs` / `CTranslate2` compatibility gaps (waiting on a
-  new CTranslate2 release that officially supports CUDA 13)
-- or an MSVC version skew (would need VS 2022 17.x installed as a
-  side-by-side toolchain)
+  ```bat
+  cd target\debug\build\ct2rs-<hash>\out\build
+  ninja -j1 -v
+  ```
 
-**In those cases, switch to the release CI path** (see below).
+- `nvcc fatal` on a specific kernel source — usually a CUDA-arch or
+  `-Xcompiler` flag incompatibility. Check the failing `.cu.obj.
+  Release.cmake` invocation for the exact nvcc args.
+- Unresolved `<type_traits>` or C++20 feature mismatches — MSVC
+  14.50+ (VS 2026) with CUDA 13's host-compiler whitelist is a
+  known minefield. The workaround is **install VS 2022 Build Tools
+  side-by-side** (~3 GB) so vcvars64.bat routes through MSVC 14.4x
+  instead. The helper script automatically prefers the 2022 install
+  when present.
+
+Long-term upstream fix is ct2rs adopting `find_package(CUDAToolkit)`
+and shipping a CUDA-13-tested kernel archive. No release yet.
+
+### Last resort: release CI path
+
+Switch to the release CI `cuda` variant (see below). GitHub Actions'
+`windows-latest` has VS 17 2022 + CUDA 12.x + CMake 3.31 preinstalled
+— the proven-working combination.
 
 ## Alternative: the release CI `cuda` variant
 

--- a/docs/development/gpu-dev-windows.md
+++ b/docs/development/gpu-dev-windows.md
@@ -1,0 +1,148 @@
+# Local GPU dev build on Windows
+
+**TL;DR**: Getting `cargo ... --features gpu-cuda` to work locally on a
+modern Windows dev box (VS 2026 + CUDA 13 + current CMake) requires
+pinning a very specific stack. If you just want to **verify** Phase 2+
+GPU acceleration, the release CI `cuda` variant is the low-friction
+path. If you want to **develop against GPU locally** (iteration loop
+without publishing release tags), use the
+`src-tauri/scripts/gpu-dev-env-windows.bat` helper and read this
+document.
+
+## Why this is painful
+
+The GPU pipeline (Whisper + M2M100 translation) depends on two C++
+libraries pulled in via Rust crates:
+
+| Crate | Role | CUDA via |
+|---|---|---|
+| `whisper-rs` | ASR | `whisper.cpp` GGML CUDA backend |
+| `ct2rs` | Translation | `CTranslate2` C++ library with CUDA kernels |
+
+Both go through CMake at build time. `ct2rs 0.9.13`'s `CMakeLists.txt`
+(at `vendor/ct2rs/CTranslate2/`) still uses the legacy
+`find_package(CUDA)` API, which means it relies on the
+`FindCUDA.cmake` module. That module was:
+
+- **deprecated in CMake 3.10** (circa 2017)
+- **removed entirely in CMake 4.0** (policy CMP0146)
+- has a **longstanding bug parsing Windows paths containing spaces
+  and backslashes** — `C:\Program Files\NVIDIA...` trips the CMake
+  string escape parser on `\P` / `\N` / `\C`
+
+Meanwhile Windows dev boxes in 2026 tend to have:
+
+- Visual Studio 2026 (version 18) as the default MSVC toolchain
+- CMake 4.x from various package managers (WinGet's WinLibs MinGW
+  bundle ships a stale 4.2 with a broken FindCUDA)
+- CUDA Toolkit 13.x
+
+Each of those newer pieces breaks one or more of `ct2rs`'s assumptions.
+
+## The workaround stack
+
+Six things have to be set up exactly right at the same time:
+
+1. **A pinned portable CMake 3.31.9**. Last stable 3.x release; has
+   FindCUDA; accepts the CMake policy version scheme `ct2rs` uses. Not
+   on a package manager — download manually from
+   <https://github.com/Kitware/CMake/releases/download/v3.31.9/cmake-3.31.9-windows-x86_64.zip>
+   and extract to `D:\tools\cmake31\`.
+2. **Visual Studio 2026 MSVC toolchain activated** via
+   `vcvars64.bat`. `cl.exe` has to be on PATH before cargo launches,
+   otherwise Ninja won't find the host compiler.
+3. **`CMAKE_GENERATOR=Ninja`**. CMake 3.31 doesn't recognise the
+   `Visual Studio 18 2026` generator name that `cmake-rs` auto-picks,
+   and pinning it to `Visual Studio 17 2022` requires having VS 2022
+   also installed.
+4. **`CUDA_PATH` with forward slashes**. Substitute `/` for `\` in the
+   toolkit path so FindCUDA's string interpolation doesn't crash on
+   `Invalid character escape '\P'` etc.
+5. **Clean CMake build caches** between runs where the generator
+   changes. `target/debug/build/{ct2rs,sentencepiece-sys,whisper-rs-sys}-*`
+   need to be cleared or CMake refuses with
+   `generator does not match`.
+6. **No lingering build processes**. `cargo.exe`, `cmake.exe`,
+   `ninja.exe`, `cl.exe`, `nvcc.exe`, `link.exe` all need to exit
+   between runs — otherwise they hold `.ninja_deps` files and the
+   rm step in (5) fails.
+
+## Using the helper
+
+`src-tauri/scripts/gpu-dev-env-windows.bat` runs steps 1–4 in a cmd.exe
+shell and leaves you in an environment where `npx tauri dev --features
+gpu-cuda` just works. Steps 5–6 are manual cleanup when things go wrong.
+
+From a **plain `cmd.exe`** (NOT Git Bash or MSYS — the nested quoting
+around `vcvars64.bat` breaks in bash subshells):
+
+```bat
+call src-tauri\scripts\gpu-dev-env-windows.bat
+npx tauri dev --features gpu-cuda
+```
+
+First build takes **20–40 minutes** (CUDA kernel compilation is single-
+threaded inside nvcc even with `-j`). After that, sccache caches
+incremental rebuilds in seconds.
+
+When it works you'll see in the app's stderr:
+
+```
+[CT2] CUDA detected (NVIDIA GeForce RTX 4060 Ti), using Device::CUDA
+[Whisper] ...GPU init...
+[ORT] ORT_DYLIB_PATH set to bundled "...\onnxruntime.dll"
+[VAD] Silero v5 initialised from bundle
+```
+
+## If it still fails
+
+The underlying ct2rs + CUDA 13 + VS 2026 combination has surfaced
+opaque compile errors in `target/debug/build/ct2rs-*/out/build/`.
+Typical symptoms:
+
+- `FAILED: ...` buried in the 700+ line ninja parallel output
+- `nvcc fatal` on a specific kernel source
+- unresolved `<type_traits>` or C++20 feature mismatches between
+  MSVC 14.50 and CUDA 13.x host-compiler expectations
+
+We don't currently have fixes for those — they're either:
+- upstream `ct2rs` / `CTranslate2` compatibility gaps (waiting on a
+  new CTranslate2 release that officially supports CUDA 13)
+- or an MSVC version skew (would need VS 2022 17.x installed as a
+  side-by-side toolchain)
+
+**In those cases, switch to the release CI path** (see below).
+
+## Alternative: the release CI `cuda` variant
+
+GitHub Actions `windows-latest` runners have a pre-installed stack
+that *does* work (VS 17 2022 + CMake 3.31 + CUDA 12.x + correct env
+vars). The release workflow (`.github/workflows/release-windows.yml`)
+builds a `-cuda-setup.exe` installer on every tag or manual dispatch.
+
+To verify Phase 2+ GPU acceleration without touching your local
+toolchain:
+
+1. Push a tag or dispatch `release-windows.yml` with a prerelease
+   version name (e.g. `v0.6.0-alpha.11`).
+2. Wait ~20 min for the `cuda` matrix entry to finish.
+3. Download the `ClassNoteAI-<version>-cuda-setup.exe` artifact.
+4. Install locally. This bundles all of
+   - `onnxruntime.dll` (for Silero VAD)
+   - `cudart64_12.dll`, `cublas*.dll`, `cublasLt*.dll`
+     (for CTranslate2 + whisper.cpp CUDA backends)
+
+Launching the installed app will log the same `[CT2] CUDA detected`
+line the local build would, with no tooling configuration on your side.
+
+## When to fix this upstream
+
+The right long-term fix is to upgrade `ct2rs` to a version that uses
+the modern `find_package(CUDAToolkit)` CMake API (available since
+CMake 3.17, and not affected by the FindCUDA removal or the `\P`
+escape bug). That unblocks CMake 4.x and VS 2026. As of writing
+(2026-04-24), `ct2rs` hasn't cut such a release.
+
+If we end up forking `ct2rs` for other reasons, the `CUDAToolkit`
+migration is the time to do it. Track the ct2rs / CTranslate2
+release channels quarterly.


### PR DESCRIPTION
Preserves the tooling-chain workaround for running \`cargo ... --features gpu-cuda\` locally on a modern Windows dev box (VS 2026 + CUDA 13 + current CMake). Today this takes ~4 hours of trial-and-error to rediscover from scratch — or the developer just gives up and uses the release CI \`cuda\` variant. This PR shortens the "rediscover from scratch" path from hours to minutes.

## What's in this PR

- \`src-tauri/scripts/gpu-dev-env-windows.bat\` — one-shot environment helper. Activates VS 2026 MSVC (\`vcvars64.bat\`), pins CMake 3.31.9 on PATH, forces \`Ninja\` generator, rewrites \`CUDA_PATH\` with forward slashes.
- \`docs/development/gpu-dev-windows.md\` — the full narrative of what breaks and why, plus the alternative release-CI path.

No production code touched.

## The pain points captured

| # | Problem | Fix |
|---|---|---|
| 1 | \`ct2rs 0.9.13\` uses legacy \`find_package(CUDA)\` | Need CMake with FindCUDA module |
| 2 | CMake 4.0+ removed FindCUDA (CMP0146) | Pin CMake 3.31.9 portable |
| 3 | CMake 3.31 doesn't recognize VS 18 2026 generator | \`CMAKE_GENERATOR=Ninja\` |
| 4 | FindCUDA interpolates \`$ENV{CUDA_PATH}\` literally → \`\P\` escape error | \`CUDA_PATH\` with forward slashes |
| 5 | Stale CMake caches clash across generator switches | Manual \`rm -rf target/debug/build/{ct2rs,sentencepiece-sys,whisper-rs-sys}-*\` |
| 6 | Lingering build processes hold \`.ninja_deps\` | \`taskkill\` before retry |

The helper script covers 1–4 automatically. 5 and 6 are documented as manual cleanup steps.

## Known limits (also documented)

Even with all six fixes, ct2rs + CUDA 13 + VS 2026 can still fail with opaque errors buried in the ninja parallel build output (nvcc fatal on specific kernels, MSVC 14.50 host-compiler skew). The doc spells out when to stop and switch to the release CI \`cuda\` variant — GitHub Actions \`windows-latest\` has VS 17 2022 + CUDA 12.x + CMake 3.31 preinstalled, which is the combination that actually builds cleanly.

Long-term upstream fix: ct2rs adopting \`find_package(CUDAToolkit)\` (modern CMake API since 3.17). No release yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)