### PR TITLE
ci: keep CUDA release packaging lightweight

### DIFF
--- a/.github/workflows/release-windows.yml
+++ b/.github/workflows/release-windows.yml
@@ -54,13 +54,12 @@ jobs:
       fail-fast: false
       matrix:
         variant:
-          # v2 streaming refactor removed in-process Whisper + ct2rs;
-          # both ASR and translation now run as sidecars. The cpu/cuda
-          # split here only affects the Candle BGE embedding model
-          # (used for PDF↔transcript alignment). Sidecar binaries are
-          # bundled separately by the post-build packaging step.
+          # The CUDA variant is a packaging variant: it ships the CUDA
+          # llama.cpp sidecar and runtime DLLs, then reports the
+          # windows-x86_64-cuda updater target. It intentionally avoids
+          # the heavier Rust gpu-cuda backend in CI.
           - { id: cpu,  features: "",         suffix: "",      label: "CPU",  llama_asset: "llama-b8933-bin-win-cpu-x64.zip",       llama_cudart_asset: "" }
-          - { id: cuda, features: "gpu-cuda", suffix: "-cuda", label: "CUDA", llama_asset: "llama-b8933-bin-win-cuda-12.4-x64.zip", llama_cudart_asset: "cudart-llama-bin-win-cuda-12.4-x64.zip" }
+          - { id: cuda, features: "bundle-cuda", suffix: "-cuda", label: "CUDA", llama_asset: "llama-b8933-bin-win-cuda-12.4-x64.zip", llama_cudart_asset: "cudart-llama-bin-win-cuda-12.4-x64.zip" }
     name: build-windows-${{ matrix.variant.id }}
     steps:
       - name: Checkout

--- a/ClassNoteAI/src-tauri/Cargo.toml
+++ b/ClassNoteAI/src-tauri/Cargo.toml
@@ -25,6 +25,7 @@ nmt-local = []
 speaker-diarization = ["parakeet-rs/sortformer"]
 gpu-directml = ["ort/directml", "parakeet-rs/directml"]
 gpu-coreml = ["ort/coreml", "parakeet-rs/coreml"]
+bundle-cuda = []
 
 # Whisper GPU backends. All three are opt-in and OFF by default — the
 # CPU build stays the baseline, so any regression from a broken
@@ -65,11 +66,9 @@ gpu-coreml = ["ort/coreml", "parakeet-rs/coreml"]
 #                             NVIDIA drivers.
 # Vulkan/Metal aren't supported by ct2rs (CUDA-only GPU backend). Metal
 # covers whisper + candle; Vulkan covers only whisper.
-# GPU features for the Candle BGE embedding model. v2 has no in-process
-# ASR (Parakeet runs as a sidecar) and no in-process translation
-# (TranslateGemma runs as a sidecar), so the only Rust-side accelerator
-# need is BGE embedding. Currently CUDA is disabled in CI for the same
-# reason as before — candle-kernels OOM in nvcc on 16 GB GitHub runners.
+# GPU features for runtime ML backends. Release CI uses `bundle-cuda`
+# for the CUDA installer variant so it can ship the CUDA llama.cpp
+# sidecar without compiling the heavier Rust CUDA backend.
 gpu-cuda = ["ort/cuda", "parakeet-rs/cuda"]
 gpu-vulkan = []
 gpu-metal = [

--- a/ClassNoteAI/src-tauri/src/gpu/mod.rs
+++ b/ClassNoteAI/src-tauri/src/gpu/mod.rs
@@ -238,33 +238,41 @@ pub async fn detect_gpu_backends(preference: Option<String>) -> Result<GpuDetect
     Ok(detect(preference.as_deref()))
 }
 
-/// Which GPU feature set the binary was compiled with. Used by the
+/// Which GPU package variant the binary was built for. Used by the
 /// updater (frontend) to pick the right artifact URL out of the merged
 /// `latest.json` — a CPU build has no business pulling a CUDA
 /// installer and vice-versa.
 ///
-/// Priority of the `cfg` checks matches the CI matrix: exactly one of
-/// the three gpu features should be on in a release build, but if
+/// Priority of the `cfg` checks matches the CI matrix: exactly one CUDA
+/// marker should be on in a release build, but if
 /// multiple are somehow on (dev override) we still pick deterministically.
 #[tauri::command]
 pub fn get_build_variant() -> &'static str {
-    #[cfg(feature = "gpu-cuda")]
+    #[cfg(any(feature = "gpu-cuda", feature = "bundle-cuda"))]
     {
         return "cuda";
     }
-    #[cfg(all(feature = "gpu-metal", not(feature = "gpu-cuda")))]
+    #[cfg(all(
+        feature = "gpu-metal",
+        not(any(feature = "gpu-cuda", feature = "bundle-cuda"))
+    ))]
     {
         return "metal";
     }
     #[cfg(all(
         feature = "gpu-vulkan",
-        not(feature = "gpu-cuda"),
+        not(any(feature = "gpu-cuda", feature = "bundle-cuda")),
         not(feature = "gpu-metal")
     ))]
     {
         return "vulkan";
     }
-    #[cfg(not(any(feature = "gpu-cuda", feature = "gpu-metal", feature = "gpu-vulkan")))]
+    #[cfg(not(any(
+        feature = "gpu-cuda",
+        feature = "bundle-cuda",
+        feature = "gpu-metal",
+        feature = "gpu-vulkan"
+    )))]
     {
         return "cpu";
     }

--- a/ClassNoteAI/src-tauri/src/lib.rs
+++ b/ClassNoteAI/src-tauri/src/lib.rs
@@ -339,6 +339,7 @@ fn get_build_features() -> serde_json::Value {
     serde_json::json!({
         "nmt_local": cfg!(feature = "nmt-local"),
         "gpu_cuda": cfg!(feature = "gpu-cuda"),
+        "bundle_cuda": cfg!(feature = "bundle-cuda"),
         "gpu_metal": cfg!(feature = "gpu-metal"),
         "gpu_vulkan": cfg!(feature = "gpu-vulkan"),
     })

--- a/ClassNoteAI/src/services/buildFeaturesService.ts
+++ b/ClassNoteAI/src/services/buildFeaturesService.ts
@@ -17,6 +17,8 @@ export interface BuildFeatures {
   nmt_local: boolean;
   /** `gpu-cuda` — Whisper CUDA + CT2 cuda-dynamic-loading. Implies nmt_local. */
   gpu_cuda: boolean;
+  /** `bundle-cuda` — CUDA installer variant with bundled CUDA sidecars. */
+  bundle_cuda?: boolean;
   /** `gpu-metal` — macOS Metal for whisper + candle. */
   gpu_metal: boolean;
   /** `gpu-vulkan` — Whisper Vulkan backend. */


### PR DESCRIPTION
## Summary
- add a lightweight bundle-cuda feature for the CUDA installer variant
- keep updater target selection on windows-x86_64-cuda without compiling the Rust CUDA backend
- switch the Windows release CUDA matrix entry from gpu-cuda to bundle-cuda

## Validation
- npm run build
- npx vitest run
- cargo check --profile=ci-check --features bundle-cuda --message-format=short
- cargo test --profile=ci-check gpu::tests --message-format=short
- python scripts/check_version_consistency.py --repo-root . source --expected-version 0.6.5-alpha.1
- git diff --check