### PR TITLE
ci: remove auto-update footer from release notes

### DIFF
--- a/.github/workflows/release-macos.yml
+++ b/.github/workflows/release-macos.yml
@@ -378,12 +378,6 @@ jobs:
           echo "### 📦 其他 (Other)" >> release_body.txt
           grep -ivE "^(feat|add|new|fix|bug|mod|modify|refactor|update|change|chore|style|build|ci|del|delete|remove|break|breaking)(\(.+\))?:" $LOG_FILE | grep -vE "!:" | sed 's/^/- /' >> release_body.txt || true
           
-          # Append installation instructions
-          echo "" >> release_body.txt
-          echo "---" >> release_body.txt
-          echo "### 自動更新" >> release_body.txt
-          echo "已安裝用戶可透過應用內「設定 → 關於與更新」檢查更新。" >> release_body.txt
-
       - name: Create Release
         if: startsWith(github.ref, 'refs/tags/')
         uses: softprops/action-gh-release@v1


### PR DESCRIPTION
## Summary
- remove the fixed Auto Update footer from generated release notes
- keep updater metadata in manifest assets instead of duplicating it in the release body

## Validation
- git diff --check
- updated v0.6.5-alpha.1 release body manually to remove the footer and add compatibility notes