### PR TITLE
ci: include macOS llama dylib aliases

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -148,8 +148,9 @@ jobs:
             --clobber
           tar -xzf "$TMP_DIR/$ASSET" -C "$TMP_DIR"
 
-          find "$TMP_DIR" -type f \( -name "llama-server" -o -name "*.dylib" \) \
-            -exec cp -f {} "$OUT_DIR/" \;
+          find "$TMP_DIR" \( -type f -o -type l \) \
+            \( -name "llama-server" -o -name "*.dylib" -o -name "*.dylib.*" \) \
+            -exec cp -fL {} "$OUT_DIR/" \;
 
           test -x "$OUT_DIR/llama-server" || chmod +x "$OUT_DIR/llama-server"
           "$OUT_DIR/llama-server" --version
@@ -169,8 +170,8 @@ jobs:
       # ===== Apple code-signing setup =====
       # We import the Developer ID Application cert into a dedicated
       # keychain, then discover the identity name and export it for
-      # `tauri build` to consume. Skips cleanly on PR / manual runs that
-      # don't have the secrets set so unsigned local builds still work.
+      # `tauri build` to consume. Only tag builds import the certificate;
+      # manual/scheduled validation builds use the unsigned step below.
       - name: Import Apple code-signing certificate
         id: apple_cert
         if: startsWith(github.ref, 'refs/tags/')
@@ -211,12 +212,10 @@ jobs:
           echo "Discovered signing identity: $IDENTITY"
 
       # ===== Build Tauri =====
-      # When APPLE_* secrets are present, Tauri's macOS bundler signs the
-      # .app with APPLE_SIGNING_IDENTITY (discovered above) and notarizes
-      # via APPLE_ID / APPLE_PASSWORD (app-specific password) / APPLE_TEAM_ID.
-      # PR / manual runs without secrets skip signing — env vars just expand
-      # to empty strings and Tauri produces an unsigned dev bundle.
-      - name: Build Tauri (Apple Silicon)
+      # Tag builds are release builds: import the Developer ID cert above,
+      # sign/notarize here, then upload updater artifacts.
+      - name: Build Tauri (Apple Silicon / signed release)
+        if: startsWith(github.ref, 'refs/tags/')
         env:
           APPLE_SIGNING_IDENTITY: ${{ steps.apple_cert.outputs.signing_identity }}
           APPLE_ID: ${{ secrets.APPLE_ID }}
@@ -225,6 +224,14 @@ jobs:
         # v2 streaming refactor: in-process Whisper/CT2 are gone.
         # macOS Metal backend in Cargo.toml's [target.macos] now only
         # accelerates the Candle BGE embedding model.
+        run: npm run tauri build -- --target aarch64-apple-darwin
+
+      # Manual and scheduled runs are validation/cache-warming runs, not
+      # publishable releases. Do not pass empty APPLE_* variables: Tauri treats
+      # APPLE_SIGNING_IDENTITY="" as an explicit codesign identity and fails
+      # with "The specified item could not be found in the keychain."
+      - name: Build Tauri (Apple Silicon / unsigned validation)
+        if: "!startsWith(github.ref, 'refs/tags/')"
         run: npm run tauri build -- --target aarch64-apple-darwin
 
       # Intel x86_64 暫時禁用 - GitHub Actions macOS runner 不支持 AVX-512


### PR DESCRIPTION
Fix the macOS release staging step so llama.cpp sidecar bundles include symlinked/versioned dylib names such as libllama-common.0.dylib. The prior release run failed when dyld could not load that sibling library.