### PR TITLE
ci: bundle llama sidecar variants

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -24,6 +24,7 @@ env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   RUSTUP_MAX_RETRIES: 10
+  LLAMA_CPP_RELEASE_TAG: b8933
 
 defaults:
   run:
@@ -126,6 +127,33 @@ jobs:
       # a known-good 1.23.0 instead of whatever else might be on path.
       - name: Fetch bundled ONNX Runtime (Silero VAD dep)
         run: bash src-tauri/scripts/fetch-onnxruntime.sh
+
+      - name: Stage llama.cpp sidecar (Apple Silicon)
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          OUT_DIR="src-tauri/resources/binaries"
+          TMP_DIR="$RUNNER_TEMP/llama-cpp-macos"
+          ASSET="llama-${LLAMA_CPP_RELEASE_TAG}-bin-macos-arm64.tar.gz"
+
+          rm -rf "$TMP_DIR"
+          mkdir -p "$TMP_DIR" "$OUT_DIR"
+          find "$OUT_DIR" -mindepth 1 ! -name .gitkeep -exec rm -rf {} +
+
+          gh release download "$LLAMA_CPP_RELEASE_TAG" \
+            --repo ggml-org/llama.cpp \
+            --pattern "$ASSET" \
+            --dir "$TMP_DIR" \
+            --clobber
+          tar -xzf "$TMP_DIR/$ASSET" -C "$TMP_DIR"
+
+          find "$TMP_DIR" -type f \( -name "llama-server" -o -name "*.dylib" \) \
+            -exec cp -f {} "$OUT_DIR/" \;
+
+          test -x "$OUT_DIR/llama-server" || chmod +x "$OUT_DIR/llama-server"
+          "$OUT_DIR/llama-server" --version
+          ls -la "$OUT_DIR"
 
       # ===== 安裝 npm 依賴 =====
       - name: Install dependencies

--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -21,6 +21,10 @@ env:
   CARGO_INCREMENTAL: 0
   CARGO_NET_RETRY: 10
   RUSTUP_MAX_RETRIES: 10
+  # Pin the llama.cpp sidecar bundle so releases are reproducible. The
+  # official assets include both CPU and CUDA Windows builds; the matrix below
+  # picks the one that matches the installer variant.
+  LLAMA_CPP_RELEASE_TAG: b8933
 
 defaults:
   run:
@@ -55,8 +59,8 @@ jobs:
           # split here only affects the Candle BGE embedding model
           # (used for PDF↔transcript alignment). Sidecar binaries are
           # bundled separately by the post-build packaging step.
-          - { id: cpu,  features: "",         suffix: "",      label: "CPU" }
-          - { id: cuda, features: "gpu-cuda", suffix: "-cuda", label: "CUDA" }
+          - { id: cpu,  features: "",         suffix: "",      label: "CPU",  llama_asset: "llama-b8933-bin-win-cpu-x64.zip",       llama_cudart_asset: "" }
+          - { id: cuda, features: "gpu-cuda", suffix: "-cuda", label: "CUDA", llama_asset: "llama-b8933-bin-win-cuda-12.4-x64.zip", llama_cudart_asset: "cudart-llama-bin-win-cuda-12.4-x64.zip" }
     name: build-windows-${{ matrix.variant.id }}
     steps:
       - name: Checkout
@@ -186,6 +190,53 @@ jobs:
       - name: Fetch bundled ONNX Runtime (Silero VAD dep)
         shell: bash
         run: bash src-tauri/scripts/fetch-onnxruntime.sh
+
+      - name: Stage llama.cpp sidecar (${{ matrix.variant.label }})
+        shell: pwsh
+        env:
+          GH_TOKEN: ${{ github.token }}
+          LLAMA_ASSET: ${{ matrix.variant.llama_asset }}
+          LLAMA_CUDART_ASSET: ${{ matrix.variant.llama_cudart_asset }}
+        run: |
+          $ErrorActionPreference = "Stop"
+
+          $outDir = "src-tauri/resources/binaries"
+          $tmpDir = Join-Path $env:RUNNER_TEMP "llama-cpp-${{ matrix.variant.id }}"
+          if (Test-Path $tmpDir) {
+            Remove-Item -Recurse -Force $tmpDir
+          }
+          New-Item -ItemType Directory -Force $tmpDir | Out-Null
+          New-Item -ItemType Directory -Force $outDir | Out-Null
+
+          Get-ChildItem -Path $outDir -Force |
+            Where-Object { $_.Name -ne ".gitkeep" } |
+            Remove-Item -Recurse -Force
+
+          $assets = @($env:LLAMA_ASSET)
+          if ($env:LLAMA_CUDART_ASSET) {
+            $assets += $env:LLAMA_CUDART_ASSET
+          }
+
+          foreach ($asset in $assets) {
+            gh release download $env:LLAMA_CPP_RELEASE_TAG `
+              --repo ggml-org/llama.cpp `
+              --pattern $asset `
+              --dir $tmpDir `
+              --clobber
+            Expand-Archive -Path (Join-Path $tmpDir $asset) -DestinationPath $tmpDir -Force
+          }
+
+          Get-ChildItem -Path $tmpDir -Recurse -File |
+            Where-Object { $_.Name -eq "llama-server.exe" -or $_.Extension -eq ".dll" } |
+            Copy-Item -Destination $outDir -Force
+
+          $server = Join-Path $outDir "llama-server.exe"
+          if (!(Test-Path $server)) {
+            Write-Error "llama-server.exe was not found after extracting llama.cpp assets."
+          }
+
+          & $server --version
+          Get-ChildItem -Path $outDir | Sort-Object Name | Format-Table Name,Length
 
       - name: Install dependencies
         run: npm ci --prefer-offline

--- a/ClassNoteAI/docs/sop/llama-sidecar-release.md
+++ b/ClassNoteAI/docs/sop/llama-sidecar-release.md
@@ -1,0 +1,24 @@
+# llama.cpp Sidecar Release Smoke
+
+Release builds must include a runnable `llama-server` sidecar:
+
+- Windows CPU installer bundles the official `win-cpu-x64` llama.cpp build.
+- Windows CUDA installer bundles the official `win-cuda-12.4-x64` build plus the matching cudart package.
+- macOS Apple Silicon bundles the official `macos-arm64` llama.cpp build.
+
+Quick binary smoke, no model required:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File ClassNoteAI/src-tauri/scripts/smoke-llama-sidecar.ps1 `
+  -BinaryDir ClassNoteAI/src-tauri/resources/binaries
+```
+
+Full local sidecar smoke with a downloaded TranslateGemma GGUF:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File ClassNoteAI/src-tauri/scripts/smoke-llama-sidecar.ps1 `
+  -BinaryDir ClassNoteAI/src-tauri/resources/binaries `
+  -ModelPath "$env:APPDATA\com.classnoteai\models\llm\translategemma-4b_Q4_K_M.gguf"
+```
+
+For the CUDA installer, add `-ExpectCuda` and confirm the sidecar log mentions CUDA backend loading.

--- a/ClassNoteAI/src-tauri/resources/binaries/.gitkeep
+++ b/ClassNoteAI/src-tauri/resources/binaries/.gitkeep
@@ -1,0 +1,11 @@
+# This directory is populated by release CI with runtime sidecar binaries.
+#
+# Windows release builds stage the llama.cpp `llama-server.exe` bundle here:
+# - CPU installer: official win-cpu-x64 llama.cpp bundle
+# - CUDA installer: official win-cuda-12.4-x64 llama.cpp bundle plus cudart DLLs
+#
+# Tauri copies this directory to `<resource_dir>/binaries/`, and
+# `translation::gemma_sidecar` starts `<resource_dir>/binaries/llama-server.exe`
+# before falling back to local dev paths or PATH lookup.
+#
+# Keep this .gitkeep so the resource path exists in fresh checkouts.

--- a/ClassNoteAI/src-tauri/scripts/smoke-llama-sidecar.ps1
+++ b/ClassNoteAI/src-tauri/scripts/smoke-llama-sidecar.ps1
@@ -1,0 +1,100 @@
+param(
+    [string]$BinaryDir = "resources/binaries",
+    [string]$ModelPath = "",
+    [int]$Port = 18080,
+    [switch]$ExpectCuda
+)
+
+$ErrorActionPreference = "Stop"
+
+$server = Join-Path $BinaryDir "llama-server.exe"
+if (!(Test-Path $server)) {
+    throw "llama-server.exe not found under $BinaryDir"
+}
+
+Write-Host "[llama-smoke] version:"
+& $server --version
+if ($LASTEXITCODE -ne 0) {
+    throw "llama-server --version failed with exit code $LASTEXITCODE"
+}
+
+if (!$ModelPath) {
+    Write-Host "[llama-smoke] no model path supplied; binary load smoke passed."
+    exit 0
+}
+
+if (!(Test-Path $ModelPath)) {
+    throw "Model file not found: $ModelPath"
+}
+
+$log = Join-Path ([System.IO.Path]::GetTempPath()) "classnoteai-llama-smoke-$Port.log"
+Remove-Item -Force $log -ErrorAction SilentlyContinue
+
+$args = @(
+    "-m", $ModelPath,
+    "-ngl", "99",
+    "-c", "1024",
+    "--port", "$Port",
+    "--host", "127.0.0.1",
+    "--no-jinja",
+    "--temp", "0.0"
+)
+
+Write-Host "[llama-smoke] starting $server on port $Port"
+$process = Start-Process `
+    -FilePath $server `
+    -ArgumentList $args `
+    -WorkingDirectory $BinaryDir `
+    -NoNewWindow `
+    -PassThru `
+    -RedirectStandardError $log `
+    -RedirectStandardOutput ([System.IO.Path]::GetTempFileName())
+
+try {
+    $deadline = (Get-Date).AddSeconds(45)
+    $healthy = $false
+    while ((Get-Date) -lt $deadline) {
+        try {
+            Invoke-RestMethod -Uri "http://127.0.0.1:$Port/health" -TimeoutSec 2 | Out-Null
+            $healthy = $true
+            break
+        } catch {
+            Start-Sleep -Milliseconds 500
+        }
+    }
+    if (!$healthy) {
+        Get-Content $log -ErrorAction SilentlyContinue
+        throw "llama-server health check timed out"
+    }
+
+    $body = @{
+        model = "local"
+        messages = @(@{ role = "user"; content = "Reply with OK only." })
+        max_tokens = 4
+        temperature = 0
+    } | ConvertTo-Json -Depth 5
+    $response = Invoke-RestMethod `
+        -Uri "http://127.0.0.1:$Port/v1/chat/completions" `
+        -Method Post `
+        -ContentType "application/json" `
+        -Body $body `
+        -TimeoutSec 30
+    $text = $response.choices[0].message.content
+    if (!$text) {
+        throw "llama-server returned an empty completion"
+    }
+
+    if ($ExpectCuda) {
+        $logText = Get-Content $log -Raw -ErrorAction SilentlyContinue
+        if ($logText -notmatch "CUDA|ggml_cuda|loaded CUDA") {
+            throw "CUDA was expected but the llama-server log did not mention CUDA"
+        }
+    }
+
+    Write-Host "[llama-smoke] completion: $text"
+} finally {
+    if ($process -and !$process.HasExited) {
+        Stop-Process -Id $process.Id -Force
+        $process.WaitForExit()
+    }
+}

--- a/ClassNoteAI/src-tauri/src/translation/gemma_sidecar.rs
+++ b/ClassNoteAI/src-tauri/src/translation/gemma_sidecar.rs
@@ -85,7 +85,11 @@ pub fn is_running() -> bool {
 
 /// Locate the llama-server binary. See module docs for resolution order.
 pub fn locate_binary(app_resource_dir: Option<&PathBuf>) -> Option<PathBuf> {
-    let exe_name = if cfg!(windows) { "llama-server.exe" } else { "llama-server" };
+    let exe_name = if cfg!(windows) {
+        "llama-server.exe"
+    } else {
+        "llama-server"
+    };
 
     // 1. Bundled in app resources
     if let Some(dir) = app_resource_dir {
@@ -148,6 +152,27 @@ pub fn locate_binary(app_resource_dir: Option<&PathBuf>) -> Option<PathBuf> {
     }
 
     None
+}
+
+#[cfg(windows)]
+fn prepend_to_path(cmd: &mut std::process::Command, dir: &std::path::Path) {
+    let mut paths: Vec<std::path::PathBuf> = std::env::var_os("PATH")
+        .map(|p| std::env::split_paths(&p).collect())
+        .unwrap_or_default();
+    paths.insert(0, dir.to_path_buf());
+    if let Ok(joined) = std::env::join_paths(paths) {
+        cmd.env("PATH", joined);
+    }
+}
+
+fn configure_sidecar_command(cmd: &mut std::process::Command, bin: &std::path::Path) {
+    if let Some(dir) = bin.parent() {
+        // Keep llama.cpp's sibling backend/runtime DLLs resolvable. This is
+        // important for the CUDA build and harmless for the CPU build.
+        cmd.current_dir(dir);
+        #[cfg(windows)]
+        prepend_to_path(cmd, dir);
+    }
 }
 
 /// Probe `http://127.0.0.1:<port>/health` once.
@@ -252,7 +277,9 @@ pub async fn ensure_running(
     let bin = match locate_binary(app_resource_dir.as_ref()) {
         Some(p) => p,
         None => {
-            eprintln!("[gemma_sidecar] llama-server binary not found in any of: bundled, dev path, PATH");
+            eprintln!(
+                "[gemma_sidecar] llama-server binary not found in any of: bundled, dev path, PATH"
+            );
             return BringUpResult::BinaryNotFound;
         }
     };
@@ -269,9 +296,10 @@ pub async fn ensure_running(
         model_path
     );
     let log_path = sidecar_log_path();
-    let stderr_target = match log_path.as_ref().and_then(|p| {
-        OpenOptions::new().create(true).append(true).open(p).ok()
-    }) {
+    let stderr_target = match log_path
+        .as_ref()
+        .and_then(|p| OpenOptions::new().create(true).append(true).open(p).ok())
+    {
         Some(f) => {
             if let Some(p) = log_path.as_ref() {
                 println!("[gemma_sidecar] llama-server stderr → {}", p.display());
@@ -288,6 +316,7 @@ pub async fn ensure_running(
         }
     };
     let mut cmd = no_window(&bin);
+    configure_sidecar_command(&mut cmd, &bin);
     cmd.args(server_args(model_path, port))
         // stdout still discarded — llama-server's progress chatter is
         // verbose and not actionable. stderr is what carries the

--- a/ClassNoteAI/src-tauri/tauri.conf.json
+++ b/ClassNoteAI/src-tauri/tauri.conf.json
@@ -52,6 +52,7 @@
       "icons/icon.ico"
     ],
     "resources": {
+      "resources/binaries/*": "./binaries/",
       "resources/cuda/*": "./",
       "resources/silero/*": "./resources/silero/",
       "resources/ort/*": "./resources/ort/"


### PR DESCRIPTION
## Summary
- bundle official llama.cpp sidecar binaries into release resources
- stage Windows CPU and CUDA llama-server variants, including CUDA runtime DLLs for the CUDA installer
- stage macOS Apple Silicon llama-server for TranslateGemma out-of-the-box
- make gemma_sidecar launch from the binary directory so sibling backend/runtime DLLs resolve
- add a PowerShell smoke script and release SOP note for llama-server sidecar validation

## Validation
- cargo check --profile=ci-check
- npm run build
- rustfmt --edition 2021 --check src/translation/gemma_sidecar.rs
- git diff --check
- PowerShell parser check for smoke-llama-sidecar.ps1
- downloaded official llama.cpp b8933 CPU bundle and ran llama-server.exe --version
- downloaded official llama.cpp b8933 CUDA + cudart bundles and ran staged llama-server.exe --version; verified CUDA backend loaded on local RTX 4060 Ti
