### PR TITLE
Add agent CLI and local app bridge

### DIFF
--- a/ClassNoteAI/evals/scripts/__tests__/cnai-agent.test.ts
+++ b/ClassNoteAI/evals/scripts/__tests__/cnai-agent.test.ts
@@ -1,0 +1,218 @@
+import { execFileSync, spawnSync } from 'node:child_process';
+import { spawn } from 'node:child_process';
+import { mkdtempSync, writeFileSync } from 'node:fs';
+import { createServer } from 'node:http';
+import { tmpdir } from 'node:os';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+const testDir = dirname(fileURLToPath(import.meta.url));
+const projectRoot = resolve(testDir, '../../..');
+const cliPath = resolve(projectRoot, 'scripts/cnai-agent.mjs');
+
+function runCli(args: string[]) {
+  return execFileSync(process.execPath, [cliPath, ...args], {
+    cwd: projectRoot,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      CNAI_AGENT_ATTACH_FILE: resolve(tmpdir(), 'cnai-agent-test-noattach.json'),
+      CNAI_AGENT_BRIDGE_URL: '',
+    },
+  });
+}
+
+function runCliJson(args: string[], env: NodeJS.ProcessEnv = {}) {
+  return spawnSync(process.execPath, [cliPath, ...args], {
+    cwd: projectRoot,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      ...env,
+    },
+  });
+}
+
+function runCliAsync(args: string[], env: NodeJS.ProcessEnv = {}) {
+  return new Promise<{ status: number | null; stdout: string; stderr: string }>((resolveRun) => {
+    const child = spawn(process.execPath, [cliPath, ...args], {
+      cwd: projectRoot,
+      env: {
+        ...process.env,
+        ...env,
+      },
+      stdio: ['ignore', 'pipe', 'pipe'],
+    });
+    let stdout = '';
+    let stderr = '';
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk.toString();
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk.toString();
+    });
+    child.on('close', (status) => {
+      resolveRun({ status, stdout, stderr });
+    });
+  });
+}
+
+describe('cnai-agent CLI', () => {
+  it('prints a versioned handshake contract', () => {
+    const payload = JSON.parse(runCli(['handshake', '--json']));
+
+    expect(payload.schemaVersion).toBe(1);
+    expect(payload.cli.name).toBe('cnai-agent');
+    expect(payload.app.packageName).toBe('classnoteai');
+    expect(payload.capabilities.map((cap: { id: string }) => cap.id)).toEqual(
+      expect.arrayContaining(['agent.handshake', 'agent.smoke']),
+    );
+    expect(payload.smokeProfiles.quick).toEqual(['typecheck']);
+    expect(payload.capabilities.map((cap: { id: string }) => cap.id)).toEqual(
+      expect.arrayContaining([
+        'app.launch',
+        'app.attach',
+        'app.status',
+        'events.watch',
+        'logs.tail',
+        'diag.bundle',
+        'ui.snapshot',
+        'call.raw',
+      ]),
+    );
+  });
+
+  it('supports dry-run smoke output without executing tools', () => {
+    const payload = JSON.parse(
+      runCli(['smoke', '--profile', 'frontend', '--dry-run', '--json']),
+    );
+
+    expect(payload.schemaVersion).toBe(1);
+    expect(payload.type).toBe('smoke_result');
+    expect(payload.profile).toBe('frontend');
+    expect(payload.status).toBe('passed');
+    expect(payload.steps).toHaveLength(2);
+    expect(payload.steps.map((step: { status: string }) => step.status)).toEqual([
+      'skipped',
+      'skipped',
+    ]);
+  });
+
+  it('streams NDJSON events for parent agents', () => {
+    const output = runCli([
+      'smoke',
+      '--profile',
+      'quick',
+      '--dry-run',
+      '--ndjson',
+    ]);
+    const events = output
+      .trim()
+      .split('\n')
+      .map((line) => JSON.parse(line));
+
+    expect(events.map((event: { type: string }) => event.type)).toEqual([
+      'run_started',
+      'step_started',
+      'step_finished',
+      'run_finished',
+    ]);
+    expect(events.every((event: { schemaVersion: number }) => event.schemaVersion === 1)).toBe(
+      true,
+    );
+  });
+
+  it('returns exit code 2 for invalid profiles', () => {
+    const result = spawnSync(
+      process.execPath,
+      [cliPath, 'smoke', '--profile', 'missing', '--json'],
+      {
+        cwd: projectRoot,
+        encoding: 'utf8',
+      },
+    );
+
+    expect(result.status).toBe(2);
+    expect(result.stderr).toContain('Unknown profile');
+  });
+
+  it('reports bridge unavailable for app status without a bridge URL', () => {
+    const result = runCliJson(['app', 'status', '--json', '--attach-file', 'missing.json'], {
+      CNAI_AGENT_BRIDGE_URL: '',
+    });
+
+    const payload = JSON.parse(result.stdout);
+
+    expect(result.status).toBe(3);
+    expect(payload.type).toBe('bridge_unavailable');
+    expect(payload.command).toBe('app_status');
+    expect(payload.bridge.configured).toBe(false);
+  });
+
+  it('lists planned workflow contracts', () => {
+    const payload = JSON.parse(runCli(['workflow', 'list', '--json']));
+
+    expect(payload.type).toBe('workflow_contracts');
+    expect(payload.workflows.map((workflow: { id: string }) => workflow.id)).toEqual(
+      expect.arrayContaining(['smoke.frontend', 'import-media', 'summarize']),
+    );
+  });
+
+  it('reads attach files and calls a running bridge with bearer auth', async () => {
+    let authorization: string | undefined;
+    const server = createServer((req, res) => {
+      authorization = req.headers.authorization;
+      res.setHeader('content-type', 'application/json');
+      res.end(
+        JSON.stringify({
+          schemaVersion: 1,
+          type: 'app_status',
+          status: 'ok',
+        }),
+      );
+    });
+    await new Promise<void>((resolveListen) => server.listen(0, '127.0.0.1', resolveListen));
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('server did not bind to a TCP port');
+    }
+    const tempDir = mkdtempSync(resolve(tmpdir(), 'cnai-agent-test-'));
+    const attachFile = resolve(tempDir, 'agent-bridge.json');
+    writeFileSync(
+      attachFile,
+      JSON.stringify({
+        schemaVersion: 1,
+        apiVersion: 1,
+        url: `http://127.0.0.1:${address.port}`,
+        token: 'test-token',
+        pid: 123,
+      }),
+    );
+
+    const result = await runCliAsync([
+      'app',
+      'status',
+      '--json',
+      '--attach-file',
+      attachFile,
+      '--timeout-ms',
+      '2000',
+    ]);
+    server.close();
+
+    const payload = JSON.parse(result.stdout);
+    expect(result.status).toBe(0);
+    expect(authorization).toBe('Bearer test-token');
+    expect(payload.type).toBe('app_status');
+    expect(payload.body.status).toBe('ok');
+  });
+
+  it('supports app launch dry-run without starting Tauri', () => {
+    const payload = JSON.parse(runCli(['app', 'launch', '--dry-run', '--json', '--port', '0']));
+
+    expect(payload.type).toBe('app_launch');
+    expect(payload.status).toBe('skipped');
+    expect(payload.env.CNAI_AGENT_BRIDGE).toBe('1');
+  });
+});

--- a/ClassNoteAI/package.json
+++ b/ClassNoteAI/package.json
@@ -10,6 +10,8 @@
     "test": "vitest",
     "test:watch": "vitest --watch",
     "test:coverage": "vitest --coverage",
+    "agent:handshake": "node scripts/cnai-agent.mjs handshake --json",
+    "agent:smoke": "node scripts/cnai-agent.mjs smoke --profile quick --json",
     "smoke:ocr": "tsx evals/scripts/ocr-smoke.ts",
     "eval:asr": "tsx evals/scripts/asr-wer.ts",
     "eval:segmenter": "tsx evals/scripts/segmenter-eval.ts",

--- a/ClassNoteAI/scripts/cnai-agent.mjs
+++ b/ClassNoteAI/scripts/cnai-agent.mjs
@@ -1,0 +1,1105 @@
+#!/usr/bin/env node
+
+import { spawn } from 'node:child_process';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir, tmpdir } from 'node:os';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const SCRIPT_DIR = dirname(fileURLToPath(import.meta.url));
+const PROJECT_ROOT = resolve(SCRIPT_DIR, '..');
+const PACKAGE_JSON = JSON.parse(
+  readFileSync(resolve(PROJECT_ROOT, 'package.json'), 'utf8'),
+);
+
+const CLI_VERSION = '0.1.0';
+const DEFAULT_BRIDGE_URL = process.env.CNAI_AGENT_BRIDGE_URL ?? '';
+const DEFAULT_BRIDGE_TOKEN = process.env.CNAI_AGENT_BRIDGE_TOKEN ?? '';
+const DEFAULT_ATTACH_FILE =
+  process.env.CNAI_AGENT_ATTACH_FILE ?? resolve(appDataDir(), 'agent-bridge.json');
+const PROFILES = {
+  quick: [
+    {
+      id: 'typecheck',
+      command: npmExec(),
+      args: ['exec', 'tsc', '--', '--noEmit'],
+      timeoutMs: 120_000,
+    },
+  ],
+  frontend: [
+    {
+      id: 'typecheck',
+      command: npmExec(),
+      args: ['exec', 'tsc', '--', '--noEmit'],
+      timeoutMs: 120_000,
+    },
+    {
+      id: 'vitest',
+      command: npmExec(),
+      args: ['exec', 'vitest', '--', 'run'],
+      timeoutMs: 180_000,
+    },
+  ],
+  release: [
+    {
+      id: 'vitest',
+      command: npmExec(),
+      args: ['exec', 'vitest', '--', 'run'],
+      timeoutMs: 180_000,
+    },
+    {
+      id: 'build',
+      command: npmExec(),
+      args: ['run', 'build'],
+      timeoutMs: 240_000,
+    },
+  ],
+};
+
+function npmExec() {
+  return process.platform === 'win32' ? 'npm.cmd' : 'npm';
+}
+
+function appDataDir() {
+  if (process.platform === 'win32') {
+    return resolve(process.env.APPDATA ?? homedir(), 'com.classnoteai');
+  }
+  if (process.platform === 'darwin') {
+    return resolve(homedir(), 'Library', 'Application Support', 'com.classnoteai');
+  }
+  return resolve(process.env.XDG_DATA_HOME ?? resolve(homedir(), '.local', 'share'), 'com.classnoteai');
+}
+
+function nowIso() {
+  return new Date().toISOString();
+}
+
+function usage() {
+  return `ClassNoteAI agent CLI
+
+Usage:
+  node scripts/cnai-agent.mjs handshake [--json]
+  node scripts/cnai-agent.mjs app launch [--json] [--dev] [--detach] [--port N]
+  node scripts/cnai-agent.mjs app attach [--json] [--attach-file PATH]
+  node scripts/cnai-agent.mjs app handshake [--json] [--bridge-url URL] [--token TOKEN]
+  node scripts/cnai-agent.mjs app status [--json] [--bridge-url URL] [--token TOKEN]
+  node scripts/cnai-agent.mjs events watch [--ndjson] [--bridge-url URL] [--token TOKEN]
+  node scripts/cnai-agent.mjs logs tail [--json] [--follow] [--bridge-url URL] [--token TOKEN]
+  node scripts/cnai-agent.mjs diag bundle [--json] [--output PATH]
+  node scripts/cnai-agent.mjs workflow list [--json]
+  node scripts/cnai-agent.mjs workflow import-media --json [--file PATH]
+  node scripts/cnai-agent.mjs ui snapshot [--json]
+  node scripts/cnai-agent.mjs ui tree [--json]
+  node scripts/cnai-agent.mjs call raw <command> [--json]
+  node scripts/cnai-agent.mjs smoke [--profile quick|frontend|release] [--json|--ndjson] [--dry-run] [--timeout-ms N]
+
+Commands:
+  handshake       Print the machine-readable CLI capability contract.
+  app launch      Launch the desktop app with the agent bridge enabled.
+  app attach      Read the app bridge attach file.
+  app handshake   Ask a running app bridge for its versioned contract.
+  app status      Ask a running app bridge for app/session health.
+  events watch    Stream app bridge events as NDJSON.
+  logs tail       Read or follow app bridge logs.
+  diag bundle     Write a local CLI diagnostic bundle.
+  workflow list   Print known workflow command contracts.
+  ui snapshot     Ask the app bridge for a visual snapshot.
+  ui tree         Ask the app bridge for a semantic UI tree.
+  call raw        Ask the bridge to invoke a raw app command.
+  smoke           Run a deterministic local smoke profile for agents/CI.
+
+Output:
+  --json      Print one final JSON object to stdout. Step logs go to stderr.
+  --ndjson    Print one JSON event per line to stdout.
+`;
+}
+
+function parseArgs(argv) {
+  const args = [...argv];
+  let command = args.shift();
+  if (['app', 'events', 'logs', 'diag', 'workflow', 'ui', 'call'].includes(command)) {
+    const subcommand = args.shift();
+    if (!subcommand || subcommand.startsWith('-')) {
+      throw new UsageError(`Missing subcommand for: ${command}`);
+    }
+    command = `${command}:${subcommand}`;
+  }
+  const options = {
+    command,
+    format: 'human',
+    profile: 'quick',
+    dryRun: false,
+    timeoutMs: undefined,
+    bridgeUrl: DEFAULT_BRIDGE_URL,
+    token: DEFAULT_BRIDGE_TOKEN,
+    attachFile: DEFAULT_ATTACH_FILE,
+    output: undefined,
+    follow: false,
+    detach: false,
+    dev: false,
+    port: undefined,
+    file: undefined,
+    positional: [],
+  };
+
+  while (args.length > 0) {
+    const arg = args.shift();
+    if (arg === '--json') {
+      options.format = 'json';
+    } else if (arg === '--ndjson') {
+      options.format = 'ndjson';
+    } else if (arg === '--dry-run') {
+      options.dryRun = true;
+    } else if (arg === '--profile') {
+      options.profile = args.shift();
+    } else if (arg === '--timeout-ms') {
+      const raw = args.shift();
+      const parsed = Number(raw);
+      if (!Number.isFinite(parsed) || parsed <= 0) {
+        throw new UsageError(`Invalid --timeout-ms value: ${raw}`);
+      }
+      options.timeoutMs = parsed;
+    } else if (arg === '--bridge-url') {
+      options.bridgeUrl = args.shift();
+    } else if (arg === '--token') {
+      options.token = args.shift();
+    } else if (arg === '--attach-file') {
+      options.attachFile = args.shift();
+    } else if (arg === '--port') {
+      const raw = args.shift();
+      const parsed = Number(raw);
+      if (!Number.isInteger(parsed) || parsed < 0 || parsed > 65535) {
+        throw new UsageError(`Invalid --port value: ${raw}`);
+      }
+      options.port = parsed;
+    } else if (arg === '--output') {
+      options.output = args.shift();
+    } else if (arg === '--file') {
+      options.file = args.shift();
+    } else if (arg === '--follow') {
+      options.follow = true;
+    } else if (arg === '--detach') {
+      options.detach = true;
+    } else if (arg === '--dev') {
+      options.dev = true;
+    } else if (arg === '--help' || arg === '-h') {
+      options.command = 'help';
+    } else {
+      options.positional.push(arg);
+    }
+  }
+
+  return options;
+}
+
+class UsageError extends Error {}
+
+function handshakePayload() {
+  return {
+    schemaVersion: 1,
+    cli: {
+      name: 'cnai-agent',
+      version: CLI_VERSION,
+    },
+    app: {
+      packageName: PACKAGE_JSON.name,
+      version: PACKAGE_JSON.version,
+    },
+    capabilities: [
+      {
+        id: 'agent.handshake',
+        stability: 'stable',
+        description: 'Return the local CLI capability contract.',
+      },
+      {
+        id: 'agent.smoke',
+        stability: 'experimental',
+        description: 'Run local smoke profiles with machine-readable results.',
+      },
+      {
+        id: 'app.handshake',
+        stability: 'experimental',
+        description: 'Negotiate with a running app bridge.',
+      },
+      {
+        id: 'app.status',
+        stability: 'experimental',
+        description: 'Inspect a running app bridge state.',
+      },
+      {
+        id: 'app.launch',
+        stability: 'experimental',
+        description: 'Launch the desktop app with the agent bridge enabled.',
+      },
+      {
+        id: 'app.attach',
+        stability: 'experimental',
+        description: 'Read the local app bridge attach file.',
+      },
+      {
+        id: 'events.watch',
+        stability: 'experimental',
+        description: 'Stream structured app events from the bridge.',
+      },
+      {
+        id: 'logs.tail',
+        stability: 'experimental',
+        description: 'Tail app logs through the bridge.',
+      },
+      {
+        id: 'diag.bundle',
+        stability: 'experimental',
+        description: 'Create a local diagnostic bundle for CLI/app bridge debugging.',
+      },
+      {
+        id: 'workflow.list',
+        stability: 'experimental',
+        description: 'List workflow command contracts exposed by this CLI.',
+      },
+      {
+        id: 'call.raw',
+        stability: 'planned',
+        description: 'Invoke a raw app command through the bridge.',
+      },
+      {
+        id: 'ui.snapshot',
+        stability: 'planned',
+        description: 'Capture visual state through the bridge.',
+      },
+      {
+        id: 'ui.tree',
+        stability: 'planned',
+        description: 'Read semantic UI state through the bridge.',
+      },
+    ],
+    bridge: {
+      transport: 'http',
+      env: 'CNAI_AGENT_BRIDGE_URL',
+      defaultUrl: DEFAULT_BRIDGE_URL || null,
+      attachFile: DEFAULT_ATTACH_FILE,
+      status: DEFAULT_BRIDGE_URL ? 'configured' : 'not_configured',
+    },
+    smokeProfiles: Object.fromEntries(
+      Object.entries(PROFILES).map(([name, steps]) => [
+        name,
+        steps.map((step) => step.id),
+      ]),
+    ),
+    outputFormats: ['human', 'json', 'ndjson'],
+    exitCodes: {
+      0: 'success',
+      1: 'command_failed',
+      2: 'usage_or_internal_error',
+      3: 'bridge_unavailable',
+    },
+  };
+}
+
+function printPayload(payload, format) {
+  if (format === 'json' || format === 'ndjson') {
+    process.stdout.write(`${JSON.stringify(payload)}\n`);
+    return;
+  }
+  process.stdout.write(`${JSON.stringify(payload, null, 2)}\n`);
+}
+
+function errorPayload(type, status, message, extra = {}) {
+  return {
+    schemaVersion: 1,
+    type,
+    status,
+    message,
+    ...extra,
+  };
+}
+
+function bridgeUnavailablePayload(command, bridgeUrl, message) {
+  return errorPayload('bridge_unavailable', 'unavailable', message, {
+    command,
+    bridge: {
+      configured: Boolean(bridgeUrl),
+      url: bridgeUrl || null,
+      transport: 'http',
+    },
+    nextStep:
+      'Start ClassNoteAI with the agent bridge enabled, then pass --bridge-url or set CNAI_AGENT_BRIDGE_URL.',
+  });
+}
+
+function readAttachFile(attachFile = DEFAULT_ATTACH_FILE) {
+  if (!attachFile || !existsSync(attachFile)) {
+    return null;
+  }
+  try {
+    return JSON.parse(readFileSync(attachFile, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function resolveBridge(options) {
+  const attach = readAttachFile(options.attachFile);
+  const url = options.bridgeUrl || attach?.url || '';
+  const token = options.token || attach?.token || '';
+  return {
+    url,
+    token,
+    attach,
+  };
+}
+
+function bridgeEndpoint(bridgeUrl, path) {
+  if (!bridgeUrl) {
+    return null;
+  }
+  return `${bridgeUrl.replace(/\/+$/u, '')}${path}`;
+}
+
+async function requestBridgeJson(command, options, path, init = {}) {
+  const bridge = resolveBridge(options);
+  const endpoint = bridgeEndpoint(bridge.url, path);
+  if (!endpoint) {
+    return {
+      code: 3,
+      payload: bridgeUnavailablePayload(
+        command,
+        bridge.url,
+        'No app bridge URL is configured.',
+      ),
+    };
+  }
+
+  try {
+    const response = await fetch(endpoint, {
+      method: init.method ?? 'GET',
+      signal: AbortSignal.timeout(options.timeoutMs ?? 30_000),
+      headers: {
+        accept: 'application/json',
+        ...(bridge.token ? { authorization: `Bearer ${bridge.token}` } : {}),
+        ...(init.body ? { 'content-type': 'application/json' } : {}),
+        ...(init.headers ?? {}),
+      },
+      body: init.body ? JSON.stringify(init.body) : undefined,
+    });
+    const text = await response.text();
+    let body = null;
+    try {
+      body = text ? JSON.parse(text) : null;
+    } catch {
+      body = text;
+    }
+
+    return {
+      code: response.ok ? 0 : 1,
+      payload: {
+        schemaVersion: 1,
+        type: command,
+        status: response.ok ? 'ok' : 'failed',
+        bridge: {
+          url: bridge.url,
+          httpStatus: response.status,
+          attachFile: options.attachFile,
+        },
+        body,
+      },
+    };
+  } catch (error) {
+    return {
+      code: 3,
+      payload: bridgeUnavailablePayload(
+        command,
+        bridge.url,
+        error instanceof Error ? error.message : String(error),
+      ),
+    };
+  }
+}
+
+async function readBridgeJson(command, bridgeUrl, path) {
+  return requestBridgeJson(command, { bridgeUrl, token: DEFAULT_BRIDGE_TOKEN, attachFile: DEFAULT_ATTACH_FILE }, path);
+}
+
+function emitEvent(event, options) {
+  const payload = {
+    schemaVersion: 1,
+    timestamp: nowIso(),
+    ...event,
+  };
+
+  if (options.format === 'ndjson') {
+    process.stdout.write(`${JSON.stringify(payload)}\n`);
+  } else if (options.format === 'human') {
+    const label = event.stepId ? `${event.type}:${event.stepId}` : event.type;
+    process.stderr.write(`[${label}] ${event.message ?? ''}\n`);
+  }
+
+  return payload;
+}
+
+function trimLog(value, maxLength = 12_000) {
+  if (value.length <= maxLength) {
+    return value;
+  }
+  return `${value.slice(0, maxLength)}\n...[truncated ${value.length - maxLength} chars]`;
+}
+
+function shellQuote(value) {
+  if (!/[\s"]/u.test(value)) {
+    return value;
+  }
+  return `"${value.replaceAll('"', '\\"')}"`;
+}
+
+function spawnSpec(step) {
+  if (process.platform !== 'win32') {
+    return {
+      command: step.command,
+      args: step.args,
+    };
+  }
+
+  return {
+    command: 'cmd.exe',
+    args: ['/d', '/s', '/c', [step.command, ...step.args].map(shellQuote).join(' ')],
+  };
+}
+
+async function runStep(step, options) {
+  const timeoutMs = options.timeoutMs ?? step.timeoutMs;
+  const startedAt = nowIso();
+  emitEvent(
+    {
+      type: 'step_started',
+      stepId: step.id,
+      command: [step.command, ...step.args],
+      timeoutMs,
+      message: `running ${step.id}`,
+    },
+    options,
+  );
+
+  if (options.dryRun) {
+    const result = {
+      id: step.id,
+      status: 'skipped',
+      startedAt,
+      finishedAt: nowIso(),
+      durationMs: 0,
+      exitCode: 0,
+      command: [step.command, ...step.args],
+      stdout: '',
+      stderr: '',
+    };
+    emitEvent(
+      {
+        type: 'step_finished',
+        stepId: step.id,
+        status: result.status,
+        exitCode: result.exitCode,
+        durationMs: result.durationMs,
+        message: `${step.id} ${result.status}`,
+      },
+      options,
+    );
+    return result;
+  }
+
+  const result = await new Promise((resolveStep) => {
+    const spec = spawnSpec(step);
+    const child = spawn(spec.command, spec.args, {
+      cwd: PROJECT_ROOT,
+      env: process.env,
+      windowsHide: true,
+    });
+
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+    const startMs = Date.now();
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill('SIGTERM');
+    }, timeoutMs);
+
+    child.stdout.on('data', (chunk) => {
+      const text = chunk.toString();
+      stdout += text;
+      if (options.format === 'human') {
+        process.stderr.write(text);
+      }
+    });
+
+    child.stderr.on('data', (chunk) => {
+      const text = chunk.toString();
+      stderr += text;
+      if (options.format === 'human') {
+        process.stderr.write(text);
+      }
+    });
+
+    child.on('error', (error) => {
+      clearTimeout(timer);
+      resolveStep({
+        id: step.id,
+        status: 'failed',
+        startedAt,
+        finishedAt: nowIso(),
+        durationMs: Date.now() - startMs,
+        exitCode: 1,
+        command: [step.command, ...step.args],
+        stdout: trimLog(stdout),
+        stderr: trimLog(`${stderr}\n${error.message}`.trim()),
+      });
+    });
+
+    child.on('close', (code, signal) => {
+      clearTimeout(timer);
+      const status = timedOut ? 'timed_out' : code === 0 ? 'passed' : 'failed';
+      resolveStep({
+        id: step.id,
+        status,
+        startedAt,
+        finishedAt: nowIso(),
+        durationMs: Date.now() - startMs,
+        exitCode: timedOut ? 124 : code ?? 1,
+        signal,
+        command: [step.command, ...step.args],
+        stdout: trimLog(stdout),
+        stderr: trimLog(stderr),
+      });
+    });
+  });
+
+  emitEvent(
+    {
+      type: 'step_finished',
+      stepId: step.id,
+      status: result.status,
+      exitCode: result.exitCode,
+      durationMs: result.durationMs,
+      message: `${step.id} ${result.status}`,
+    },
+    options,
+  );
+
+  return result;
+}
+
+async function runSmoke(options) {
+  const steps = PROFILES[options.profile];
+  if (!steps) {
+    throw new UsageError(
+      `Unknown profile: ${options.profile}. Expected one of: ${Object.keys(PROFILES).join(', ')}`,
+    );
+  }
+
+  const startedAt = nowIso();
+  emitEvent(
+    {
+      type: 'run_started',
+      profile: options.profile,
+      dryRun: options.dryRun,
+      message: `starting ${options.profile} smoke profile`,
+    },
+    options,
+  );
+
+  const results = [];
+  for (const step of steps) {
+    const result = await runStep(step, options);
+    results.push(result);
+    if (result.status !== 'passed' && result.status !== 'skipped') {
+      break;
+    }
+  }
+
+  const failed = results.find(
+    (result) => result.status !== 'passed' && result.status !== 'skipped',
+  );
+  const payload = {
+    schemaVersion: 1,
+    type: 'smoke_result',
+    profile: options.profile,
+    status: failed ? 'failed' : 'passed',
+    dryRun: options.dryRun,
+    startedAt,
+    finishedAt: nowIso(),
+    steps: results,
+  };
+
+  emitEvent(
+    {
+      type: 'run_finished',
+      profile: options.profile,
+      status: payload.status,
+      message: `${options.profile} smoke ${payload.status}`,
+    },
+    options,
+  );
+
+  if (options.format === 'json') {
+    printPayload(payload, 'json');
+  } else if (options.format === 'human') {
+    printPayload(payload, 'human');
+  }
+
+  return payload.status === 'passed' ? 0 : 1;
+}
+
+function launchApp(options) {
+  const command = npmExec();
+  const args = ['run', 'tauri', '--', 'dev'];
+  const env = {
+    ...process.env,
+    CNAI_AGENT_BRIDGE: '1',
+    CNAI_AGENT_ATTACH_FILE: options.attachFile,
+  };
+  if (options.port !== undefined) {
+    env.CNAI_AGENT_BRIDGE_PORT = String(options.port);
+  }
+
+  if (options.dryRun) {
+    const payload = {
+      schemaVersion: 1,
+      type: 'app_launch',
+      status: 'skipped',
+      dryRun: true,
+      command: [command, ...args],
+      env: {
+        CNAI_AGENT_BRIDGE: env.CNAI_AGENT_BRIDGE,
+        CNAI_AGENT_BRIDGE_PORT: env.CNAI_AGENT_BRIDGE_PORT ?? null,
+        CNAI_AGENT_ATTACH_FILE: env.CNAI_AGENT_ATTACH_FILE,
+      },
+    };
+    printPayload(payload, options.format);
+    return 0;
+  }
+
+  const spec = spawnSpec({ command, args });
+  const child = spawn(spec.command, spec.args, {
+    cwd: PROJECT_ROOT,
+    env,
+    detached: options.detach,
+    stdio: options.detach ? 'ignore' : 'inherit',
+    windowsHide: false,
+  });
+  if (options.detach) {
+    child.unref();
+  }
+
+  const payload = {
+    schemaVersion: 1,
+    type: 'app_launch',
+    status: 'started',
+    pid: child.pid,
+    detached: options.detach,
+    attachFile: options.attachFile,
+    command: [command, ...args],
+  };
+  printPayload(payload, options.format);
+  return 0;
+}
+
+function workflowContracts() {
+  return {
+    schemaVersion: 1,
+    type: 'workflow_contracts',
+    status: 'ok',
+    workflows: [
+      {
+        id: 'smoke.quick',
+        stability: 'experimental',
+        command: ['smoke', '--profile', 'quick'],
+        description: 'Run the fastest local sub-agent sanity check.',
+      },
+      {
+        id: 'smoke.frontend',
+        stability: 'experimental',
+        command: ['smoke', '--profile', 'frontend'],
+        description: 'Run typecheck and Vitest through the agent CLI.',
+      },
+      {
+        id: 'smoke.release',
+        stability: 'experimental',
+        command: ['smoke', '--profile', 'release'],
+        description: 'Run the frontend release gate through the agent CLI.',
+      },
+      {
+        id: 'diagnostics',
+        stability: 'experimental',
+        command: ['workflow', 'diagnostics'],
+        requiresBridge: true,
+        description: 'Create an app-backed diagnostic bundle through the bridge.',
+      },
+      {
+        id: 'import-media',
+        stability: 'planned',
+        command: ['workflow', 'import-media', '--file', '<path>'],
+        requiresBridge: true,
+        description: 'Import an audio/video file into a lecture through the app bridge.',
+      },
+      {
+        id: 'ocr-index',
+        stability: 'planned',
+        command: ['workflow', 'ocr-index', '--course-id', '<id>'],
+        requiresBridge: true,
+        description: 'Index course material through the app bridge.',
+      },
+      {
+        id: 'summarize',
+        stability: 'planned',
+        command: ['workflow', 'summarize', '--lecture-id', '<id>'],
+        requiresBridge: true,
+        description: 'Generate a lecture summary through the app bridge.',
+      },
+      {
+        id: 'chat',
+        stability: 'planned',
+        command: ['workflow', 'chat', '--course-id', '<id>', '--message', '<text>'],
+        requiresBridge: true,
+        description: 'Ask the AI tutor through the app bridge.',
+      },
+    ],
+  };
+}
+
+async function handleAppCommand(options) {
+  const subcommand = options.commandParts[1];
+  if (subcommand === 'launch') {
+    return launchApp(options);
+  }
+
+  if (subcommand === 'attach') {
+    const attach = readAttachFile(options.attachFile);
+    if (!attach) {
+      printPayload(
+        bridgeUnavailablePayload(
+          'app_attach',
+          options.bridgeUrl,
+          `No attach file found at ${options.attachFile}.`,
+        ),
+        options.format,
+      );
+      return 3;
+    }
+    printPayload(
+      {
+        schemaVersion: 1,
+        type: 'app_attach',
+        status: 'ok',
+        attachFile: options.attachFile,
+        bridge: {
+          url: attach.url,
+          pid: attach.pid,
+          apiVersion: attach.apiVersion,
+          createdAt: attach.createdAt,
+        },
+      },
+      options.format,
+    );
+    return 0;
+  }
+
+  if (subcommand === 'handshake') {
+    const { code, payload } = await requestBridgeJson(
+      'app_handshake',
+      options,
+      '/v1/handshake',
+    );
+    printPayload(payload, options.format);
+    return code;
+  }
+
+  if (subcommand === 'status') {
+    const { code, payload } = await requestBridgeJson(
+      'app_status',
+      options,
+      '/v1/status',
+    );
+    printPayload(payload, options.format);
+    return code;
+  }
+
+  throw new UsageError(`Unknown app command: ${subcommand ?? ''}`);
+}
+
+async function handleEventsCommand(options) {
+  const subcommand = options.commandParts[1];
+  if (subcommand !== 'watch') {
+    throw new UsageError(`Unknown events command: ${subcommand ?? ''}`);
+  }
+
+  const bridge = resolveBridge(options);
+  if (!bridge.url) {
+    printPayload(
+      bridgeUnavailablePayload('events_watch', bridge.url, 'No app bridge URL is configured.'),
+      options.format,
+    );
+    return 3;
+  }
+
+  const endpoint = bridgeEndpoint(bridge.url, '/v1/events');
+  try {
+    const response = await fetch(endpoint, {
+      signal: AbortSignal.timeout(options.timeoutMs ?? 30_000),
+      headers: {
+        accept: 'text/event-stream',
+        ...(bridge.token ? { authorization: `Bearer ${bridge.token}` } : {}),
+      },
+    });
+    const text = await response.text();
+    const events = parseSse(text);
+    if (options.format === 'ndjson') {
+      for (const event of events) {
+        process.stdout.write(`${JSON.stringify(event)}\n`);
+      }
+    } else {
+      printPayload(
+        {
+          schemaVersion: 1,
+          type: 'events_watch',
+          status: response.ok ? 'ok' : 'failed',
+          bridge: { url: bridge.url, httpStatus: response.status },
+          events,
+        },
+        options.format,
+      );
+    }
+    return response.ok ? 0 : 1;
+  } catch (error) {
+    printPayload(
+      bridgeUnavailablePayload(
+        'events_watch',
+        bridge.url,
+        error instanceof Error ? error.message : String(error),
+      ),
+      options.format,
+    );
+    return 3;
+  }
+}
+
+async function handleLogsCommand(options) {
+  const subcommand = options.commandParts[1];
+  if (subcommand !== 'tail') {
+    throw new UsageError(`Unknown logs command: ${subcommand ?? ''}`);
+  }
+
+  const bridge = resolveBridge(options);
+  if (!bridge.url) {
+    printPayload(
+      bridgeUnavailablePayload('logs_tail', bridge.url, 'No app bridge URL is configured.'),
+      options.format,
+    );
+    return 3;
+  }
+
+  const path = options.follow ? '/v1/logs?follow=1' : '/v1/logs';
+  const { code, payload } = await requestBridgeJson('logs_tail', options, path);
+  printPayload(payload, options.format);
+  return code;
+}
+
+function writeDiagBundle(options) {
+  const createdAt = nowIso();
+  const defaultDir = resolve(tmpdir(), 'classnoteai-agent');
+  mkdirSync(defaultDir, { recursive: true });
+  const outputPath =
+    options.output ?? resolve(defaultDir, `diag-${createdAt.replace(/[:.]/gu, '-')}.json`);
+  const payload = {
+    schemaVersion: 1,
+    type: 'diag_bundle',
+    status: 'ok',
+    createdAt,
+    cli: handshakePayload().cli,
+    app: handshakePayload().app,
+    bridge: handshakePayload().bridge,
+    platform: {
+      node: process.version,
+      platform: process.platform,
+      arch: process.arch,
+      cwd: process.cwd(),
+    },
+    outputPath,
+  };
+  writeFileSync(outputPath, `${JSON.stringify(payload, null, 2)}\n`, 'utf8');
+  printPayload(payload, options.format);
+  return 0;
+}
+
+async function handleDiagCommand(options) {
+  const subcommand = options.commandParts[1];
+  if (subcommand !== 'bundle') {
+    throw new UsageError(`Unknown diag command: ${subcommand ?? ''}`);
+  }
+  const bridge = resolveBridge(options);
+  if (bridge.url && !options.output) {
+    const { code, payload } = await requestBridgeJson('diag_bundle', options, '/v1/diag/bundle', {
+      method: 'POST',
+      body: {},
+    });
+    printPayload(payload, options.format);
+    return code;
+  }
+  return writeDiagBundle(options);
+}
+
+async function handleWorkflowCommand(options) {
+  const subcommand = options.commandParts[1];
+  if (subcommand === 'list') {
+    const bridge = resolveBridge(options);
+    if (bridge.url) {
+      const { code, payload } = await requestBridgeJson('workflow_list', options, '/v1/workflows');
+      printPayload(payload, options.format);
+      return code;
+    }
+    printPayload(workflowContracts(), options.format);
+    return 0;
+  }
+
+  const contracts = workflowContracts().workflows;
+  const contract = contracts.find((item) => item.id === subcommand);
+  if (contract?.requiresBridge) {
+    const { code, payload } = await requestBridgeJson(
+      `workflow_${subcommand}`,
+      options,
+      `/v1/workflow/${subcommand}`,
+      {
+        method: 'POST',
+        body: {
+          file: options.file ?? null,
+        },
+      },
+    );
+    printPayload(payload, options.format);
+    return code;
+  }
+
+  throw new UsageError(`Unknown workflow command: ${subcommand ?? ''}`);
+}
+
+function parseSse(text) {
+  return text
+    .split(/\r?\n\r?\n/u)
+    .filter((block) => block.trim().length > 0)
+    .map((block) => {
+      const event = { schemaVersion: 1, type: 'sse_event', event: 'message', data: null };
+      const dataLines = [];
+      for (const line of block.split(/\r?\n/u)) {
+        if (line.startsWith('event:')) {
+          event.event = line.slice('event:'.length).trim();
+        } else if (line.startsWith('data:')) {
+          dataLines.push(line.slice('data:'.length).trim());
+        }
+      }
+      const dataText = dataLines.join('\n');
+      try {
+        event.data = dataText ? JSON.parse(dataText) : null;
+      } catch {
+        event.data = dataText;
+      }
+      return event;
+    });
+}
+
+async function handleUiCommand(options) {
+  const subcommand = options.commandParts[1];
+  if (!['snapshot', 'tree'].includes(subcommand)) {
+    throw new UsageError(`Unknown ui command: ${subcommand ?? ''}`);
+  }
+  const { code, payload } = await requestBridgeJson(`ui_${subcommand}`, options, `/v1/ui/${subcommand}`);
+  printPayload(payload, options.format);
+  return code;
+}
+
+async function handleCallCommand(options) {
+  const subcommand = options.commandParts[1];
+  if (subcommand !== 'raw') {
+    throw new UsageError(`Unknown call command: ${subcommand ?? ''}`);
+  }
+  const command = options.positional[0];
+  if (!command) {
+    throw new UsageError('call raw requires a command name');
+  }
+  const { code, payload } = await requestBridgeJson('call_raw', options, '/v1/call/raw', {
+    method: 'POST',
+    body: {
+      command,
+      args: options.positional.slice(1),
+    },
+  });
+  printPayload(payload, options.format);
+  return code;
+}
+
+async function main() {
+  let options;
+  try {
+    options = parseArgs(process.argv.slice(2));
+  } catch (error) {
+    if (error instanceof UsageError) {
+      process.stderr.write(`${error.message}\n\n${usage()}`);
+      return 2;
+    }
+    throw error;
+  }
+
+  if (!options.command || options.command === 'help') {
+    process.stdout.write(usage());
+    return 0;
+  }
+
+  options.commandParts = options.command.split(':');
+
+  try {
+    if (options.command === 'handshake') {
+      printPayload(handshakePayload(), options.format);
+      return 0;
+    }
+    if (options.commandParts[0] === 'app') {
+      return await handleAppCommand(options);
+    }
+    if (options.commandParts[0] === 'events') {
+      return await handleEventsCommand(options);
+    }
+    if (options.commandParts[0] === 'logs') {
+      return await handleLogsCommand(options);
+    }
+    if (options.commandParts[0] === 'diag') {
+      return await handleDiagCommand(options);
+    }
+    if (options.commandParts[0] === 'workflow') {
+      return await handleWorkflowCommand(options);
+    }
+    if (options.commandParts[0] === 'ui') {
+      return await handleUiCommand(options);
+    }
+    if (options.commandParts[0] === 'call') {
+      return await handleCallCommand(options);
+    }
+    if (options.command === 'smoke') {
+      return await runSmoke(options);
+    }
+    throw new UsageError(`Unknown command: ${options.command}`);
+  } catch (error) {
+    if (error instanceof UsageError) {
+      process.stderr.write(`${error.message}\n\n${usage()}`);
+      return 2;
+    }
+
+    const payload = {
+      schemaVersion: 1,
+      type: 'internal_error',
+      status: 'failed',
+      message: error instanceof Error ? error.message : String(error),
+    };
+    if (options?.format === 'json' || options?.format === 'ndjson') {
+      printPayload(payload, options.format);
+    } else {
+      process.stderr.write(`${payload.message}\n`);
+    }
+    return 2;
+  }
+}
+
+process.exitCode = await main();

--- a/ClassNoteAI/src-tauri/src/agent_bridge.rs
+++ b/ClassNoteAI/src-tauri/src/agent_bridge.rs
@@ -1,0 +1,682 @@
+use std::collections::{HashMap, VecDeque};
+use std::fs;
+use std::path::PathBuf;
+use std::sync::Arc;
+
+use rand::RngCore;
+use serde::{Deserialize, Serialize};
+use serde_json::{json, Value};
+use tauri::{AppHandle, Manager};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::{TcpListener, TcpStream};
+use tokio::sync::Mutex;
+
+const API_VERSION: u32 = 1;
+const DEFAULT_PORT: u16 = 4317;
+const MAX_REQUEST_BYTES: usize = 64 * 1024;
+const EVENT_RING_CAPACITY: usize = 128;
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct AttachFile {
+    pub schema_version: u32,
+    pub api_version: u32,
+    pub app_version: String,
+    pub url: String,
+    pub token: String,
+    pub pid: u32,
+    pub port: u16,
+    pub created_at: String,
+}
+
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct BridgeEvent {
+    id: u64,
+    event_type: String,
+    timestamp: String,
+    payload: Value,
+}
+
+#[derive(Debug)]
+struct BridgeState {
+    app: AppHandle,
+    attach: AttachFile,
+    started_at: String,
+    events: Mutex<VecDeque<BridgeEvent>>,
+    next_event_id: Mutex<u64>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct HttpRequest {
+    method: String,
+    path: String,
+    query: HashMap<String, String>,
+    headers: HashMap<String, String>,
+    body: Vec<u8>,
+}
+
+pub fn enabled_from_env() -> bool {
+    std::env::var("CNAI_AGENT_BRIDGE")
+        .map(|value| matches!(value.as_str(), "1" | "true" | "TRUE" | "yes" | "on"))
+        .unwrap_or(false)
+        || std::env::var("CNAI_AGENT_BRIDGE_PORT").is_ok()
+}
+
+pub fn maybe_start(app: AppHandle) -> Result<(), String> {
+    if !enabled_from_env() {
+        return Ok(());
+    }
+
+    start(app)
+}
+
+pub fn start(app: AppHandle) -> Result<(), String> {
+    let requested_port = std::env::var("CNAI_AGENT_BRIDGE_PORT")
+        .ok()
+        .and_then(|value| value.parse::<u16>().ok())
+        .unwrap_or(DEFAULT_PORT);
+    let token = std::env::var("CNAI_AGENT_BRIDGE_TOKEN").unwrap_or_else(|_| generate_token());
+
+    tauri::async_runtime::spawn(async move {
+        if let Err(error) = run_server(app, requested_port, token).await {
+            eprintln!("[agent_bridge] failed: {error}");
+        }
+    });
+
+    Ok(())
+}
+
+async fn run_server(app: AppHandle, requested_port: u16, token: String) -> Result<(), String> {
+    let bind_addr = format!("127.0.0.1:{requested_port}");
+    let listener = TcpListener::bind(&bind_addr)
+        .await
+        .map_err(|e| format!("bind {bind_addr}: {e}"))?;
+    let port = listener
+        .local_addr()
+        .map_err(|e| format!("local_addr: {e}"))?
+        .port();
+
+    let created_at = now();
+    let attach = AttachFile {
+        schema_version: 1,
+        api_version: API_VERSION,
+        app_version: env!("CARGO_PKG_VERSION").to_string(),
+        url: format!("http://127.0.0.1:{port}"),
+        token,
+        pid: std::process::id(),
+        port,
+        created_at: created_at.clone(),
+    };
+
+    write_attach_file(&app, &attach)?;
+
+    let state = Arc::new(BridgeState {
+        app,
+        attach,
+        started_at: created_at,
+        events: Mutex::new(VecDeque::with_capacity(EVENT_RING_CAPACITY)),
+        next_event_id: Mutex::new(1),
+    });
+
+    push_event(
+        &state,
+        "bridge.started",
+        json!({
+            "url": state.attach.url,
+            "pid": state.attach.pid,
+        }),
+    )
+    .await;
+    println!("[agent_bridge] listening on {}", state.attach.url);
+
+    loop {
+        let (stream, _) = listener
+            .accept()
+            .await
+            .map_err(|e| format!("accept: {e}"))?;
+        let state = state.clone();
+        tauri::async_runtime::spawn(async move {
+            if let Err(error) = handle_connection(stream, state).await {
+                eprintln!("[agent_bridge] request failed: {error}");
+            }
+        });
+    }
+}
+
+async fn push_event(state: &Arc<BridgeState>, event_type: &str, payload: Value) {
+    let mut next = state.next_event_id.lock().await;
+    let event = BridgeEvent {
+        id: *next,
+        event_type: event_type.to_string(),
+        timestamp: now(),
+        payload,
+    };
+    *next += 1;
+
+    let mut events = state.events.lock().await;
+    if events.len() >= EVENT_RING_CAPACITY {
+        events.pop_front();
+    }
+    events.push_back(event);
+}
+
+fn write_attach_file(app: &AppHandle, attach: &AttachFile) -> Result<(), String> {
+    let path = attach_file_path(app)?;
+    if let Some(parent) = path.parent() {
+        fs::create_dir_all(parent).map_err(|e| format!("create attach dir: {e}"))?;
+    }
+    let bytes = serde_json::to_vec_pretty(attach).map_err(|e| format!("serialize attach: {e}"))?;
+    fs::write(&path, bytes).map_err(|e| format!("write attach file {}: {e}", path.display()))
+}
+
+fn attach_file_path(app: &AppHandle) -> Result<PathBuf, String> {
+    if let Some(path) = std::env::var_os("CNAI_AGENT_ATTACH_FILE") {
+        return Ok(PathBuf::from(path));
+    }
+    Ok(app
+        .path()
+        .app_data_dir()
+        .map_err(|e| format!("resolve app data dir: {e}"))?
+        .join("agent-bridge.json"))
+}
+
+fn generate_token() -> String {
+    let mut bytes = [0_u8; 32];
+    rand::thread_rng().fill_bytes(&mut bytes);
+    bytes.iter().map(|byte| format!("{byte:02x}")).collect()
+}
+
+async fn handle_connection(mut stream: TcpStream, state: Arc<BridgeState>) -> Result<(), String> {
+    let request = read_request(&mut stream).await?;
+    let response = route_request(request, state).await;
+    stream
+        .write_all(&response)
+        .await
+        .map_err(|e| format!("write response: {e}"))?;
+    Ok(())
+}
+
+async fn read_request(stream: &mut TcpStream) -> Result<HttpRequest, String> {
+    let mut buffer = Vec::with_capacity(4096);
+    let mut temp = [0_u8; 1024];
+    loop {
+        let read = stream
+            .read(&mut temp)
+            .await
+            .map_err(|e| format!("read request: {e}"))?;
+        if read == 0 {
+            break;
+        }
+        buffer.extend_from_slice(&temp[..read]);
+        if buffer.windows(4).any(|window| window == b"\r\n\r\n") {
+            break;
+        }
+        if buffer.len() > MAX_REQUEST_BYTES {
+            return Err("request too large".to_string());
+        }
+    }
+    parse_http_request(&buffer)
+}
+
+async fn route_request(request: HttpRequest, state: Arc<BridgeState>) -> Vec<u8> {
+    if request.method == "OPTIONS" {
+        return empty_response(204);
+    }
+
+    if request.path == "/v1/handshake" {
+        return json_response(200, handshake_payload(&state));
+    }
+
+    if !is_authorized(&request, &state.attach.token) {
+        return json_response(
+            401,
+            json!({
+                "schemaVersion": 1,
+                "type": "auth_error",
+                "status": "unauthorized",
+                "message": "Missing or invalid bearer token.",
+            }),
+        );
+    }
+
+    match (request.method.as_str(), request.path.as_str()) {
+        ("GET", "/v1/status") => json_response(200, status_payload(&state).await),
+        ("GET", "/v1/logs") => json_response(200, logs_payload(&state, &request).await),
+        ("GET", "/v1/events") => events_response(&state).await,
+        ("POST", "/v1/diag/bundle") => diag_bundle_response(&state).await,
+        ("GET", "/v1/workflows") => json_response(200, workflow_payload()),
+        ("POST", "/v1/call/raw") => raw_command_response(&state, &request).await,
+        ("POST", "/v1/workflow/diagnostics") => diag_bundle_response(&state).await,
+        ("POST", "/v1/workflow/import-media") => unsupported_response("workflow.import-media"),
+        ("POST", "/v1/workflow/ocr-index") => unsupported_response("workflow.ocr-index"),
+        ("POST", "/v1/workflow/summarize") => unsupported_response("workflow.summarize"),
+        ("POST", "/v1/workflow/chat") => unsupported_response("workflow.chat"),
+        ("GET", "/v1/ui/snapshot") => unsupported_response("ui.snapshot"),
+        ("GET", "/v1/ui/tree") => json_response(200, ui_tree_payload(&state)),
+        _ => json_response(
+            404,
+            json!({
+                "schemaVersion": 1,
+                "type": "not_found",
+                "status": "failed",
+                "message": format!("No agent bridge route for {} {}", request.method, request.path),
+            }),
+        ),
+    }
+}
+
+fn handshake_payload(state: &BridgeState) -> Value {
+    json!({
+        "schemaVersion": 1,
+        "type": "bridge_handshake",
+        "status": "ok",
+        "apiVersion": API_VERSION,
+        "app": {
+            "name": "ClassNoteAI",
+            "version": state.attach.app_version,
+            "pid": state.attach.pid,
+        },
+        "bridge": {
+            "url": state.attach.url,
+            "auth": "bearer",
+            "startedAt": state.started_at,
+        },
+        "capabilities": [
+            {"id": "app.handshake", "stability": "stable"},
+            {"id": "app.status", "stability": "stable"},
+            {"id": "logs.tail", "stability": "experimental"},
+            {"id": "events.watch", "stability": "experimental"},
+            {"id": "diag.bundle", "stability": "experimental"},
+            {"id": "workflow.list", "stability": "experimental"},
+            {"id": "call.raw", "stability": "planned"},
+            {"id": "workflow.import-media", "stability": "planned"},
+            {"id": "workflow.diagnostics", "stability": "experimental"},
+            {"id": "workflow.ocr-index", "stability": "planned"},
+            {"id": "workflow.summarize", "stability": "planned"},
+            {"id": "workflow.chat", "stability": "planned"},
+            {"id": "ui.snapshot", "stability": "planned"},
+            {"id": "ui.tree", "stability": "planned"}
+        ],
+    })
+}
+
+async fn status_payload(state: &Arc<BridgeState>) -> Value {
+    let events = state.events.lock().await;
+    let window_count = state.app.webview_windows().len();
+    let log_dir = state
+        .app
+        .path()
+        .app_log_dir()
+        .map(|path| path.to_string_lossy().to_string())
+        .ok();
+    let app_data_dir = state
+        .app
+        .path()
+        .app_data_dir()
+        .map(|path| path.to_string_lossy().to_string())
+        .ok();
+
+    json!({
+        "schemaVersion": 1,
+        "type": "app_status",
+        "status": "ok",
+        "app": {
+            "version": state.attach.app_version,
+            "pid": state.attach.pid,
+            "windowCount": window_count,
+        },
+        "bridge": {
+            "url": state.attach.url,
+            "apiVersion": API_VERSION,
+            "startedAt": state.started_at,
+            "eventCount": events.len(),
+        },
+        "paths": {
+            "appDataDir": app_data_dir,
+            "logDir": log_dir,
+        }
+    })
+}
+
+async fn logs_payload(state: &Arc<BridgeState>, request: &HttpRequest) -> Value {
+    let lines = request
+        .query
+        .get("lines")
+        .and_then(|value| value.parse::<usize>().ok())
+        .unwrap_or(200)
+        .min(2000);
+    let text = read_recent_log_lines(&state.app, lines)
+        .unwrap_or_else(|error| format!("[agent_bridge] failed to read app log: {error}"));
+    json!({
+        "schemaVersion": 1,
+        "type": "logs_tail",
+        "status": "ok",
+        "lines": lines,
+        "followSupported": false,
+        "text": text,
+    })
+}
+
+async fn events_response(state: &Arc<BridgeState>) -> Vec<u8> {
+    let events = state.events.lock().await;
+    let mut body = String::new();
+    body.push_str("event: bridge.snapshot\n");
+    body.push_str(&format!(
+        "data: {}\n\n",
+        json!({
+            "schemaVersion": 1,
+            "type": "event_snapshot",
+            "status": "ok",
+            "events": events.iter().collect::<Vec<_>>(),
+        })
+    ));
+    raw_response(
+        200,
+        "OK",
+        "text/event-stream; charset=utf-8",
+        body.into_bytes(),
+    )
+}
+
+async fn diag_bundle_response(state: &Arc<BridgeState>) -> Vec<u8> {
+    let log_text = read_recent_log_lines(&state.app, 2000).unwrap_or_default();
+    let input = crate::diagnostics::DiagnosticPackageInput {
+        lecture_meta_json: "{}".to_string(),
+        subtitles_json: "[]".to_string(),
+        audio_path: None,
+        redacted_log_text: log_text,
+        metadata_json: serde_json::to_string_pretty(&json!({
+            "source": "agent_bridge",
+            "createdAt": now(),
+            "bridge": {
+                "url": state.attach.url,
+                "apiVersion": API_VERSION,
+            },
+            "app": {
+                "version": state.attach.app_version,
+                "pid": state.attach.pid,
+            }
+        }))
+        .unwrap_or_else(|_| "{}".to_string()),
+    };
+    match crate::diagnostics::build_diagnostic_zip(input, false) {
+        Ok(path) => json_response(
+            200,
+            json!({
+                "schemaVersion": 1,
+                "type": "diag_bundle",
+                "status": "ok",
+                "path": path.to_string_lossy(),
+            }),
+        ),
+        Err(error) => json_response(
+            500,
+            json!({
+                "schemaVersion": 1,
+                "type": "diag_bundle",
+                "status": "failed",
+                "message": error,
+            }),
+        ),
+    }
+}
+
+fn workflow_payload() -> Value {
+    json!({
+        "schemaVersion": 1,
+        "type": "workflow_contracts",
+        "status": "ok",
+        "workflows": [
+            {"id": "diagnostics", "stability": "experimental", "requiresBridge": true},
+            {"id": "import-media", "stability": "planned", "requiresBridge": true},
+            {"id": "ocr-index", "stability": "planned", "requiresBridge": true},
+            {"id": "summarize", "stability": "planned", "requiresBridge": true},
+            {"id": "chat", "stability": "planned", "requiresBridge": true}
+        ]
+    })
+}
+
+async fn raw_command_response(state: &Arc<BridgeState>, request: &HttpRequest) -> Vec<u8> {
+    let value: Value = serde_json::from_slice(&request.body).unwrap_or_else(|_| json!({}));
+    let command = value
+        .get("command")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+
+    let result = match command {
+        "get_build_features" => json!({
+            "nmt_local": cfg!(feature = "nmt-local"),
+            "gpu_cuda": cfg!(feature = "gpu-cuda"),
+            "bundle_cuda": cfg!(feature = "bundle-cuda"),
+            "gpu_metal": cfg!(feature = "gpu-metal"),
+            "gpu_vulkan": cfg!(feature = "gpu-vulkan"),
+        }),
+        "agent_bridge_status" => status_payload(state).await,
+        _ => {
+            return json_response(
+                404,
+                json!({
+                    "schemaVersion": 1,
+                    "type": "raw_command",
+                    "status": "failed",
+                    "message": format!("Raw command is not allowlisted: {command}"),
+                    "allowlist": ["get_build_features", "agent_bridge_status"],
+                }),
+            )
+        }
+    };
+
+    json_response(
+        200,
+        json!({
+            "schemaVersion": 1,
+            "type": "raw_command",
+            "status": "ok",
+            "command": command,
+            "result": result,
+        }),
+    )
+}
+
+fn ui_tree_payload(state: &Arc<BridgeState>) -> Value {
+    let windows = state
+        .app
+        .webview_windows()
+        .into_keys()
+        .map(|label| {
+            json!({
+                "id": label,
+                "role": "window",
+                "label": label,
+            })
+        })
+        .collect::<Vec<_>>();
+
+    json!({
+        "schemaVersion": 1,
+        "type": "ui_tree",
+        "status": "ok",
+        "source": "tauri-window-inventory",
+        "note": "Semantic DOM/accessibility tree is not wired yet; this is the stable native window inventory.",
+        "tree": {
+            "role": "application",
+            "label": "ClassNoteAI",
+            "children": windows,
+        }
+    })
+}
+
+fn unsupported_response(capability: &str) -> Vec<u8> {
+    json_response(
+        501,
+        json!({
+            "schemaVersion": 1,
+            "type": "unsupported",
+            "status": "unsupported",
+            "capability": capability,
+            "message": format!("{capability} is part of the Agent Bridge contract but is not implemented yet."),
+        }),
+    )
+}
+
+fn read_recent_log_lines(app: &AppHandle, lines: usize) -> Result<String, String> {
+    let log_path = app
+        .path()
+        .app_log_dir()
+        .map_err(|e| format!("resolve log dir: {e}"))?
+        .join("classnoteai.log");
+    if !log_path.exists() {
+        return Ok(String::new());
+    }
+    let text = fs::read_to_string(&log_path)
+        .map_err(|e| format!("read log {}: {e}", log_path.display()))?;
+    let all_lines: Vec<_> = text.lines().collect();
+    let start = all_lines.len().saturating_sub(lines.min(2000));
+    Ok(all_lines[start..].join("\n"))
+}
+
+fn is_authorized(request: &HttpRequest, token: &str) -> bool {
+    let bearer = request
+        .headers
+        .get("authorization")
+        .and_then(|value| value.strip_prefix("Bearer "));
+    bearer == Some(token)
+}
+
+fn parse_http_request(bytes: &[u8]) -> Result<HttpRequest, String> {
+    let split = bytes
+        .windows(4)
+        .position(|window| window == b"\r\n\r\n")
+        .ok_or_else(|| "missing header terminator".to_string())?;
+    let header_text = std::str::from_utf8(&bytes[..split])
+        .map_err(|e| format!("request headers are not utf8: {e}"))?;
+    let body = bytes[(split + 4)..].to_vec();
+    let mut lines = header_text.lines();
+    let request_line = lines
+        .next()
+        .ok_or_else(|| "missing request line".to_string())?;
+    let mut parts = request_line.split_whitespace();
+    let method = parts.next().unwrap_or_default().to_string();
+    let target = parts.next().unwrap_or_default();
+    if method.is_empty() || target.is_empty() {
+        return Err("invalid request line".to_string());
+    }
+
+    let mut headers = HashMap::new();
+    for line in lines {
+        if let Some((key, value)) = line.split_once(':') {
+            headers.insert(key.trim().to_ascii_lowercase(), value.trim().to_string());
+        }
+    }
+
+    let (path, query) = parse_target(target);
+    Ok(HttpRequest {
+        method,
+        path,
+        query,
+        headers,
+        body,
+    })
+}
+
+fn parse_target(target: &str) -> (String, HashMap<String, String>) {
+    let Some((path, query_text)) = target.split_once('?') else {
+        return (target.to_string(), HashMap::new());
+    };
+    let query = query_text
+        .split('&')
+        .filter_map(|part| {
+            let (key, value) = part.split_once('=')?;
+            Some((key.to_string(), value.to_string()))
+        })
+        .collect();
+    (path.to_string(), query)
+}
+
+fn json_response(status: u16, value: Value) -> Vec<u8> {
+    let body = serde_json::to_vec(&value).unwrap_or_else(|_| b"{}".to_vec());
+    raw_response(
+        status,
+        reason(status),
+        "application/json; charset=utf-8",
+        body,
+    )
+}
+
+fn empty_response(status: u16) -> Vec<u8> {
+    raw_response(
+        status,
+        reason(status),
+        "text/plain; charset=utf-8",
+        Vec::new(),
+    )
+}
+
+fn raw_response(status: u16, reason: &str, content_type: &str, body: Vec<u8>) -> Vec<u8> {
+    let mut response = Vec::new();
+    let headers = format!(
+        "HTTP/1.1 {status} {reason}\r\n\
+         Content-Type: {content_type}\r\n\
+         Content-Length: {}\r\n\
+         Access-Control-Allow-Origin: http://localhost\r\n\
+         Access-Control-Allow-Headers: authorization, content-type\r\n\
+         Access-Control-Allow-Methods: GET, POST, OPTIONS\r\n\
+         Connection: close\r\n\r\n",
+        body.len()
+    );
+    response.extend_from_slice(headers.as_bytes());
+    response.extend_from_slice(&body);
+    response
+}
+
+fn reason(status: u16) -> &'static str {
+    match status {
+        200 => "OK",
+        204 => "No Content",
+        401 => "Unauthorized",
+        404 => "Not Found",
+        500 => "Internal Server Error",
+        501 => "Not Implemented",
+        _ => "OK",
+    }
+}
+
+fn now() -> String {
+    chrono::Utc::now().to_rfc3339()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_request_with_query_and_headers() {
+        let request = parse_http_request(
+            b"GET /v1/logs?lines=50 HTTP/1.1\r\nHost: 127.0.0.1\r\nAuthorization: Bearer abc\r\n\r\n",
+        )
+        .unwrap();
+
+        assert_eq!(request.method, "GET");
+        assert_eq!(request.path, "/v1/logs");
+        assert_eq!(request.query.get("lines").unwrap(), "50");
+        assert_eq!(request.headers.get("authorization").unwrap(), "Bearer abc");
+    }
+
+    #[test]
+    fn validates_bearer_token() {
+        let request =
+            parse_http_request(b"GET /v1/status HTTP/1.1\r\nAuthorization: Bearer secret\r\n\r\n")
+                .unwrap();
+
+        assert!(is_authorized(&request, "secret"));
+        assert!(!is_authorized(&request, "other"));
+    }
+
+    #[test]
+    fn generated_token_is_hex_64() {
+        let token = generate_token();
+        assert_eq!(token.len(), 64);
+        assert!(token.chars().all(|ch| ch.is_ascii_hexdigit()));
+    }
+}

--- a/ClassNoteAI/src-tauri/src/lib.rs
+++ b/ClassNoteAI/src-tauri/src/lib.rs
@@ -23,6 +23,7 @@ mod setup;
 pub mod paths;
 // 統一下載管理模塊
 pub mod diagnostics;
+pub mod agent_bridge;
 pub mod downloads;
 // 同步模塊
 // Localhost OAuth callback listener (for ChatGPT OAuth sign-in)
@@ -2690,6 +2691,10 @@ pub fn run() {
                     println!("數據庫初始化成功");
                 }
             });
+
+            if let Err(e) = agent_bridge::maybe_start(app.handle().clone()) {
+                eprintln!("[agent_bridge] startup skipped/failed: {e}");
+            }
 
             // Auto-load the Nemotron model in the background if any
             // variant is already on disk. INT8 wins over FP32 if both

--- a/docs/development/AGENT_CLI.md
+++ b/docs/development/AGENT_CLI.md
@@ -1,0 +1,118 @@
+# Agent CLI
+
+The agent CLI is the first stable command surface for automated debugging and
+smoke testing. It gives humans, CI, and sub-agents a machine-readable way to ask
+"what can this checkout do?", "is the app bridge available?", and "does the local
+smoke profile pass?" without relying on WebView remote debugging.
+
+## Commands
+
+Run from `ClassNoteAI/`:
+
+```bash
+npm run agent:handshake
+npm run agent:smoke
+```
+
+Direct form:
+
+```bash
+node scripts/cnai-agent.mjs handshake --json
+node scripts/cnai-agent.mjs app launch --dev --detach --json
+node scripts/cnai-agent.mjs app attach --json
+node scripts/cnai-agent.mjs app status --json
+node scripts/cnai-agent.mjs app handshake --json --bridge-url http://127.0.0.1:4317
+node scripts/cnai-agent.mjs events watch --ndjson --bridge-url http://127.0.0.1:4317
+node scripts/cnai-agent.mjs logs tail --json --bridge-url http://127.0.0.1:4317
+node scripts/cnai-agent.mjs diag bundle --json
+node scripts/cnai-agent.mjs workflow list --json
+node scripts/cnai-agent.mjs workflow diagnostics --json
+node scripts/cnai-agent.mjs call raw get_build_features --json
+node scripts/cnai-agent.mjs ui tree --json
+node scripts/cnai-agent.mjs smoke --profile quick --json
+node scripts/cnai-agent.mjs smoke --profile frontend --ndjson
+node scripts/cnai-agent.mjs smoke --profile release --json
+```
+
+## Output Contract
+
+`--json` prints a single final JSON object to stdout. Step logs are written to
+stderr so another agent can parse stdout safely.
+
+`--ndjson` prints one JSON event per line to stdout. This is the preferred mode
+for long-running agent sessions because a parent agent can stream progress
+without waiting for the final result.
+
+All payloads include `schemaVersion: 1`.
+
+## Exit Codes
+
+| Code | Meaning |
+| --- | --- |
+| `0` | The command completed successfully. |
+| `1` | A smoke step failed or timed out. |
+| `2` | Usage error or internal CLI error. |
+| `3` | The requested command needs the app bridge, but the bridge is unavailable. |
+
+## Requirement Coverage
+
+Issue #112 is larger than this first CLI PR. This table keeps the scope honest:
+
+| Original CLI / bridge requirement | Current status |
+| --- | --- |
+| Versioned machine-readable CLI handshake | Implemented by `handshake --json`. |
+| Machine-readable progress output | Implemented for smoke profiles via `--json` / `--ndjson`. |
+| Explicit exit codes | Implemented, including bridge-unavailable code `3`. |
+| Capability discovery | Implemented for CLI capabilities and planned workflow contracts. |
+| App launch / attach / authenticated local bridge | Implemented behind opt-in `CNAI_AGENT_BRIDGE=1`; `app launch` starts dev mode with the bridge, `app attach` reads the attach file, and app-backed commands send bearer auth. |
+| App status | Implemented through `/v1/status`. |
+| Log tail | Implemented through `/v1/logs` for recent logs. Continuous follow is part of the command contract but currently returns the current log snapshot. |
+| Structured event streaming | Implemented through `/v1/events` as a bridge SSE snapshot. Long-lived streaming is the next bridge increment. |
+| Diagnostic bundle | Implemented locally and through `/v1/diag/bundle` when attached to the app bridge. |
+| Raw command plane | Implemented for a small safe allowlist: `get_build_features` and `agent_bridge_status`. |
+| High-level workflow commands | `workflow list` exposes contracts locally and through `/v1/workflows`; `workflow diagnostics` is implemented as an app-backed workflow. Media/OCR/summary/chat execution endpoints currently return structured `unsupported`. |
+| Visual snapshot / semantic UI tree | `ui tree` returns native Tauri window inventory now. Pixel screenshot and full semantic DOM/accessibility tree still require UI instrumentation. |
+| Cross-platform app smoke | Local CLI smoke is cross-platform; real CLI-to-running-app smoke is available through `app launch` + `app status`, and should be added to CI/manual release smoke once stable on both OSes. |
+
+## Smoke Profiles
+
+| Profile | Steps | Intended Use |
+| --- | --- | --- |
+| `quick` | `tsc --noEmit` | Fast sub-agent sanity check before handing work back. |
+| `frontend` | `tsc --noEmit`, `vitest run` | Normal frontend regression check. |
+| `release` | `vitest run`, `npm run build` | Mirrors the frontend gate used before release bundling. |
+
+## Bridge Roadmap
+
+This CLI can attach to a desktop app that was started with the agent bridge
+enabled. The bridge is opt-in so normal users do not expose a localhost control
+surface.
+
+```bash
+CNAI_AGENT_BRIDGE=1 npm run tauri -- dev
+node scripts/cnai-agent.mjs app attach --json
+node scripts/cnai-agent.mjs app status --json
+```
+
+The first bridge-backed version provides:
+
+- versioned handshake
+- machine-readable output
+- deterministic smoke profiles
+- explicit exit codes
+- progress streaming through NDJSON
+- bridge-aware commands that fail with structured `bridge_unavailable` payloads
+- authenticated attach via an app-written attach file
+- status, logs, events, diagnostic bundle, and workflow discovery endpoints
+
+The next bridge-backed commands should reuse this entry point:
+
+```bash
+node scripts/cnai-agent.mjs app status --json
+node scripts/cnai-agent.mjs events watch --ndjson
+node scripts/cnai-agent.mjs workflow import-media --file lecture.mp4 --json
+node scripts/cnai-agent.mjs diag bundle --json
+```
+
+That keeps sub-agents on one stable CLI channel while the app bridge grows
+behind it.


### PR DESCRIPTION
## Summary
- Add an opt-in local Agent Bridge inside the Tauri app (`CNAI_AGENT_BRIDGE=1` / `CNAI_AGENT_BRIDGE_PORT`) with an app-written attach file containing URL, token, pid, and API version.
- Add authenticated localhost HTTP endpoints for bridge handshake, app status, recent logs, event snapshot over SSE, diagnostic bundle generation, workflow discovery, safe raw commands, and native window inventory.
- Expand `scripts/cnai-agent.mjs` from a smoke runner into the CLI surface for launch/attach/status/logs/events/diag/workflow/raw/ui commands.
- Keep machine-readable JSON/NDJSON output and explicit exit codes for sub-agent use.
- Add CLI contract tests and Rust bridge unit tests.
- Document the CLI/bridge contract, requirement coverage, implemented surfaces, and remaining planned surfaces.

## Implemented CLI surfaces
- `handshake`
- `app launch`
- `app attach`
- `app handshake`
- `app status`
- `logs tail`
- `events watch`
- `diag bundle`
- `workflow list`
- `workflow diagnostics`
- `call raw get_build_features`
- `call raw agent_bridge_status`
- `ui tree`
- `smoke --profile quick|frontend|release`

## Notes on scope
This PR now includes a real app bridge, authenticated attach, and local app-backed calls. Some surfaces are intentionally still partial:
- `ui tree` returns stable native Tauri window inventory; full DOM/accessibility semantics still need UI instrumentation.
- `ui snapshot` is part of the contract but returns structured `unsupported` because Tauri does not provide a cross-platform screenshot API here yet.
- Media import / OCR / summary / chat workflow execution endpoints return structured `unsupported`; `workflow diagnostics` is the first real app-backed workflow.

## Local live validation
I launched the desktop app locally through the CLI with the bridge enabled and verified these commands against the running Tauri app:
- `node scripts/cnai-agent.mjs app launch --detach --json --port 0 --attach-file <temp>`
- `node scripts/cnai-agent.mjs app attach --json --attach-file <temp>`
- `node scripts/cnai-agent.mjs app handshake --json --attach-file <temp>`
- `node scripts/cnai-agent.mjs app status --json --attach-file <temp>`
- `node scripts/cnai-agent.mjs logs tail --json --attach-file <temp>`
- `node scripts/cnai-agent.mjs events watch --ndjson --attach-file <temp>`
- `node scripts/cnai-agent.mjs workflow list --json --attach-file <temp>`
- `node scripts/cnai-agent.mjs workflow diagnostics --json --attach-file <temp>`
- `node scripts/cnai-agent.mjs call raw get_build_features --json --attach-file <temp>`
- `node scripts/cnai-agent.mjs ui tree --json --attach-file <temp>`

Live outputs confirmed:
- bridge handshake returned API version 1, app version 0.6.5-alpha.1, bearer auth, and capability list.
- app status returned pid, `windowCount: 1`, app data path, and log dir.
- raw `get_build_features` returned the build feature flags.
- `ui tree` returned native window inventory with `main` window.
- `workflow diagnostics` generated a diagnostic zip under Downloads.

## Validation
- `node scripts/cnai-agent.mjs smoke --profile frontend --json` (typecheck + 53 Vitest files, 442 tests)
- `npx vitest run` (53 files, 442 tests)
- `npx vitest run evals/scripts/__tests__/cnai-agent.test.ts` (8 tests)
- `npm run build`
- `cargo check --lib --package classnoteai --message-format=short`
- `cargo test --lib --package classnoteai agent_bridge --message-format=short` (3 tests)
- `git diff --check`

Refs #112