### PR TITLE
Advance audio source reliability MVP

### DIFF
--- a/ClassNoteAI/README.md
+++ b/ClassNoteAI/README.md
@@ -11,6 +11,7 @@ This README is for the app workspace. For the project overview, release links, a
 - Create or open a course.
 - Start a lecture recording from the desktop app.
 - Watch captions appear during the session.
+- Keep recording through long classes with disk-backed recovery and safety prompts if the session appears forgotten.
 - Stop the session to commit the final transcript and translation state.
 
 ### Import Media
@@ -22,6 +23,7 @@ This README is for the app workspace. For the project overview, release links, a
 ### Review And Search
 
 - Review transcript captions and translations in the lecture view.
+- See speaker labels when attribution is available, so teacher speech and student questions can stay distinguishable.
 - Add PDFs, notes, or syllabus material to the course.
 - Search across course material and ask the AI assistant contextual questions.
 

--- a/ClassNoteAI/src-tauri/src/recording/mod.rs
+++ b/ClassNoteAI/src-tauri/src/recording/mod.rs
@@ -36,7 +36,7 @@ pub mod video_import;
 
 use serde::{Deserialize, Serialize};
 use std::fs::{self, File, OpenOptions};
-use std::io::{Read, Write};
+use std::io::Write;
 use std::path::{Path, PathBuf};
 
 /// Default assumptions if no sidecar is present. Matches what the frontend
@@ -105,6 +105,10 @@ pub struct PersistedTranscriptSegment {
     /// allowed to drop on crash without data loss).
     #[serde(rename = "type")]
     pub kind: String,
+    #[serde(default)]
+    pub speaker_role: Option<String>,
+    #[serde(default)]
+    pub speaker_id: Option<String>,
 }
 
 /// Validates a lecture_id is a plain UUID-ish identifier with no
@@ -316,6 +320,32 @@ pub fn wrap_pcm_as_wav(pcm: &[u8], sample_rate: u32, channels: u16) -> Vec<u8> {
     out
 }
 
+fn write_wav_header<W: Write>(
+    out: &mut W,
+    data_size: u32,
+    sample_rate: u32,
+    channels: u16,
+) -> std::io::Result<()> {
+    let byte_rate = sample_rate * channels as u32 * BITS_PER_SAMPLE as u32 / 8;
+    let block_align = channels * BITS_PER_SAMPLE / 8;
+    let riff_size = 36 + data_size;
+
+    out.write_all(b"RIFF")?;
+    out.write_all(&riff_size.to_le_bytes())?;
+    out.write_all(b"WAVE")?;
+    out.write_all(b"fmt ")?;
+    out.write_all(&16u32.to_le_bytes())?;
+    out.write_all(&1u16.to_le_bytes())?;
+    out.write_all(&channels.to_le_bytes())?;
+    out.write_all(&sample_rate.to_le_bytes())?;
+    out.write_all(&byte_rate.to_le_bytes())?;
+    out.write_all(&block_align.to_le_bytes())?;
+    out.write_all(&BITS_PER_SAMPLE.to_le_bytes())?;
+    out.write_all(b"data")?;
+    out.write_all(&data_size.to_le_bytes())?;
+    Ok(())
+}
+
 /// Read the in-progress PCM, wrap as WAV, write to `final_path`, delete
 /// the scratch. Returns the bytes of the finalized WAV file.
 pub fn finalize_recording_inner(
@@ -327,15 +357,27 @@ pub fn finalize_recording_inner(
     let p = pcm_path(in_progress_dir, lecture_id);
     let meta = read_meta_or_default(in_progress_dir, lecture_id);
 
-    let mut pcm = Vec::new();
-    File::open(&p)?.read_to_end(&mut pcm)?;
-
-    let wav = wrap_pcm_as_wav(&pcm, meta.sample_rate, meta.channels);
+    let data_size = fs::metadata(&p)?.len();
+    if data_size > u32::MAX as u64 {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "recording is too large for a single WAV file",
+        ));
+    }
 
     if let Some(parent) = final_path.parent() {
         fs::create_dir_all(parent)?;
     }
-    fs::write(final_path, &wav)?;
+    let mut input = File::open(&p)?;
+    let mut output = File::create(final_path)?;
+    write_wav_header(
+        &mut output,
+        data_size as u32,
+        meta.sample_rate,
+        meta.channels,
+    )?;
+    std::io::copy(&mut input, &mut output)?;
+    output.flush()?;
 
     // Clean up the scratch files. Best-effort — the finalized WAV is
     // already safely on disk, so partial cleanup won't lose anything.
@@ -345,7 +387,7 @@ pub fn finalize_recording_inner(
     let _ = fs::remove_file(&p);
     let _ = fs::remove_file(meta_path(in_progress_dir, lecture_id));
 
-    Ok(wav.len() as u64)
+    Ok(44 + data_size)
 }
 
 /// List every in-progress `.pcm` file with a companion meta if present,
@@ -623,6 +665,22 @@ mod tests {
     }
 
     #[test]
+    fn find_orphaned_recordings_ignores_temp_pcm_sibling_dir() {
+        let tmp = TempDir::new().unwrap();
+        let in_progress = tmp.path().join("audio").join("in-progress");
+        let temp_pcm = tmp.path().join("temp_pcm");
+        fs::create_dir_all(&in_progress).unwrap();
+        fs::create_dir_all(&temp_pcm).unwrap();
+        fs::write(temp_pcm.join("import.pcm"), [0u8; 4]).unwrap();
+
+        let orphans = find_orphaned_recordings_inner(&in_progress).unwrap();
+        assert!(
+            orphans.is_empty(),
+            "import temp PCM must not look like interrupted recording audio"
+        );
+    }
+
+    #[test]
     fn discard_removes_both_pcm_and_meta() {
         let (_tmp, dir) = fresh();
         append_pcm_chunk_inner(&dir, "gone", &[9i16], 16_000, 1).unwrap();
@@ -713,6 +771,8 @@ mod tests {
             text_en: text.to_string(),
             text_zh: None,
             kind: "rough".to_string(),
+            speaker_role: None,
+            speaker_id: None,
         }
     }
 
@@ -735,6 +795,8 @@ mod tests {
             text_en: "world".to_string(),
             text_zh: Some("世界".to_string()),
             kind: "fine".to_string(),
+            speaker_role: Some("teacher".to_string()),
+            speaker_id: Some("speaker-0".to_string()),
         };
         append_transcript_segment_inner(&dir, "lec-r", &s1).unwrap();
         append_transcript_segment_inner(&dir, "lec-r", &s2).unwrap();
@@ -745,6 +807,8 @@ mod tests {
         assert_eq!(segs[1].id, "b");
         assert_eq!(segs[1].text_zh.as_deref(), Some("世界"));
         assert_eq!(segs[1].kind, "fine");
+        assert_eq!(segs[1].speaker_role.as_deref(), Some("teacher"));
+        assert_eq!(segs[1].speaker_id.as_deref(), Some("speaker-0"));
     }
 
     #[test]
@@ -803,7 +867,10 @@ mod tests {
             .unwrap();
         }
         let orphans = find_orphaned_recordings_inner(&dir).unwrap();
-        let lec = orphans.iter().find(|o| o.lecture_id == "lec-with-tx").unwrap();
+        let lec = orphans
+            .iter()
+            .find(|o| o.lecture_id == "lec-with-tx")
+            .unwrap();
         assert_eq!(lec.transcript_segments, 3);
     }
 
@@ -870,7 +937,10 @@ mod tests {
     fn append_transcript_rejects_lecture_id_with_path_traversal() {
         let (_tmp, dir) = fresh();
         let r = append_transcript_segment_inner(&dir, "../escape", &sample_segment("x", "y"));
-        assert!(r.is_err(), "transcript append must reject path-traversal id");
+        assert!(
+            r.is_err(),
+            "transcript append must reject path-traversal id"
+        );
     }
 
     #[test]

--- a/ClassNoteAI/src-tauri/src/recording/video_import.rs
+++ b/ClassNoteAI/src-tauri/src/recording/video_import.rs
@@ -32,9 +32,13 @@
 use crate::utils::command::no_window;
 use serde::{Deserialize, Serialize};
 use std::fs::File;
-use std::io::{BufWriter, Read, Seek, SeekFrom, Write};
+use std::io::{Read, Seek, SeekFrom};
 use std::path::{Path, PathBuf};
 use std::process::Stdio;
+
+const SUPPORTED_MEDIA_EXTENSIONS: &[&str] = &[
+    "mp4", "m4v", "mkv", "webm", "mov", "avi", "wav", "mp3", "m4a", "aac", "flac", "ogg", "opus",
+];
 
 /// Run ffmpeg to decode a video file into raw 16 kHz mono i16 PCM.
 ///
@@ -130,6 +134,56 @@ fn locate_ffmpeg() -> Option<PathBuf> {
     None
 }
 
+fn lower_extension(path: &Path) -> Option<String> {
+    path.extension()
+        .and_then(|e| e.to_str())
+        .map(|e| e.to_ascii_lowercase())
+}
+
+fn supported_media_extension(path: &Path) -> Result<String, String> {
+    let ext = lower_extension(path).ok_or_else(|| {
+        format!(
+            "unsupported media file without extension: {}",
+            path.display()
+        )
+    })?;
+    if SUPPORTED_MEDIA_EXTENSIONS.contains(&ext.as_str()) {
+        Ok(ext)
+    } else {
+        Err(format!(
+            "unsupported media extension .{}; raw .pcm files are internal scratch files, not import media",
+            ext
+        ))
+    }
+}
+
+fn app_temp_pcm_dir() -> Result<PathBuf, String> {
+    Ok(crate::paths::get_app_data_dir()?.join("temp_pcm"))
+}
+
+fn validate_temp_pcm_path(path: &Path, temp_dir: &Path) -> Result<(), String> {
+    if lower_extension(path).as_deref() != Some("pcm") {
+        return Err(format!("expected a .pcm temp file: {}", path.display()));
+    }
+    if !path.exists() {
+        return Ok(());
+    }
+
+    let canonical_temp = temp_dir
+        .canonicalize()
+        .map_err(|e| format!("canonicalize temp_pcm dir {}: {e}", temp_dir.display()))?;
+    let canonical_path = path
+        .canonicalize()
+        .map_err(|e| format!("canonicalize pcm path {}: {e}", path.display()))?;
+    if !canonical_path.starts_with(&canonical_temp) {
+        return Err(format!(
+            "rejected non-temp PCM path: {}",
+            canonical_path.display()
+        ));
+    }
+    Ok(())
+}
+
 // ============================================================
 // Tauri commands
 // ============================================================
@@ -144,23 +198,15 @@ pub async fn import_video_for_lecture(
     use crate::paths;
     let src = PathBuf::from(&src_path);
     if !src.exists() {
-        return Err(format!("source video not found: {src_path}"));
+        return Err(format!("source media not found: {src_path}"));
     }
+    let ext = supported_media_extension(&src)?;
     let video_dir = paths::get_video_dir()?;
-    std::fs::create_dir_all(&video_dir).map_err(|e| format!("mkdir {}: {e}", video_dir.display()))?;
-    let ext = src
-        .extension()
-        .and_then(|e| e.to_str())
-        .unwrap_or("mp4")
-        .to_string();
+    std::fs::create_dir_all(&video_dir)
+        .map_err(|e| format!("mkdir {}: {e}", video_dir.display()))?;
     let dest = video_dir.join(format!("{lecture_id}.{ext}"));
-    std::fs::copy(&src, &dest).map_err(|e| {
-        format!(
-            "copy video {} -> {}: {e}",
-            src.display(),
-            dest.display()
-        )
-    })?;
+    std::fs::copy(&src, &dest)
+        .map_err(|e| format!("copy video {} -> {}: {e}", src.display(), dest.display()))?;
     Ok(dest.to_string_lossy().to_string())
 }
 
@@ -170,6 +216,7 @@ pub async fn import_video_for_lecture(
 #[tauri::command]
 pub async fn extract_pcm_from_video(video_path: String) -> Result<Vec<i16>, String> {
     let path = PathBuf::from(&video_path);
+    supported_media_extension(&path)?;
     extract_pcm_16k_mono(&path)
 }
 
@@ -189,8 +236,9 @@ pub async fn extract_video_pcm_to_temp(video_path: String) -> Result<PcmExtractR
     use crate::paths;
     let video = PathBuf::from(&video_path);
     if !video.exists() {
-        return Err(format!("video not found: {video_path}"));
+        return Err(format!("media not found: {video_path}"));
     }
+    supported_media_extension(&video)?;
     let ffmpeg = locate_ffmpeg().ok_or_else(|| {
         "ffmpeg not found on PATH. Install via WinGet/Homebrew/apt and retry.".to_string()
     })?;
@@ -234,14 +282,12 @@ pub async fn extract_video_pcm_to_temp(video_path: String) -> Result<PcmExtractR
             }
         });
     }
-    let status = child
-        .wait()
-        .map_err(|e| format!("ffmpeg wait: {e}"))?;
+    let status = child.wait().map_err(|e| format!("ffmpeg wait: {e}"))?;
     if !status.success() {
         return Err(format!("ffmpeg exited {:?}", status.code()));
     }
-    let metadata = std::fs::metadata(&pcm_path)
-        .map_err(|e| format!("stat {}: {e}", pcm_path.display()))?;
+    let metadata =
+        std::fs::metadata(&pcm_path).map_err(|e| format!("stat {}: {e}", pcm_path.display()))?;
     let sample_count = metadata.len() / 2; // i16 = 2 bytes
     let duration_sec = sample_count as f64 / 16000.0;
     Ok(PcmExtractResult {
@@ -262,6 +308,8 @@ pub async fn read_pcm_slice(
     count: u64,
 ) -> Result<Vec<i16>, String> {
     let path = PathBuf::from(&pcm_path);
+    let temp_dir = app_temp_pcm_dir()?;
+    validate_temp_pcm_path(&path, &temp_dir)?;
     let mut file = File::open(&path).map_err(|e| format!("open {pcm_path}: {e}"))?;
     file.seek(SeekFrom::Start(start_sample * 2))
         .map_err(|e| format!("seek: {e}"))?;
@@ -283,6 +331,8 @@ pub async fn read_pcm_slice(
 #[tauri::command]
 pub async fn delete_temp_pcm(pcm_path: String) -> Result<(), String> {
     let path = PathBuf::from(&pcm_path);
+    let temp_dir = app_temp_pcm_dir()?;
+    validate_temp_pcm_path(&path, &temp_dir)?;
     if !path.exists() {
         return Ok(());
     }
@@ -292,4 +342,41 @@ pub async fn delete_temp_pcm(pcm_path: String) -> Result<(), String> {
 /// Helper used by frontend to find existing lecture videos on disk.
 pub fn stage_video_inner(_dir: &Path, _lecture_id: &str) -> Result<Option<PathBuf>, String> {
     Ok(None)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn supported_media_extension_accepts_audio_and_video_but_rejects_pcm() {
+        assert_eq!(
+            supported_media_extension(Path::new("lecture.MP4")).unwrap(),
+            "mp4"
+        );
+        assert_eq!(
+            supported_media_extension(Path::new("audio.m4a")).unwrap(),
+            "m4a"
+        );
+        assert!(supported_media_extension(Path::new("scratch.pcm")).is_err());
+        assert!(supported_media_extension(Path::new("slides.pdf")).is_err());
+    }
+
+    #[test]
+    fn temp_pcm_validation_stays_inside_temp_pcm_dir() {
+        let tmp = TempDir::new().unwrap();
+        let temp_pcm = tmp.path().join("temp_pcm");
+        std::fs::create_dir_all(&temp_pcm).unwrap();
+        let good = temp_pcm.join("import.pcm");
+        std::fs::write(&good, [0u8; 4]).unwrap();
+        let outside = tmp.path().join("audio").join("in-progress");
+        std::fs::create_dir_all(&outside).unwrap();
+        let interrupted_recording = outside.join("lecture.pcm");
+        std::fs::write(&interrupted_recording, [0u8; 4]).unwrap();
+
+        assert!(validate_temp_pcm_path(&good, &temp_pcm).is_ok());
+        assert!(validate_temp_pcm_path(&interrupted_recording, &temp_pcm).is_err());
+        assert!(validate_temp_pcm_path(&temp_pcm.join("not-pcm.wav"), &temp_pcm).is_err());
+    }
 }

--- a/ClassNoteAI/src-tauri/src/storage/database.rs
+++ b/ClassNoteAI/src-tauri/src/storage/database.rs
@@ -472,10 +472,31 @@ impl Database {
                 type TEXT NOT NULL,
                 confidence REAL,
                 created_at TEXT NOT NULL,
+                speaker_role TEXT NOT NULL DEFAULT 'unknown',
+                speaker_id TEXT,
                 FOREIGN KEY (lecture_id) REFERENCES lectures(id) ON DELETE CASCADE
             )",
             [],
         )?;
+
+        let mut stmt = self.conn.prepare("PRAGMA table_info(subtitles)")?;
+        let subtitle_columns = stmt
+            .query_map([], |row| row.get::<_, String>(1))?
+            .filter_map(|name| name.ok())
+            .collect::<Vec<_>>();
+        drop(stmt);
+        if !subtitle_columns.iter().any(|name| name == "speaker_role") {
+            println!("Migrating subtitles table: adding speaker_role column");
+            self.conn.execute(
+                "ALTER TABLE subtitles ADD COLUMN speaker_role TEXT NOT NULL DEFAULT 'unknown'",
+                [],
+            )?;
+        }
+        if !subtitle_columns.iter().any(|name| name == "speaker_id") {
+            println!("Migrating subtitles table: adding speaker_id column");
+            self.conn
+                .execute("ALTER TABLE subtitles ADD COLUMN speaker_id TEXT", [])?;
+        }
 
         // 創建索引以提升查詢性能
         self.conn.execute(
@@ -912,8 +933,8 @@ impl Database {
     /// 保存字幕
     pub fn save_subtitle(&self, subtitle: &Subtitle) -> SqlResult<()> {
         self.conn.execute(
-            "INSERT OR REPLACE INTO subtitles (id, lecture_id, timestamp, text_en, text_zh, type, confidence, created_at)
-             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8)",
+            "INSERT OR REPLACE INTO subtitles (id, lecture_id, timestamp, text_en, text_zh, type, confidence, created_at, speaker_role, speaker_id)
+             VALUES (?1, ?2, ?3, ?4, ?5, ?6, ?7, ?8, ?9, ?10)",
             rusqlite::params![
                 subtitle.id,
                 subtitle.lecture_id,
@@ -922,7 +943,13 @@ impl Database {
                 subtitle.text_zh,
                 subtitle.subtitle_type,
                 subtitle.confidence,
-                subtitle.created_at
+                subtitle.created_at,
+                subtitle
+                    .speaker_role
+                    .as_deref()
+                    .filter(|role| matches!(*role, "teacher" | "student" | "unknown"))
+                    .unwrap_or("unknown"),
+                subtitle.speaker_id
             ],
         )?;
         Ok(())
@@ -993,7 +1020,7 @@ impl Database {
     /// 獲取課程的所有字幕
     pub fn get_subtitles(&self, lecture_id: &str) -> SqlResult<Vec<Subtitle>> {
         let mut stmt = self.conn.prepare(
-            "SELECT id, lecture_id, timestamp, text_en, text_zh, type, confidence, created_at
+            "SELECT id, lecture_id, timestamp, text_en, text_zh, type, confidence, created_at, speaker_role, speaker_id
              FROM subtitles WHERE lecture_id = ?1 ORDER BY timestamp ASC",
         )?;
 
@@ -1735,7 +1762,7 @@ mod tests {
         let lecture = Lecture::new(course.id.clone(), "Lecture".to_string(), None);
         db.save_lecture(&lecture, "test_user").unwrap();
 
-        let sub1 = Subtitle::new(
+        let mut sub1 = Subtitle::new(
             lecture.id.clone(),
             0.0,
             "Hello".to_string(),
@@ -1743,6 +1770,8 @@ mod tests {
             "rough".to_string(),
             Some(0.95),
         );
+        sub1.speaker_role = Some("teacher".to_string());
+        sub1.speaker_id = Some("speaker-0".to_string());
         let sub2 = Subtitle::new(
             lecture.id.clone(),
             1.5,
@@ -1758,7 +1787,11 @@ mod tests {
         let subtitles = db.get_subtitles(&lecture.id).unwrap();
         assert_eq!(subtitles.len(), 2);
         assert_eq!(subtitles[0].text_en, "Hello");
+        assert_eq!(subtitles[0].speaker_role.as_deref(), Some("teacher"));
+        assert_eq!(subtitles[0].speaker_id.as_deref(), Some("speaker-0"));
         assert_eq!(subtitles[1].text_en, "World");
+        assert_eq!(subtitles[1].speaker_role.as_deref(), Some("unknown"));
+        assert_eq!(subtitles[1].speaker_id, None);
     }
 
     #[test]

--- a/ClassNoteAI/src-tauri/src/storage/models.rs
+++ b/ClassNoteAI/src-tauri/src/storage/models.rs
@@ -150,6 +150,10 @@ pub struct Subtitle {
     #[serde(rename = "type")]
     pub subtitle_type: String, // "rough" | "fine" - 序列化為 "type"
     pub confidence: Option<f64>,
+    #[serde(default)]
+    pub speaker_role: Option<String>,
+    #[serde(default)]
+    pub speaker_id: Option<String>,
     pub created_at: String,
 }
 
@@ -170,6 +174,8 @@ impl Subtitle {
             text_zh,
             subtitle_type,
             confidence,
+            speaker_role: None,
+            speaker_id: None,
             created_at: Utc::now().to_rfc3339(),
         }
     }
@@ -188,6 +194,8 @@ impl TryFrom<&Row<'_>> for Subtitle {
             subtitle_type: row.get(5)?,
             confidence: row.get(6)?,
             created_at: row.get(7)?,
+            speaker_role: row.get::<_, Option<String>>(8).unwrap_or(None),
+            speaker_id: row.get::<_, Option<String>>(9).unwrap_or(None),
         })
     }
 }

--- a/ClassNoteAI/src/components/ImportModal.tsx
+++ b/ClassNoteAI/src/components/ImportModal.tsx
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState } from 'react';
 import { Film, ClipboardPaste, X, Loader2, ArrowLeft } from 'lucide-react';
 import { useTauriFileDrop } from '../hooks/useTauriFileDrop';
 import { storageService } from '../services/storageService';
+import { isSupportedMediaPath } from '../utils/mediaFileTypes';
 
 /**
  * v0.6.0 — unified "匯入" entry point for the Notes view.
@@ -55,8 +56,6 @@ interface Props {
     onSubmitPaste: (submission: PasteSubmission) => void;
 }
 
-const MEDIA_EXT = /\.(mp4|m4v|mkv|webm|mov|avi|wav|mp3|m4a|aac|flac|ogg|opus)$/i;
-
 export default function ImportModal({
     open,
     isBusy,
@@ -101,7 +100,7 @@ export default function ImportModal({
         zoneRef: modalRef,
         enabled: open && !isBusy,
         onDrop: (paths) => {
-            const video = paths.find((p) => MEDIA_EXT.test(p));
+            const video = paths.find(isSupportedMediaPath);
             if (video) {
                 onDropVideo(video, {
                     language: videoLang,

--- a/ClassNoteAI/src/components/LectureView.tsx
+++ b/ClassNoteAI/src/components/LectureView.tsx
@@ -420,6 +420,8 @@ export default function LectureView() {
           text_zh: seg.displayTranslation || seg.roughTranslation || undefined,
           type: (seg.source === 'fine' ? 'fine' : 'rough') as 'rough' | 'fine',
           confidence: undefined,
+          speaker_role: seg.speakerRole ?? 'unknown',
+          speaker_id: seg.speakerId,
           created_at: now, // 設置創建時間
         }));
 

--- a/ClassNoteAI/src/components/NotesView.tsx
+++ b/ClassNoteAI/src/components/NotesView.tsx
@@ -45,9 +45,11 @@ import { subtitleImportService } from "../services/subtitleImportService";
 import { selectVideoFile } from "../services/fileService";
 import ImportModal, { PasteSubmission, VideoImportOptions } from "./ImportModal";
 import { Lecture, Note, RecordingStatus } from "../types";
+import { isSupportedMediaPath } from "../utils/mediaFileTypes";
 import CourseCreationDialog from "./CourseCreationDialog";
 import { AudioRecorder } from "../services/audioRecorder";
 import { BatteryMonitor } from "../services/batteryMonitorService";
+import { recordingSessionSafetyService, type RecordingSafetyStopReason } from "../services/recordingSessionSafetyService";
 import SubtitleDisplay from "./SubtitleDisplay";
 import AudioPlayer from "./AudioPlayer";
 import { transcriptionService } from "../services/transcriptionService";
@@ -62,6 +64,12 @@ import { pdfService } from "../services/pdfService";
 import AIChatPanel from "./AIChatPanel";
 
 type ViewMode = 'recording' | 'review';
+
+interface RecordingPipelineLag {
+  queueDepth: number;
+  oldestAgeMs: number;
+  noticedAt: number;
+}
 
 interface NotesViewProps {
   courseId?: string;
@@ -91,6 +99,7 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
   // Recording State
   const [recordingStatus, setRecordingStatus] = useState<RecordingStatus>("idle");
   const [volume, setVolume] = useState(0);
+  const [recordingPipelineLag, setRecordingPipelineLag] = useState<RecordingPipelineLag | null>(null);
   const [pdfPath, setPdfPath] = useState<string | null>(null);
   const [pdfData, setPdfData] = useState<ArrayBuffer | null>(null);
   const [modelLoaded, setModelLoaded] = useState(false);
@@ -932,6 +941,8 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
               endTime: (sub.timestamp + 5) * 1000,
               source: sub.type === 'fine' ? 'fine' : 'rough',
               translationSource: sub.text_zh ? (sub.type === 'fine' ? 'fine' : 'rough') : undefined,
+              speakerRole: sub.speaker_role ?? 'unknown',
+              speakerId: sub.speaker_id,
               text: sub.text_en,
               translatedText: sub.text_zh,
             });
@@ -1255,6 +1266,7 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
       audioRecorderRef.current.enablePersistence(currentLectureData.id);
 
       await audioRecorderRef.current.start();
+      setRecordingPipelineLag(null);
 
       // Phase 1 of speech-pipeline-v0.6.5 (#52): battery guard. Warns at
       // 10% and force-stops at 5% to flush the JSONL + finalize the WAV
@@ -1271,6 +1283,34 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
       void batteryMonitorRef.current.start().catch((err) => {
         console.warn('[NotesView] battery monitor start failed:', err);
       });
+      recordingSessionSafetyService.start({
+        onLongSilenceWarning: () => {
+          toastService.warning(
+            'Recording has been silent for a while',
+            'ClassNoteAI will auto-stop soon if no speech resumes.',
+          );
+        },
+        onBackpressure: ({ queueDepth, oldestAgeMs }) => {
+          console.warn('[NotesView] Recording pipeline backpressure', {
+            queueDepth,
+            oldestAgeMs,
+          });
+          setRecordingPipelineLag({
+            queueDepth,
+            oldestAgeMs,
+            noticedAt: Date.now(),
+          });
+        },
+        onStop: (reason: RecordingSafetyStopReason) => {
+          console.warn('[NotesView] Recording safety auto-stop:', reason);
+          toastService.warning(
+            reason === 'hard_duration_cap'
+              ? 'Recording reached the safety time limit'
+              : 'Recording auto-stopped after long silence',
+          );
+          void handleStopRecording();
+        },
+      });
 
       const resolvedInputDeviceId = audioRecorderRef.current.getDeviceId();
       if (resolvedInputDeviceId && resolvedInputDeviceId !== preferredInputDeviceId) {
@@ -1282,6 +1322,8 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
       setRecordingStartTime(Date.now());
     } catch (error) {
       console.error('Failed to start recording:', error);
+      recordingSessionSafetyService.stop();
+      setRecordingPipelineLag(null);
       toastService.error(
         '無法開始錄音',
         error instanceof Error ? error.message : String(error),
@@ -1306,11 +1348,11 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
     // 00:00 / 00:00 in Review mode.
     //
     // New order of operations:
-    //   1. Snapshot the in-memory WAV (no throw — null is fine).
+    //   1. Snapshot the bounded in-memory WAV fallback (no throw — null is fine).
     //   2. Stop the recorder.
     //   3. ALWAYS attempt finalize (.pcm → .wav). If persistence was
     //      enabled, this is the lossless path covering the full session.
-    //   4. If finalize didn't produce a path, fall back to the in-memory
+    //   4. If finalize didn't produce a path, fall back to the bounded in-memory
     //      WAV (covers users upgrading from v0.5.1 where persistence is
     //      disabled mid-session).
     //   5. Whatever we end up with, persist the lecture row to the DB.
@@ -1338,6 +1380,8 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
       // listeners now that this session is done. start() is idempotent
       // so the next recording reattaches.
       batteryMonitorRef.current?.stop();
+      recordingSessionSafetyService.stop();
+      setRecordingPipelineLag(null);
       stopRecordingDeviceMonitor();
       setRecordingStatus("stopped");
       setVolume(0);
@@ -1637,6 +1681,8 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
           text_zh: seg.displayTranslation || seg.roughTranslation || undefined,
           type: (seg.source === 'fine' ? 'fine' : 'rough') as 'rough' | 'fine',
           confidence: undefined,
+          speaker_role: seg.speakerRole ?? 'unknown',
+          speaker_id: seg.speakerId,
           created_at: now,
         }));
         await storageService.saveSubtitles(subtitles);
@@ -1798,7 +1844,7 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
     const path = paths[0];
     const lower = path.toLowerCase();
 
-    const isMedia = /\.(mp4|m4v|mkv|webm|mov|avi|wav|mp3|m4a|aac|flac|ogg|opus)$/.test(lower);
+    const isMedia = isSupportedMediaPath(path);
     const isPdf = lower.endsWith('.pdf');
     const isConvertible =
       lower.endsWith('.ppt') ||
@@ -2401,7 +2447,17 @@ export default function NotesView({ courseId: propCourseId, lectureId: propLectu
                           <div className="h-full bg-green-500 transition-all" style={{ width: `${volume}%` }} />
                         </div>
                       </div>
-                      <span className="text-xs text-gray-500">{recordingStatus === 'recording' ? 'Recording...' : 'Ready'}</span>
+                      <div className="flex flex-col items-end gap-1">
+                        <span className="text-xs text-gray-500">{recordingStatus === 'recording' ? 'Recording...' : 'Ready'}</span>
+                        {recordingPipelineLag && recordingStatus === 'recording' && (
+                          <span
+                            className="text-[11px] text-amber-700 dark:text-amber-300 bg-amber-50 dark:bg-amber-900/25 border border-amber-200 dark:border-amber-800 rounded px-2 py-0.5"
+                            title={`Queue depth ${recordingPipelineLag.queueDepth}, oldest ${Math.round(recordingPipelineLag.oldestAgeMs / 1000)}s`}
+                          >
+                            Live subtitles delayed
+                          </span>
+                        )}
+                      </div>
                     </div>
 
                     <div className="flex gap-2">

--- a/ClassNoteAI/src/components/SubtitleDisplay.tsx
+++ b/ClassNoteAI/src/components/SubtitleDisplay.tsx
@@ -7,6 +7,7 @@ import { useState, useEffect, useMemo, useRef } from 'react';
 import { Trash2 } from 'lucide-react';
 import { subtitleService } from '../services/subtitleService';
 import type { SubtitleState } from '../types/subtitle';
+import { buildSpeakerLabel } from '../utils/speakerLabels';
 
 interface SubtitleDisplayProps {
   maxLines?: number;
@@ -139,6 +140,7 @@ export default function SubtitleDisplay({ onSeek, currentTime, baseTime }: Subti
                 `${centis.toString().padStart(2, '0')}`;
 
             const isActive = index === activeIdx;
+            const speakerLabel = buildSpeakerLabel(segment.speakerRole, segment.speakerId);
 
             return (
               <div
@@ -155,12 +157,19 @@ export default function SubtitleDisplay({ onSeek, currentTime, baseTime }: Subti
                 `}
                 style={{ zIndex: 10 }}
               >
-                <div className="flex items-start justify-between mb-1">
-                  <span className="text-xs text-gray-500 dark:text-gray-400">
-                    {timeString}
-                  </span>
+                <div className="flex items-start justify-between gap-2 mb-1">
+                  <div className="flex flex-wrap items-center gap-2 min-w-0">
+                    <span className="text-xs text-gray-500 dark:text-gray-400">
+                      {timeString}
+                    </span>
+                    {speakerLabel && (
+                      <span className={`px-1.5 py-0.5 border rounded text-[11px] leading-tight font-medium ${speakerLabel.className}`}>
+                        {speakerLabel.text}
+                      </span>
+                    )}
+                  </div>
                   {segment.language && (
-                    <span className="text-xs text-gray-400 dark:text-gray-500">
+                    <span className="text-xs text-gray-400 dark:text-gray-500 shrink-0">
                       {segment.language}
                     </span>
                   )}

--- a/ClassNoteAI/src/services/__tests__/recordingRecoveryService.transcript.test.ts
+++ b/ClassNoteAI/src/services/__tests__/recordingRecoveryService.transcript.test.ts
@@ -39,7 +39,15 @@ describe('recordingRecoveryService.recoverTranscript', () => {
 
   it('imports every well-formed segment into sqlite via save_subtitles', async () => {
     setMockInvokeResult('read_orphaned_transcript', [
-      { id: 'a', timestamp: 1.0, text_en: 'hello', text_zh: null, type: 'rough' },
+      {
+        id: 'a',
+        timestamp: 1.0,
+        text_en: 'hello',
+        text_zh: null,
+        type: 'rough',
+        speaker_role: 'teacher',
+        speaker_id: 'speaker-0',
+      },
       { id: 'b', timestamp: 2.0, text_en: 'world', text_zh: '世界', type: 'rough' },
       { id: 'c', timestamp: 3.0, text_en: 'goodbye', text_zh: null, type: 'rough' },
     ]);
@@ -52,8 +60,17 @@ describe('recordingRecoveryService.recoverTranscript', () => {
       .mocked(invoke)
       .mock.calls.find(([cmd]) => cmd === 'save_subtitles');
     expect(saveCall).toBeDefined();
-    const subtitles = (saveCall![1] as { subtitles: unknown[] }).subtitles;
+    const subtitles = (saveCall![1] as {
+      subtitles: Array<{
+        id: string;
+        speaker_role?: string;
+        speaker_id?: string;
+      }>;
+    }).subtitles;
     expect(subtitles).toHaveLength(3);
+    expect(subtitles[0].speaker_role).toBe('teacher');
+    expect(subtitles[0].speaker_id).toBe('speaker-0');
+    expect(subtitles[1].speaker_role).toBe('unknown');
   });
 
   it('dedupes by id and keeps the latest entry (with translation populated)', async () => {

--- a/ClassNoteAI/src/services/__tests__/recordingSessionSafetyService.test.ts
+++ b/ClassNoteAI/src/services/__tests__/recordingSessionSafetyService.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest';
+import {
+  deriveRecordingSafetyDecision,
+  type RecordingSafetyState,
+} from '../recordingSessionSafetyService';
+
+const baseState: RecordingSafetyState = {
+  startedAtMs: 0,
+  lastSpeechAtMs: 0,
+  silenceGraceUntilMs: null,
+  stopRequested: false,
+};
+
+const config = {
+  hardMaxMs: 1000,
+  longSilenceMs: 300,
+  silenceGraceMs: 100,
+};
+
+describe('deriveRecordingSafetyDecision', () => {
+  it('requests a hard stop when the duration cap is reached', () => {
+    const decision = deriveRecordingSafetyDecision(baseState, 1000, config);
+    expect(decision.stopReason).toBe('hard_duration_cap');
+    expect(decision.nextState.stopRequested).toBe(true);
+  });
+
+  it('warns once when long silence starts, then waits for the grace window', () => {
+    const first = deriveRecordingSafetyDecision(baseState, 300, config);
+    expect(first.warnLongSilence).toBe(true);
+    expect(first.stopReason).toBeNull();
+    expect(first.nextState.silenceGraceUntilMs).toBe(400);
+
+    const second = deriveRecordingSafetyDecision(first.nextState, 350, config);
+    expect(second.warnLongSilence).toBe(false);
+    expect(second.stopReason).toBeNull();
+  });
+
+  it('requests stop when silence remains past the grace window', () => {
+    const warned = {
+      ...baseState,
+      silenceGraceUntilMs: 400,
+    };
+    const decision = deriveRecordingSafetyDecision(warned, 401, config);
+    expect(decision.stopReason).toBe('long_silence');
+    expect(decision.nextState.stopRequested).toBe(true);
+  });
+
+  it('clears pending silence grace after speech activity updates lastSpeechAt', () => {
+    const state = {
+      ...baseState,
+      lastSpeechAtMs: 390,
+      silenceGraceUntilMs: 400,
+    };
+    const decision = deriveRecordingSafetyDecision(state, 410, config);
+    expect(decision.stopReason).toBeNull();
+    expect(decision.nextState.silenceGraceUntilMs).toBeNull();
+  });
+});

--- a/ClassNoteAI/src/services/__tests__/videoImportService.test.ts
+++ b/ClassNoteAI/src/services/__tests__/videoImportService.test.ts
@@ -69,6 +69,7 @@ beforeEach(() => {
       audioEndSec: 2,
       wallClockMs: 100,
       textEn: 'Hello class.',
+      speakerRole: 'unknown',
     });
     subtitleStream.emit({
       kind: 'translation_ready',
@@ -111,6 +112,7 @@ describe('videoImportService.importVideo', () => {
         id: 'seg-1',
         lecture_id: 'lecture-1',
         text_en: 'Hello class.',
+        speaker_role: 'unknown',
       }),
     ]);
   });
@@ -133,6 +135,7 @@ describe('videoImportService.importVideo', () => {
         id: 'seg-1',
         lecture_id: 'lecture-1',
         text_en: 'Hello class.',
+        speaker_role: 'unknown',
         text_zh: '各位同學好。',
       }),
     ]);

--- a/ClassNoteAI/src/services/audioRecorder.ts
+++ b/ClassNoteAI/src/services/audioRecorder.ts
@@ -44,6 +44,7 @@ export class AudioRecorder {
 
   // 測試用途：存儲錄製的音頻數據
   private recordedChunks: Int16Array[] = [];
+  private recordedSampleCount: number = 0;
   private recordingSampleRate: number = 0;
 
   // Crash-safe persistence (v0.5.2): while a lecture is being recorded,
@@ -57,12 +58,12 @@ export class AudioRecorder {
   private persistTimer: ReturnType<typeof setInterval> | null = null;
   /** Consecutive flush failures. After N in a row we disable persistence
    *  for the rest of the session instead of silently accumulating samples
-   *  in JS heap until the tab OOMs. The session's in-memory
-   *  `recordedChunks` → `getWavData()` fallback still works on Stop. */
+   *  in JS heap until the tab OOMs. */
   private persistConsecutiveFailures = 0;
   private persistDisabled = false;
   private static readonly PERSIST_FLUSH_MS = 5_000;
   private static readonly PERSIST_MAX_CONSECUTIVE_FAILURES = 5;
+  private static readonly IN_MEMORY_FALLBACK_SECONDS = 120;
   /** Hard cap on how many samples we'll hold in memory waiting to be
    *  flushed. ~10 minutes of 48 kHz mono i16 = ~55 MB; above that we
    *  refuse to retry and fall back to in-memory-only persistence so
@@ -205,6 +206,23 @@ export class AudioRecorder {
   /**
    * 處理音頻數據
    */
+  private rememberRecordedChunk(chunk: Int16Array): void {
+    this.recordedChunks.push(chunk);
+    this.recordedSampleCount += chunk.length;
+
+    if (!this.persistLectureId) {
+      return;
+    }
+
+    const sampleRate = this.recordingSampleRate || this.config.sampleRate;
+    const maxSamples = sampleRate * AudioRecorder.IN_MEMORY_FALLBACK_SECONDS;
+    while (this.recordedSampleCount > maxSamples && this.recordedChunks.length > 1) {
+      const removed = this.recordedChunks.shift();
+      if (!removed) break;
+      this.recordedSampleCount -= removed.length;
+    }
+  }
+
   private handleAudioProcess = (event: AudioProcessingEvent) => {
     if (this.status !== 'recording') {
       return;
@@ -232,10 +250,10 @@ export class AudioRecorder {
       const sample = Math.max(-1, Math.min(1, inputData[i]));
       originalPcmData[i] = sample < 0 ? sample * 0x8000 : sample * 0x7FFF;
     }
-    this.recordedChunks.push(originalPcmData);
     if (this.recordingSampleRate === 0) {
       this.recordingSampleRate = inputBuffer.sampleRate;
     }
+    this.rememberRecordedChunk(originalPcmData);
     // Queue a copy for crash-safe disk flush. The queue is drained by
     // the periodic timer; we don't invoke Tauri per chunk because that
     // would bombard the IPC bus every ~20-40ms.
@@ -310,8 +328,7 @@ export class AudioRecorder {
    *  cause the pending array to grow without bound — each 5s tick
    *  re-serialising the whole thing and ballooning memory until the tab
    *  died. After the hard cap, persistence is disabled for the rest of
-   *  the session; recording continues in-memory and the old
-   *  `getWavData()` path on Stop still saves the audio. */
+   *  the session; recording continues with bounded in-memory fallback. */
   private async flushPersistPending(): Promise<void> {
     if (!this.persistLectureId || this.persistDisabled) return;
     if (this.persistPending.length === 0) return;
@@ -344,8 +361,7 @@ export class AudioRecorder {
       );
 
       // Decide whether to retry. Retrying means putting samples back at
-      // the head; giving up means dropping them from the persist queue
-      // (they remain in `recordedChunks` for the in-memory WAV fallback).
+      // the head; giving up means dropping them from the persist queue.
       const hitFailureCap =
         this.persistConsecutiveFailures >= AudioRecorder.PERSIST_MAX_CONSECUTIVE_FAILURES;
       const projectedPending =
@@ -356,10 +372,10 @@ export class AudioRecorder {
         console.error(
           `[AudioRecorder] Giving up on disk persistence for this session ` +
             `(failures=${this.persistConsecutiveFailures}, pending_samples=${projectedPending}). ` +
-            `Recording continues in memory; Stop will still produce a WAV via the in-memory fallback.`,
+            `Recording will keep only the recent in-memory fallback window.`,
         );
         this.persistDisabled = true;
-        // Drop the merged samples — they're already in recordedChunks.
+        // Drop the merged samples; the bounded fallback window may still have recent audio.
         return;
       }
 
@@ -479,6 +495,7 @@ export class AudioRecorder {
 
       // 測試用途：重置錄製數據
       this.recordedChunks = [];
+      this.recordedSampleCount = 0;
       this.recordingSampleRate = 0;
 
       // 更新狀態
@@ -629,7 +646,7 @@ export class AudioRecorder {
     }
 
     // 合併所有音頻塊
-    const totalLength = this.recordedChunks.reduce((sum, chunk) => sum + chunk.length, 0);
+    const totalLength = this.recordedSampleCount;
     const mergedData = new Int16Array(totalLength);
     let offset = 0;
     for (const chunk of this.recordedChunks) {
@@ -713,11 +730,11 @@ export class AudioRecorder {
    * 測試用途：獲取錄製的音頻信息
    */
   getRecordingInfo(): { duration: number; sampleRate: number; chunks: number } | null {
-    if (this.recordedChunks.length === 0) {
+    if (this.recordedSampleCount === 0) {
       return null;
     }
 
-    const totalSamples = this.recordedChunks.reduce((sum, chunk) => sum + chunk.length, 0);
+    const totalSamples = this.recordedSampleCount;
     const sampleRate = this.recordingSampleRate || this.config.sampleRate;
     const duration = totalSamples / sampleRate;
 
@@ -754,6 +771,7 @@ export class AudioRecorder {
     this.onStatusChangeCallback = null;
     this.onErrorCallback = null;
     this.recordedChunks = [];
+    this.recordedSampleCount = 0;
     this.recordingSampleRate = 0;
 
     console.log('[AudioRecorder] 實例已銷毀');

--- a/ClassNoteAI/src/services/fileService.ts
+++ b/ClassNoteAI/src/services/fileService.ts
@@ -1,5 +1,6 @@
 import { open } from "@tauri-apps/plugin-dialog";
 import { invoke } from "@tauri-apps/api/core";
+import { mediaDialogExtensions } from "../utils/mediaFileTypes";
 
 /**
  * 選擇 PDF 文件並讀取其內容
@@ -46,7 +47,7 @@ export async function selectVideoFile(): Promise<string | null> {
       filters: [
         {
           name: 'Video or Audio',
-          extensions: ['mp4', 'mkv', 'webm', 'mov', 'm4v', 'avi', 'wav', 'mp3', 'm4a', 'aac', 'flac', 'ogg', 'opus'],
+          extensions: mediaDialogExtensions(),
         },
       ],
       title: '選擇影片檔案',

--- a/ClassNoteAI/src/services/recordingRecoveryService.ts
+++ b/ClassNoteAI/src/services/recordingRecoveryService.ts
@@ -42,6 +42,8 @@ export interface PersistedTranscriptSegment {
   text_en: string;
   text_zh?: string;
   type: 'rough' | 'fine';
+  speaker_role?: 'teacher' | 'student' | 'unknown';
+  speaker_id?: string;
 }
 
 export interface OrphanedLecture {
@@ -215,6 +217,8 @@ class RecordingRecoveryService {
       text_en: seg.text_en,
       text_zh: seg.text_zh ?? null,
       type: seg.type,
+      speaker_role: seg.speaker_role ?? 'unknown',
+      speaker_id: seg.speaker_id,
     }));
     await invoke('save_subtitles', { subtitles });
     return subtitles.length;

--- a/ClassNoteAI/src/services/recordingSessionSafetyService.ts
+++ b/ClassNoteAI/src/services/recordingSessionSafetyService.ts
@@ -1,0 +1,188 @@
+import { subtitleStream, type SubtitleEvent } from './streaming/subtitleStream';
+
+export type RecordingSafetyStopReason = 'hard_duration_cap' | 'long_silence';
+
+export interface RecordingSafetyConfig {
+  hardMaxMs: number;
+  longSilenceMs: number;
+  silenceGraceMs: number;
+  checkIntervalMs: number;
+  backpressureQueueDepth: number;
+  backpressureOldestAgeMs: number;
+  backpressureNotifyEveryMs: number;
+}
+
+export interface RecordingSafetyState {
+  startedAtMs: number;
+  lastSpeechAtMs: number;
+  silenceGraceUntilMs: number | null;
+  stopRequested: boolean;
+}
+
+export interface RecordingSafetyDecision {
+  warnLongSilence: boolean;
+  stopReason: RecordingSafetyStopReason | null;
+  nextState: RecordingSafetyState;
+}
+
+const DEFAULT_CONFIG: RecordingSafetyConfig = {
+  hardMaxMs: 4 * 60 * 60 * 1000,
+  longSilenceMs: 30 * 60 * 1000,
+  silenceGraceMs: 10 * 1000,
+  checkIntervalMs: 30 * 1000,
+  backpressureQueueDepth: 12,
+  backpressureOldestAgeMs: 60 * 1000,
+  backpressureNotifyEveryMs: 60 * 1000,
+};
+
+export function deriveRecordingSafetyDecision(
+  state: RecordingSafetyState,
+  nowMs: number,
+  config: Pick<RecordingSafetyConfig, 'hardMaxMs' | 'longSilenceMs' | 'silenceGraceMs'>,
+): RecordingSafetyDecision {
+  if (state.stopRequested) {
+    return { warnLongSilence: false, stopReason: null, nextState: state };
+  }
+
+  if (nowMs - state.startedAtMs >= config.hardMaxMs) {
+    return {
+      warnLongSilence: false,
+      stopReason: 'hard_duration_cap',
+      nextState: { ...state, stopRequested: true },
+    };
+  }
+
+  const silenceMs = nowMs - state.lastSpeechAtMs;
+  if (silenceMs < config.longSilenceMs) {
+    return {
+      warnLongSilence: false,
+      stopReason: null,
+      nextState: { ...state, silenceGraceUntilMs: null },
+    };
+  }
+
+  if (state.silenceGraceUntilMs === null) {
+    return {
+      warnLongSilence: true,
+      stopReason: null,
+      nextState: { ...state, silenceGraceUntilMs: nowMs + config.silenceGraceMs },
+    };
+  }
+
+  if (nowMs >= state.silenceGraceUntilMs) {
+    return {
+      warnLongSilence: false,
+      stopReason: 'long_silence',
+      nextState: { ...state, stopRequested: true },
+    };
+  }
+
+  return { warnLongSilence: false, stopReason: null, nextState: state };
+}
+
+class RecordingSessionSafetyService {
+  private config: RecordingSafetyConfig = DEFAULT_CONFIG;
+  private state: RecordingSafetyState | null = null;
+  private timer: ReturnType<typeof setInterval> | null = null;
+  private unsubscribe: (() => void) | null = null;
+  private onStop: ((reason: RecordingSafetyStopReason) => void) | null = null;
+  private onLongSilenceWarning: (() => void) | null = null;
+  private onBackpressure: ((status: {
+    queueDepth: number;
+    oldestAgeMs: number;
+  }) => void) | null = null;
+  private lastBackpressureNoticeAt = 0;
+
+  start(options: {
+    config?: Partial<RecordingSafetyConfig>;
+    onStop: (reason: RecordingSafetyStopReason) => void;
+    onLongSilenceWarning?: () => void;
+    onBackpressure?: (status: { queueDepth: number; oldestAgeMs: number }) => void;
+  }): void {
+    this.stop();
+    this.config = { ...DEFAULT_CONFIG, ...options.config };
+    const now = Date.now();
+    this.state = {
+      startedAtMs: now,
+      lastSpeechAtMs: now,
+      silenceGraceUntilMs: null,
+      stopRequested: false,
+    };
+    this.onStop = options.onStop;
+    this.onLongSilenceWarning = options.onLongSilenceWarning ?? null;
+    this.onBackpressure = options.onBackpressure ?? null;
+    this.lastBackpressureNoticeAt = 0;
+    this.unsubscribe = subtitleStream.subscribe((event) => this.onSubtitleEvent(event));
+    this.timer = setInterval(() => this.check(), this.config.checkIntervalMs);
+  }
+
+  stop(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+      this.timer = null;
+    }
+    if (this.unsubscribe) {
+      this.unsubscribe();
+      this.unsubscribe = null;
+    }
+    this.state = null;
+    this.onStop = null;
+    this.onLongSilenceWarning = null;
+    this.onBackpressure = null;
+  }
+
+  private onSubtitleEvent(event: SubtitleEvent): void {
+    if (!this.state) return;
+    if (event.kind === 'partial_text' && event.text.trim()) {
+      this.markSpeechActivity();
+      return;
+    }
+    if (event.kind === 'sentence_committed') {
+      this.markSpeechActivity();
+      return;
+    }
+    if (event.kind === 'pipeline_status') {
+      this.maybeNotifyBackpressure(event);
+    }
+  }
+
+  private markSpeechActivity(): void {
+    if (!this.state) return;
+    this.state = {
+      ...this.state,
+      lastSpeechAtMs: Date.now(),
+      silenceGraceUntilMs: null,
+    };
+  }
+
+  private maybeNotifyBackpressure(event: Extract<SubtitleEvent, { kind: 'pipeline_status' }>): void {
+    const overloaded =
+      event.translationQueueDepth >= this.config.backpressureQueueDepth ||
+      event.oldestTranslationAgeMs >= this.config.backpressureOldestAgeMs;
+    if (!overloaded || !this.onBackpressure) return;
+
+    const now = Date.now();
+    if (now - this.lastBackpressureNoticeAt < this.config.backpressureNotifyEveryMs) {
+      return;
+    }
+    this.lastBackpressureNoticeAt = now;
+    this.onBackpressure({
+      queueDepth: event.translationQueueDepth,
+      oldestAgeMs: event.oldestTranslationAgeMs,
+    });
+  }
+
+  private check(): void {
+    if (!this.state) return;
+    const decision = deriveRecordingSafetyDecision(this.state, Date.now(), this.config);
+    this.state = decision.nextState;
+    if (decision.warnLongSilence) {
+      this.onLongSilenceWarning?.();
+    }
+    if (decision.stopReason) {
+      this.onStop?.(decision.stopReason);
+    }
+  }
+}
+
+export const recordingSessionSafetyService = new RecordingSessionSafetyService();

--- a/ClassNoteAI/src/services/streaming/asrPipeline.ts
+++ b/ClassNoteAI/src/services/streaming/asrPipeline.ts
@@ -255,6 +255,7 @@ export class AsrPipeline {
       audioEndSec: endSec,
       wallClockMs: Date.now() - this.startedAt,
       textEn: text,
+      speakerRole: 'unknown',
     });
     translationPipeline.enqueue({
       id,

--- a/ClassNoteAI/src/services/streaming/subtitleStream.ts
+++ b/ClassNoteAI/src/services/streaming/subtitleStream.ts
@@ -14,6 +14,8 @@
  *     for replay / debug.
  */
 
+export type SpeakerRole = 'teacher' | 'student' | 'unknown';
+
 export type SubtitleEvent =
   | {
       kind: 'sentence_committed';
@@ -23,6 +25,8 @@ export type SubtitleEvent =
       audioEndSec: number;
       wallClockMs: number;
       textEn: string;
+      speakerRole: SpeakerRole;
+      speakerId?: string;
     }
   | {
       kind: 'translation_ready';
@@ -54,6 +58,12 @@ export type SubtitleEvent =
       kind: 'session_ended';
       sessionId: string;
       finalWallClockMs: number;
+    }
+  | {
+      kind: 'pipeline_status';
+      sessionId: string;
+      translationQueueDepth: number;
+      oldestTranslationAgeMs: number;
     };
 
 type Listener = (event: SubtitleEvent) => void;

--- a/ClassNoteAI/src/services/streaming/translationPipeline.ts
+++ b/ClassNoteAI/src/services/streaming/translationPipeline.ts
@@ -65,6 +65,7 @@ class TranslationPipeline {
   /** Push a sentence for async translation. Non-blocking. */
   enqueue(job: TranslationJob): void {
     this.queue.push(job);
+    this.emitStatus(job.sessionId);
     void this.drain();
   }
 
@@ -83,7 +84,9 @@ class TranslationPipeline {
     try {
       while (this.queue.length > 0) {
         const job = this.queue.shift()!;
+        this.emitStatus(job.sessionId);
         await this.translateOne(job);
+        this.emitStatus(job.sessionId);
       }
     } finally {
       this.processing = false;
@@ -142,6 +145,16 @@ class TranslationPipeline {
       id: job.id,
       sessionId: job.sessionId,
       error: String((lastError as { message?: string })?.message ?? lastError),
+    });
+  }
+
+  private emitStatus(sessionId: string): void {
+    const oldest = this.queue[0];
+    subtitleStream.emit({
+      kind: 'pipeline_status',
+      sessionId,
+      translationQueueDepth: this.queue.length,
+      oldestTranslationAgeMs: oldest ? Math.max(0, Date.now() - oldest.enqueuedAt) : 0,
     });
   }
 }

--- a/ClassNoteAI/src/services/transcriptionService.ts
+++ b/ClassNoteAI/src/services/transcriptionService.ts
@@ -127,6 +127,8 @@ class TranscriptionService {
               endTime: this.startTimeWall + event.audioEndSec * 1000,
               source: 'rough',
               translationSource: undefined,
+              speakerRole: event.speakerRole,
+              speakerId: event.speakerId,
               text: event.textEn,
             });
             break;
@@ -145,6 +147,7 @@ class TranscriptionService {
           case 'session_ended':
           case 'translation_failed':
           case 'session_started':
+          case 'pipeline_status':
             // No UI side-effect needed here; consumers that care
             // subscribe to subtitleStream directly.
             break;

--- a/ClassNoteAI/src/services/videoImportService.ts
+++ b/ClassNoteAI/src/services/videoImportService.ts
@@ -3,6 +3,7 @@ import { asrPipeline } from './streaming/asrPipeline';
 import { subtitleStream, type SubtitleEvent } from './streaming/subtitleStream';
 import { storageService } from './storageService';
 import type { Lecture, Subtitle } from '../types';
+import { isAudioOnlyMediaPath } from '../utils/mediaFileTypes';
 
 export type ImportStage =
     | 'staging'
@@ -38,10 +39,8 @@ interface PcmExtractResult {
 
 const ASR_CHUNK_SAMPLES = 8_960;
 const IMPORT_SLICE_SAMPLES = ASR_CHUNK_SAMPLES * 10; // 5.6 s of audio
-const AUDIO_EXT = /\.(wav|mp3|m4a|aac|flac|ogg|opus)$/i;
-
 function isAudioOnly(path: string): boolean {
-    return AUDIO_EXT.test(path);
+    return isAudioOnlyMediaPath(path);
 }
 
 function delay(ms: number): Promise<void> {
@@ -67,6 +66,8 @@ function subtitleFromEvent(
         text_en: event.textEn,
         type: 'rough',
         confidence: undefined,
+        speaker_role: event.speakerRole,
+        speaker_id: event.speakerId,
         created_at: new Date().toISOString(),
     };
 }

--- a/ClassNoteAI/src/types/index.ts
+++ b/ClassNoteAI/src/types/index.ts
@@ -54,6 +54,8 @@ export interface Subtitle {
   text_zh?: string;
   type: "rough" | "fine"; // 對應後端的 subtitle_type 字段
   confidence?: number;
+  speaker_role?: "teacher" | "student" | "unknown";
+  speaker_id?: string;
   created_at: string; // ISO 8601 - 必需字段
 }
 

--- a/ClassNoteAI/src/types/subtitle.ts
+++ b/ClassNoteAI/src/types/subtitle.ts
@@ -1,49 +1,40 @@
-/**
- * 字幕相關類型定義
- */
+export type SpeakerRole = 'teacher' | 'student' | 'unknown';
 
 export interface SubtitleSegment {
   id: string;
-  
-  // 粗層（本地）
-  roughText: string;           // 粗轉錄文本（英文）
-  roughTranslation?: string;   // 粗翻譯文本（中文）
-  roughConfidence?: number;     // 粗轉錄置信度（0-1）
-  
-  // 精層（遠程，可選）
-  fineText?: string;            // 精轉錄文本（英文）
-  fineTranslation?: string;     // 精翻譯文本（中文）
-  fineConfidence?: number;       // 精轉錄置信度（0-1）
-  
-  // 顯示邏輯
-  displayText: string;          // 當前顯示的英文（roughText 或 fineText）
-  displayTranslation?: string;  // 當前顯示的中文（roughTranslation 或 fineTranslation）
-  
-  // 元數據
-  startTime: number; // 毫秒
-  endTime: number; // 毫秒
-  language?: string; // 檢測到的語言
-  source: 'rough' | 'fine';     // 當前顯示的來源
-  translationSource?: 'rough' | 'fine' | 'error'; // 當前翻譯的來源 ('error' = 本地模型失敗)
-  
-  // 精層狀態
+
+  roughText: string;
+  roughTranslation?: string;
+  roughConfidence?: number;
+
+  fineText?: string;
+  fineTranslation?: string;
+  fineConfidence?: number;
+
+  displayText: string;
+  displayTranslation?: string;
+
+  startTime: number;
+  endTime: number;
+  language?: string;
+  source: 'rough' | 'fine';
+  translationSource?: 'rough' | 'fine' | 'error';
+  speakerRole?: SpeakerRole;
+  speakerId?: string;
+
   fineStatus?: 'pending' | 'transcribing' | 'translating' | 'completed' | 'failed';
 
-  /** Per-segment share of a fine-refinement batch's LLM token cost.
-   *  Rendered inline next to the "✓ 已精修" badge so the user can see
-   *  how expensive the LLM pass was without opening a separate panel. */
   fineUsage?: { inputTokens: number; outputTokens: number };
 
-  // 向後兼容（保留舊字段）
-  text?: string; // 已廢棄，使用 displayText
-  translatedText?: string; // 已廢棄，使用 displayTranslation
-  confidence?: number; // 已廢棄，使用 roughConfidence 或 fineConfidence
+  text?: string;
+  translatedText?: string;
+  confidence?: number;
 }
 
 export interface SubtitleState {
   segments: SubtitleSegment[];
-  currentText: string; // 當前顯示的文本（英文）
-  currentTranslation?: string; // 當前顯示的翻譯（中文）
+  currentText: string;
+  currentTranslation?: string;
   isRecording: boolean;
   isTranscribing: boolean;
   lastUpdateTime: number;
@@ -58,6 +49,5 @@ export interface SubtitleDisplayConfig {
   backgroundOpacity: number;
   position: 'top' | 'bottom' | 'center';
   maxLines: number;
-  fadeDuration: number; // 毫秒
+  fadeDuration: number;
 }
-

--- a/ClassNoteAI/src/utils/__tests__/mediaFileTypes.test.ts
+++ b/ClassNoteAI/src/utils/__tests__/mediaFileTypes.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getFileExtension,
+  isAudioOnlyMediaPath,
+  isSupportedMediaPath,
+  mediaDialogExtensions,
+} from '../mediaFileTypes';
+
+describe('mediaFileTypes', () => {
+  it('recognizes supported video and audio files case-insensitively', () => {
+    expect(isSupportedMediaPath('D:/lecture/intro.MP4')).toBe(true);
+    expect(isSupportedMediaPath('D:/lecture/audio.m4a')).toBe(true);
+    expect(isAudioOnlyMediaPath('D:/lecture/audio.m4a')).toBe(true);
+    expect(isAudioOnlyMediaPath('D:/lecture/intro.MP4')).toBe(false);
+  });
+
+  it('does not treat raw PCM sidecars as importable media', () => {
+    expect(getFileExtension('D:/ClassNoteAI/audio/in-progress/lecture.pcm')).toBe('pcm');
+    expect(isSupportedMediaPath('D:/ClassNoteAI/audio/in-progress/lecture.pcm')).toBe(false);
+    expect(isAudioOnlyMediaPath('D:/ClassNoteAI/temp_pcm/import.pcm')).toBe(false);
+    expect(mediaDialogExtensions()).not.toContain('pcm');
+  });
+});

--- a/ClassNoteAI/src/utils/__tests__/speakerLabels.test.ts
+++ b/ClassNoteAI/src/utils/__tests__/speakerLabels.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { buildSpeakerLabel } from '../speakerLabels';
+
+describe('buildSpeakerLabel', () => {
+  it('labels teacher speech directly', () => {
+    expect(buildSpeakerLabel('teacher')?.text).toBe('Teacher');
+  });
+
+  it('keeps student identity when a speaker id exists', () => {
+    expect(buildSpeakerLabel('student', 'speaker-2')?.text).toBe('Student 2');
+    expect(buildSpeakerLabel('student', 's_a')?.text).toBe('Student A');
+  });
+
+  it('hides completely unknown speakers but shows unknown speaker ids', () => {
+    expect(buildSpeakerLabel('unknown')).toBeNull();
+    expect(buildSpeakerLabel('unknown', 'speaker-0')?.text).toBe('Speaker 0');
+  });
+});

--- a/ClassNoteAI/src/utils/mediaFileTypes.ts
+++ b/ClassNoteAI/src/utils/mediaFileTypes.ts
@@ -1,0 +1,25 @@
+export const VIDEO_EXTENSIONS = ['mp4', 'm4v', 'mkv', 'webm', 'mov', 'avi'] as const;
+export const AUDIO_EXTENSIONS = ['wav', 'mp3', 'm4a', 'aac', 'flac', 'ogg', 'opus'] as const;
+export const SUPPORTED_MEDIA_EXTENSIONS = [...VIDEO_EXTENSIONS, ...AUDIO_EXTENSIONS] as const;
+
+const VIDEO_EXTENSION_SET = new Set<string>(VIDEO_EXTENSIONS);
+const AUDIO_EXTENSION_SET = new Set<string>(AUDIO_EXTENSIONS);
+
+export function getFileExtension(path: string): string | null {
+  const match = /(?:^|[\\/])?[^\\/]*\.([^./\\]+)$/.exec(path.trim());
+  return match?.[1]?.toLowerCase() ?? null;
+}
+
+export function isSupportedMediaPath(path: string): boolean {
+  const ext = getFileExtension(path);
+  return !!ext && (VIDEO_EXTENSION_SET.has(ext) || AUDIO_EXTENSION_SET.has(ext));
+}
+
+export function isAudioOnlyMediaPath(path: string): boolean {
+  const ext = getFileExtension(path);
+  return !!ext && AUDIO_EXTENSION_SET.has(ext);
+}
+
+export function mediaDialogExtensions(): string[] {
+  return [...SUPPORTED_MEDIA_EXTENSIONS];
+}

--- a/ClassNoteAI/src/utils/speakerLabels.ts
+++ b/ClassNoteAI/src/utils/speakerLabels.ts
@@ -1,0 +1,40 @@
+import type { SpeakerRole } from '../types/subtitle';
+
+export interface SpeakerLabel {
+  text: string;
+  className: string;
+}
+
+export function buildSpeakerLabel(
+  role: SpeakerRole | undefined,
+  speakerId?: string,
+): SpeakerLabel | null {
+  const resolvedRole = role ?? 'unknown';
+  if (resolvedRole === 'teacher') {
+    return {
+      text: 'Teacher',
+      className: 'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-900/25 dark:text-emerald-300 dark:border-emerald-800',
+    };
+  }
+  if (resolvedRole === 'student') {
+    return {
+      text: speakerId ? `Student ${normalizeSpeakerId(speakerId)}` : 'Student',
+      className: 'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-900/25 dark:text-amber-300 dark:border-amber-800',
+    };
+  }
+  if (speakerId) {
+    return {
+      text: `Speaker ${normalizeSpeakerId(speakerId)}`,
+      className: 'bg-slate-50 text-slate-600 border-slate-200 dark:bg-slate-700/40 dark:text-slate-300 dark:border-slate-600',
+    };
+  }
+  return null;
+}
+
+function normalizeSpeakerId(speakerId: string): string {
+  return speakerId
+    .replace(/^speaker[-_\s]*/i, '')
+    .replace(/^s[-_\s]*/i, '')
+    .trim()
+    .toUpperCase();
+}

--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@ ClassNote AI is built for real classrooms: live lectures, imported recordings, s
 | Live recording | Record a class and generate transcript captions while the session is running. |
 | Media import | Import lecture videos or audio-only recordings and process them through the same note pipeline. |
 | Translation | Produce Chinese subtitles from English lecture audio, with final transcript text used for stable translation. |
+| Speaker context | Preserve speaker attribution when available so teacher speech and student questions can be reviewed separately. |
+| Long-session safety | Keep long recordings recoverable, bound memory use, and warn or stop when a session appears forgotten. |
 | Course memory | Search across lecture transcripts, PDFs, notes, and course material. |
 | AI assistant | Ask questions about a lecture or course using your configured AI provider. |
 | Local-first data | Store lecture data, subtitles, notes, and indexes on your machine. |


### PR DESCRIPTION
## Summary
- Add a durable speaker metadata path (`teacher` / `student` / `unknown`, optional speaker id) through streaming events, subtitle persistence, recovery JSONL, import flows, SQLite storage, and subtitle display badges.
- Add long-session safety handling for live recording: hard cap, long-silence detection, translation queue backpressure telemetry, and UI status feedback.
- Bound live recording memory usage while disk persistence is enabled, and stream `.pcm -> .wav` finalization instead of loading the whole PCM into memory.
- Harden media import extension handling for audio/video files and explicitly keep temp import `.pcm` files isolated from interrupted-recording recovery `.pcm` files.
- Update README notes for long recording behavior and speaker-aware subtitles without locking the docs to a specific implementation detail.

## Validation
- `npx tsc --noEmit`
- `npx vitest run` (55 files, 443 tests)
- `npm run build`
- `cargo test --lib --package classnoteai recording::tests --message-format=short`
- `cargo test --lib --package classnoteai recording::video_import::tests --message-format=short`
- `cargo test --lib --package classnoteai storage::database::tests --message-format=short`
- `cargo test --lib --package classnoteai translation:: --message-format=short`
- `cargo test --lib --package classnoteai vad:: --message-format=short`
- `cargo test --lib --package classnoteai setup:: --message-format=short`
- `cargo test --lib --package classnoteai gpu:: --message-format=short`
- `cargo test --lib --package classnoteai paths:: --message-format=short`
- `cargo test --lib --package classnoteai utils::sys_proxy::tests --message-format=short`
- `cargo test --lib --package classnoteai utils::onnx::tests::test_init_onnx --message-format=short`
- `git diff --cached --check`
- `rustfmt --edition 2021 src\recording\mod.rs src\recording\video_import.rs src\storage\database.rs src\storage\models.rs`

## Notes
- Full `cargo test --lib --package classnoteai --message-format=short` still times out in the existing `utils::onnx::tests::test_session_builder_does_not_hang`; that isolated test also timed out alone. The touched Rust modules were covered with targeted tests above.
- This PR provides the durable metadata/storage/UI path for speaker roles and ids, but live speaker diarization inference is still a follow-up integration step once the selected runtime path is finalized.

Refs #57
Refs #62