### PR TITLE
Add agent renderer UI action bridge

### DIFF
--- a/ClassNoteAI/evals/scripts/__tests__/cnai-agent.test.ts
+++ b/ClassNoteAI/evals/scripts/__tests__/cnai-agent.test.ts
@@ -215,4 +215,62 @@ describe('cnai-agent CLI', () => {
     expect(payload.status).toBe('skipped');
     expect(payload.env.CNAI_AGENT_BRIDGE).toBe('1');
   });
+
+  it('posts renderer UI actions to the bridge', async () => {
+    let requestBody = '';
+    const server = createServer((req, res) => {
+      req.on('data', (chunk) => {
+        requestBody += chunk.toString();
+      });
+      req.on('end', () => {
+        res.setHeader('content-type', 'application/json');
+        res.end(
+          JSON.stringify({
+            schemaVersion: 1,
+            type: 'ui_action',
+            status: 'ok',
+            kind: 'click',
+          }),
+        );
+      });
+    });
+    await new Promise<void>((resolveListen) => server.listen(0, '127.0.0.1', resolveListen));
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('server did not bind to a TCP port');
+    }
+    const tempDir = mkdtempSync(resolve(tmpdir(), 'cnai-agent-test-'));
+    const attachFile = resolve(tempDir, 'agent-bridge.json');
+    writeFileSync(
+      attachFile,
+      JSON.stringify({
+        schemaVersion: 1,
+        apiVersion: 1,
+        url: `http://127.0.0.1:${address.port}`,
+        token: 'test-token',
+        pid: 123,
+      }),
+    );
+
+    const result = await runCliAsync([
+      'ui',
+      'click',
+      '--target',
+      'nav.settings',
+      '--json',
+      '--attach-file',
+      attachFile,
+      '--timeout-ms',
+      '2000',
+    ]);
+    server.close();
+
+    const payload = JSON.parse(result.stdout);
+    expect(result.status).toBe(0);
+    expect(payload.type).toBe('ui_click');
+    expect(JSON.parse(requestBody)).toEqual({
+      target: 'nav.settings',
+      selector: null,
+    });
+  });
 });

--- a/ClassNoteAI/scripts/cnai-agent.mjs
+++ b/ClassNoteAI/scripts/cnai-agent.mjs
@@ -90,6 +90,11 @@ Usage:
   node scripts/cnai-agent.mjs workflow import-media --json [--file PATH]
   node scripts/cnai-agent.mjs ui snapshot [--json]
   node scripts/cnai-agent.mjs ui tree [--json]
+  node scripts/cnai-agent.mjs ui click --target ID [--json]
+  node scripts/cnai-agent.mjs ui type --target ID --text TEXT [--clear] [--json]
+  node scripts/cnai-agent.mjs ui key --key KEY [--json]
+  node scripts/cnai-agent.mjs ui navigate --path PATH [--json]
+  node scripts/cnai-agent.mjs ui wait-for [--target ID|--selector CSS|--text TEXT] [--timeout-ms N] [--json]
   node scripts/cnai-agent.mjs call raw <command> [--json]
   node scripts/cnai-agent.mjs smoke [--profile quick|frontend|release] [--json|--ndjson] [--dry-run] [--timeout-ms N]
 
@@ -105,6 +110,11 @@ Commands:
   workflow list   Print known workflow command contracts.
   ui snapshot     Ask the app bridge for a visual snapshot.
   ui tree         Ask the app bridge for a semantic UI tree.
+  ui click        Click a renderer UI element by stable id or selector.
+  ui type         Type text into an input/textarea/contenteditable target.
+  ui key          Send a keyboard event to the focused element.
+  ui navigate     Push a renderer route/path.
+  ui wait-for     Wait until text or a target appears in the renderer UI.
   call raw        Ask the bridge to invoke a raw app command.
   smoke           Run a deterministic local smoke profile for agents/CI.
 
@@ -139,6 +149,12 @@ function parseArgs(argv) {
     dev: false,
     port: undefined,
     file: undefined,
+    target: undefined,
+    selector: undefined,
+    text: undefined,
+    path: undefined,
+    key: undefined,
+    clear: false,
     positional: [],
   };
 
@@ -176,6 +192,18 @@ function parseArgs(argv) {
       options.output = args.shift();
     } else if (arg === '--file') {
       options.file = args.shift();
+    } else if (arg === '--target') {
+      options.target = args.shift();
+    } else if (arg === '--selector') {
+      options.selector = args.shift();
+    } else if (arg === '--text') {
+      options.text = args.shift();
+    } else if (arg === '--path') {
+      options.path = args.shift();
+    } else if (arg === '--key') {
+      options.key = args.shift();
+    } else if (arg === '--clear') {
+      options.clear = true;
     } else if (arg === '--follow') {
       options.follow = true;
     } else if (arg === '--detach') {
@@ -263,13 +291,18 @@ function handshakePayload() {
       },
       {
         id: 'ui.snapshot',
-        stability: 'planned',
+        stability: 'experimental',
         description: 'Capture visual state through the bridge.',
       },
       {
         id: 'ui.tree',
-        stability: 'planned',
+        stability: 'experimental',
         description: 'Read semantic UI state through the bridge.',
+      },
+      {
+        id: 'ui.action',
+        stability: 'experimental',
+        description: 'Drive renderer UI actions through the bridge.',
       },
     ],
     bridge: {
@@ -1004,12 +1037,77 @@ function parseSse(text) {
 
 async function handleUiCommand(options) {
   const subcommand = options.commandParts[1];
-  if (!['snapshot', 'tree'].includes(subcommand)) {
+  if (['snapshot', 'tree'].includes(subcommand)) {
+    const { code, payload } = await requestBridgeJson(`ui_${subcommand}`, options, `/v1/ui/${subcommand}`);
+    printPayload(payload, options.format);
+    return code;
+  }
+
+  if (!['click', 'type', 'key', 'navigate', 'wait-for'].includes(subcommand)) {
     throw new UsageError(`Unknown ui command: ${subcommand ?? ''}`);
   }
-  const { code, payload } = await requestBridgeJson(`ui_${subcommand}`, options, `/v1/ui/${subcommand}`);
+
+  const body = uiActionBody(subcommand, options);
+  const requestOptions = subcommand === 'wait-for'
+    ? {
+        ...options,
+        timeoutMs: Math.max(options.timeoutMs ?? 5000, (body.timeoutMs ?? 5000) + 5000),
+      }
+    : options;
+  const { code, payload } = await requestBridgeJson(`ui_${subcommand.replace('-', '_')}`, requestOptions, `/v1/ui/${subcommand}`, {
+    method: 'POST',
+    body,
+  });
   printPayload(payload, options.format);
   return code;
+}
+
+function uiActionBody(subcommand, options) {
+  if (subcommand === 'click') {
+    if (!options.target && !options.selector) {
+      throw new UsageError('ui click requires --target or --selector');
+    }
+    return { target: options.target ?? null, selector: options.selector ?? null };
+  }
+
+  if (subcommand === 'type') {
+    if (!options.target && !options.selector) {
+      throw new UsageError('ui type requires --target or --selector');
+    }
+    if (options.text == null) {
+      throw new UsageError('ui type requires --text');
+    }
+    return {
+      target: options.target ?? null,
+      selector: options.selector ?? null,
+      text: options.text,
+      clear: options.clear,
+    };
+  }
+
+  if (subcommand === 'key') {
+    if (!options.key && !options.text) {
+      throw new UsageError('ui key requires --key');
+    }
+    return { key: options.key ?? options.text };
+  }
+
+  if (subcommand === 'navigate') {
+    if (!options.path) {
+      throw new UsageError('ui navigate requires --path');
+    }
+    return { path: options.path };
+  }
+
+  if (!options.target && !options.selector && options.text == null) {
+    throw new UsageError('ui wait-for requires --target, --selector, or --text');
+  }
+  return {
+    target: options.target ?? null,
+    selector: options.selector ?? null,
+    text: options.text ?? null,
+    timeoutMs: options.timeoutMs ?? 5000,
+  };
 }
 
 async function handleCallCommand(options) {

--- a/ClassNoteAI/src-tauri/src/agent_bridge.rs
+++ b/ClassNoteAI/src-tauri/src/agent_bridge.rs
@@ -1,20 +1,25 @@
 use std::collections::{HashMap, VecDeque};
 use std::fs;
 use std::path::PathBuf;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
 
 use rand::RngCore;
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
-use tauri::{AppHandle, Manager};
+use tauri::{AppHandle, Emitter, Manager};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::Mutex;
+use tokio::sync::{oneshot, Mutex};
+use uuid::Uuid;
 
 const API_VERSION: u32 = 1;
 const DEFAULT_PORT: u16 = 4317;
 const MAX_REQUEST_BYTES: usize = 64 * 1024;
 const EVENT_RING_CAPACITY: usize = 128;
+const UI_ACTION_TIMEOUT_MS: u64 = 30_000;
+
+static BRIDGE_STATE: OnceLock<Arc<BridgeState>> = OnceLock::new();
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -45,6 +50,8 @@ struct BridgeState {
     started_at: String,
     events: Mutex<VecDeque<BridgeEvent>>,
     next_event_id: Mutex<u64>,
+    ui_state: Mutex<Option<Value>>,
+    pending_ui_actions: Mutex<HashMap<String, oneshot::Sender<Value>>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -117,7 +124,10 @@ async fn run_server(app: AppHandle, requested_port: u16, token: String) -> Resul
         started_at: created_at,
         events: Mutex::new(VecDeque::with_capacity(EVENT_RING_CAPACITY)),
         next_event_id: Mutex::new(1),
+        ui_state: Mutex::new(None),
+        pending_ui_actions: Mutex::new(HashMap::new()),
     });
+    let _ = BRIDGE_STATE.set(state.clone());
 
     push_event(
         &state,
@@ -161,6 +171,35 @@ async fn push_event(state: &Arc<BridgeState>, event_type: &str, payload: Value) 
     events.push_back(event);
 }
 
+#[tauri::command]
+pub async fn agent_bridge_update_ui_state(state: Value) -> Result<(), String> {
+    let Some(bridge_state) = BRIDGE_STATE.get() else {
+        return Ok(());
+    };
+    let mut slot = bridge_state.ui_state.lock().await;
+    *slot = Some(state);
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn agent_bridge_complete_ui_action(
+    action_id: String,
+    result: Value,
+) -> Result<(), String> {
+    let Some(bridge_state) = BRIDGE_STATE.get() else {
+        return Ok(());
+    };
+    let sender = bridge_state
+        .pending_ui_actions
+        .lock()
+        .await
+        .remove(&action_id);
+    if let Some(sender) = sender {
+        let _ = sender.send(result);
+    }
+    Ok(())
+}
+
 fn write_attach_file(app: &AppHandle, attach: &AttachFile) -> Result<(), String> {
     let path = attach_file_path(app)?;
     if let Some(parent) = path.parent() {
@@ -200,6 +239,7 @@ async fn handle_connection(mut stream: TcpStream, state: Arc<BridgeState>) -> Re
 async fn read_request(stream: &mut TcpStream) -> Result<HttpRequest, String> {
     let mut buffer = Vec::with_capacity(4096);
     let mut temp = [0_u8; 1024];
+    let mut header_end = None;
     loop {
         let read = stream
             .read(&mut temp)
@@ -209,9 +249,25 @@ async fn read_request(stream: &mut TcpStream) -> Result<HttpRequest, String> {
             break;
         }
         buffer.extend_from_slice(&temp[..read]);
-        if buffer.windows(4).any(|window| window == b"\r\n\r\n") {
+        if let Some(split) = buffer.windows(4).position(|window| window == b"\r\n\r\n") {
+            header_end = Some(split + 4);
             break;
         }
+        if buffer.len() > MAX_REQUEST_BYTES {
+            return Err("request too large".to_string());
+        }
+    }
+    let header_end = header_end.ok_or_else(|| "missing header terminator".to_string())?;
+    let content_length = parse_content_length(&buffer[..header_end])?;
+    while buffer.len() < header_end + content_length {
+        let read = stream
+            .read(&mut temp)
+            .await
+            .map_err(|e| format!("read request body: {e}"))?;
+        if read == 0 {
+            break;
+        }
+        buffer.extend_from_slice(&temp[..read]);
         if buffer.len() > MAX_REQUEST_BYTES {
             return Err("request too large".to_string());
         }
@@ -252,8 +308,13 @@ async fn route_request(request: HttpRequest, state: Arc<BridgeState>) -> Vec<u8>
         ("POST", "/v1/workflow/ocr-index") => unsupported_response("workflow.ocr-index"),
         ("POST", "/v1/workflow/summarize") => unsupported_response("workflow.summarize"),
         ("POST", "/v1/workflow/chat") => unsupported_response("workflow.chat"),
-        ("GET", "/v1/ui/snapshot") => unsupported_response("ui.snapshot"),
-        ("GET", "/v1/ui/tree") => json_response(200, ui_tree_payload(&state)),
+        ("GET", "/v1/ui/snapshot") => json_response(200, ui_snapshot_payload(&state).await),
+        ("GET", "/v1/ui/tree") => json_response(200, ui_tree_payload(&state).await),
+        ("POST", "/v1/ui/click") => ui_action_response(&state, "click", &request).await,
+        ("POST", "/v1/ui/type") => ui_action_response(&state, "type", &request).await,
+        ("POST", "/v1/ui/key") => ui_action_response(&state, "key", &request).await,
+        ("POST", "/v1/ui/navigate") => ui_action_response(&state, "navigate", &request).await,
+        ("POST", "/v1/ui/wait-for") => ui_action_response(&state, "wait-for", &request).await,
         _ => json_response(
             404,
             json!({
@@ -295,8 +356,13 @@ fn handshake_payload(state: &BridgeState) -> Value {
             {"id": "workflow.ocr-index", "stability": "planned"},
             {"id": "workflow.summarize", "stability": "planned"},
             {"id": "workflow.chat", "stability": "planned"},
-            {"id": "ui.snapshot", "stability": "planned"},
-            {"id": "ui.tree", "stability": "planned"}
+            {"id": "ui.snapshot", "stability": "experimental"},
+            {"id": "ui.tree", "stability": "experimental"},
+            {"id": "ui.click", "stability": "experimental"},
+            {"id": "ui.type", "stability": "experimental"},
+            {"id": "ui.key", "stability": "experimental"},
+            {"id": "ui.navigate", "stability": "experimental"},
+            {"id": "ui.wait-for", "stability": "experimental"}
         ],
     })
 }
@@ -479,7 +545,19 @@ async fn raw_command_response(state: &Arc<BridgeState>, request: &HttpRequest) -
     )
 }
 
-fn ui_tree_payload(state: &Arc<BridgeState>) -> Value {
+async fn ui_tree_payload(state: &Arc<BridgeState>) -> Value {
+    if let Some(renderer_state) = state.ui_state.lock().await.clone() {
+        return json!({
+            "schemaVersion": 1,
+            "type": "ui_tree",
+            "status": "ok",
+            "source": "renderer-dom",
+            "state": renderer_state,
+            "tree": renderer_state.get("tree").cloned().unwrap_or_else(|| json!(null)),
+            "elements": renderer_state.get("elements").cloned().unwrap_or_else(|| json!([])),
+        });
+    }
+
     let windows = state
         .app
         .webview_windows()
@@ -505,6 +583,140 @@ fn ui_tree_payload(state: &Arc<BridgeState>) -> Value {
             "children": windows,
         }
     })
+}
+
+async fn ui_snapshot_payload(state: &Arc<BridgeState>) -> Value {
+    if let Some(renderer_state) = state.ui_state.lock().await.clone() {
+        return json!({
+            "schemaVersion": 1,
+            "type": "ui_snapshot",
+            "status": "ok",
+            "source": "renderer-dom",
+            "note": "Semantic snapshot only; pixel capture is reserved for a later bridge phase.",
+            "state": renderer_state,
+        });
+    }
+
+    json!({
+        "schemaVersion": 1,
+        "type": "ui_snapshot",
+        "status": "ok",
+        "source": "tauri-window-inventory",
+        "note": "Renderer DOM state has not registered yet; pixel capture is reserved for a later bridge phase.",
+        "state": ui_tree_payload(state).await,
+    })
+}
+
+async fn ui_action_response(
+    state: &Arc<BridgeState>,
+    kind: &str,
+    request: &HttpRequest,
+) -> Vec<u8> {
+    let mut payload: Value = serde_json::from_slice(&request.body).unwrap_or_else(|_| json!({}));
+    let action_id = Uuid::new_v4().to_string();
+    payload["actionId"] = json!(action_id);
+    payload["kind"] = json!(kind);
+
+    let Some(window) = state.app.get_webview_window("main") else {
+        return json_response(
+            500,
+            json!({
+                "schemaVersion": 1,
+                "type": "ui_action",
+                "status": "failed",
+                "kind": kind,
+                "message": "main webview window is not available",
+            }),
+        );
+    };
+
+    let (sender, receiver) = oneshot::channel();
+    state
+        .pending_ui_actions
+        .lock()
+        .await
+        .insert(action_id.clone(), sender);
+
+    push_event(
+        state,
+        "ui.action.started",
+        json!({
+            "actionId": action_id,
+            "kind": kind,
+        }),
+    )
+    .await;
+
+    if let Err(error) = window.emit("agent-bridge-ui-action", payload.clone()) {
+        let _ = state.pending_ui_actions.lock().await.remove(&action_id);
+        return json_response(
+            500,
+            json!({
+                "schemaVersion": 1,
+                "type": "ui_action",
+                "status": "failed",
+                "kind": kind,
+                "actionId": action_id,
+                "message": format!("emit ui action: {error}"),
+            }),
+        );
+    }
+
+    match tokio::time::timeout(Duration::from_millis(UI_ACTION_TIMEOUT_MS), receiver).await {
+        Ok(Ok(result)) => {
+            push_event(
+                state,
+                "ui.action.completed",
+                json!({
+                    "actionId": action_id,
+                    "kind": kind,
+                    "result": result,
+                }),
+            )
+            .await;
+            let ok = result
+                .get("status")
+                .and_then(Value::as_str)
+                .map(|status| status == "ok")
+                .unwrap_or(false);
+            json_response(
+                if ok { 200 } else { 500 },
+                json!({
+                    "schemaVersion": 1,
+                    "type": "ui_action",
+                    "status": if ok { "ok" } else { "failed" },
+                    "kind": kind,
+                    "actionId": action_id,
+                    "result": result,
+                }),
+            )
+        }
+        Ok(Err(_)) => json_response(
+            500,
+            json!({
+                "schemaVersion": 1,
+                "type": "ui_action",
+                "status": "failed",
+                "kind": kind,
+                "actionId": action_id,
+                "message": "renderer dropped ui action response",
+            }),
+        ),
+        Err(_) => {
+            let _ = state.pending_ui_actions.lock().await.remove(&action_id);
+            json_response(
+                504,
+                json!({
+                    "schemaVersion": 1,
+                    "type": "ui_action",
+                    "status": "timeout",
+                    "kind": kind,
+                    "actionId": action_id,
+                    "message": "renderer did not complete ui action before timeout",
+                }),
+            )
+        }
+    }
 }
 
 fn unsupported_response(capability: &str) -> Vec<u8> {
@@ -580,6 +792,23 @@ fn parse_http_request(bytes: &[u8]) -> Result<HttpRequest, String> {
     })
 }
 
+fn parse_content_length(header_bytes: &[u8]) -> Result<usize, String> {
+    let header_text = std::str::from_utf8(header_bytes)
+        .map_err(|e| format!("request headers are not utf8: {e}"))?;
+    for line in header_text.lines() {
+        let Some((key, value)) = line.split_once(':') else {
+            continue;
+        };
+        if key.trim().eq_ignore_ascii_case("content-length") {
+            return value
+                .trim()
+                .parse::<usize>()
+                .map_err(|e| format!("invalid content-length: {e}"));
+        }
+    }
+    Ok(0)
+}
+
 fn parse_target(target: &str) -> (String, HashMap<String, String>) {
     let Some((path, query_text)) = target.split_once('?') else {
         return (target.to_string(), HashMap::new());
@@ -636,6 +865,7 @@ fn reason(status: u16) -> &'static str {
         204 => "No Content",
         401 => "Unauthorized",
         404 => "Not Found",
+        504 => "Gateway Timeout",
         500 => "Internal Server Error",
         501 => "Not Implemented",
         _ => "OK",
@@ -661,6 +891,23 @@ mod tests {
         assert_eq!(request.path, "/v1/logs");
         assert_eq!(request.query.get("lines").unwrap(), "50");
         assert_eq!(request.headers.get("authorization").unwrap(), "Bearer abc");
+    }
+
+    #[test]
+    fn parses_post_request_body() {
+        let request = parse_http_request(
+            b"POST /v1/ui/click HTTP/1.1\r\nContent-Type: application/json\r\nContent-Length: 25\r\n\r\n{\"target\":\"nav.settings\"}",
+        )
+        .unwrap();
+
+        assert_eq!(request.method, "POST");
+        assert_eq!(request.path, "/v1/ui/click");
+        assert_eq!(request.body, br#"{"target":"nav.settings"}"#);
+        assert_eq!(
+            parse_content_length(b"POST /v1/ui/click HTTP/1.1\r\nContent-Length: 25\r\n\r\n")
+                .unwrap(),
+            25
+        );
     }
 
     #[test]

--- a/ClassNoteAI/src-tauri/src/lib.rs
+++ b/ClassNoteAI/src-tauri/src/lib.rs
@@ -2777,6 +2777,8 @@ pub fn run() {
         .invoke_handler(tauri::generate_handler![
             open_devtools,
             close_devtools,
+            agent_bridge::agent_bridge_update_ui_state,
+            agent_bridge::agent_bridge_complete_ui_action,
             read_recent_log,
             open_log_folder,
             export_diagnostic_package,

--- a/ClassNoteAI/src/App.tsx
+++ b/ClassNoteAI/src/App.tsx
@@ -14,6 +14,7 @@ import { setupService } from "./services/setupService";
 import { toastService } from "./services/toastService";
 import { buildInterruptedRecordingNotice } from "./services/recordingInterruptionNotice";
 import { audioDeviceService } from "./services/audioDeviceService";
+import { useAgentAutomationBridge } from "./services/agentAutomationService";
 import { useAuth } from "./contexts/AuthContext";
 
 type AppState = 'loading' | 'setup' | 'ready';
@@ -22,6 +23,7 @@ function App() {
   const [appState, setAppState] = useState<AppState>('loading');
   const [recoverableSessions, setRecoverableSessions] = useState<RecoverableSession[]>([]);
   const { user } = useAuth();
+  useAgentAutomationBridge();
 
   // Detached AI 助教 webview: spawned by openDetachedAiTutor with the
   // `?aiTutorWindow=1` query flag. That window shares this bundle

--- a/ClassNoteAI/src/components/LoginScreen.tsx
+++ b/ClassNoteAI/src/components/LoginScreen.tsx
@@ -47,7 +47,10 @@ export default function LoginScreen({ onComplete }: LoginScreenProps) {
     };
 
     return (
-        <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900">
+        <div
+            data-agent-id="auth.login"
+            className="min-h-screen flex items-center justify-center bg-gradient-to-br from-slate-900 via-slate-800 to-slate-900"
+        >
             <div className="w-full max-w-md p-8 bg-white dark:bg-slate-800 rounded-2xl shadow-xl border border-gray-200 dark:border-gray-700 animate-in fade-in zoom-in duration-300">
                 <div className="text-center mb-8">
                     <div className="w-16 h-16 bg-blue-100 dark:bg-blue-900/30 rounded-full flex items-center justify-center mx-auto mb-4">
@@ -64,6 +67,7 @@ export default function LoginScreen({ onComplete }: LoginScreenProps) {
                 <div className="space-y-4">
                     <div>
                         <input
+                            data-agent-id="auth.username"
                             type="text"
                             value={username}
                             onChange={(e) => setUsername(e.target.value)}
@@ -82,6 +86,7 @@ export default function LoginScreen({ onComplete }: LoginScreenProps) {
                     )}
 
                     <button
+                        data-agent-id="auth.submit"
                         onClick={handleLogin}
                         disabled={isLoading || !username.trim()}
                         className="w-full flex items-center justify-center gap-2 px-4 py-3 bg-blue-600 hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed text-white rounded-xl font-medium transition-all transform active:scale-[0.98]"

--- a/ClassNoteAI/src/components/MainWindow.tsx
+++ b/ClassNoteAI/src/components/MainWindow.tsx
@@ -222,7 +222,10 @@ export default function MainWindow() {
   ];
 
   return (
-    <div className="flex flex-col h-screen bg-white dark:bg-slate-900 text-gray-900 dark:text-gray-100 relative">
+    <div
+      data-agent-id="app.main"
+      className="flex flex-col h-screen bg-white dark:bg-slate-900 text-gray-900 dark:text-gray-100 relative"
+    >
       {/* 頂部導航欄。z-[60] 高於 Settings/Profile/Trash overlay 的 z-50，
           讓 TaskIndicator 等向下展開的氣泡（它繼承 header 的 stacking
           context）能蓋在全螢幕 overlay 上面而不被截斷。 */}
@@ -241,6 +244,7 @@ export default function MainWindow() {
             return (
               <button
                 key={item.id}
+                data-agent-id={`nav.${item.id}`}
                 onClick={item.action}
                 className={`flex items-center gap-2 px-4 py-2 rounded-lg transition-colors ${isActive
                   ? "bg-blue-500 text-white"
@@ -257,6 +261,7 @@ export default function MainWindow() {
         <div className="flex items-center gap-2">
           <TaskIndicator />
           <button
+            data-agent-id="nav.profile"
             onClick={() => setIsProfileOpen(true)}
             className={`p-2 rounded-lg transition-colors ${isProfileOpen ? "bg-blue-100 text-blue-600 dark:bg-blue-900/30 dark:text-blue-300" : "hover:bg-gray-100 dark:hover:bg-gray-800"}`}
             aria-label="個人中心"
@@ -264,7 +269,7 @@ export default function MainWindow() {
             <User size={20} />
           </button>
           <button
-
+            data-agent-id="nav.theme"
             onClick={toggleTheme}
             className="p-2 rounded-lg hover:bg-gray-100 dark:hover:bg-gray-800 transition-colors"
             aria-label="切換主題"
@@ -302,14 +307,14 @@ export default function MainWindow() {
 
         {/* 1. Home View (Course List) */}
         {activeView === 'home' && !isSettingsOpen && !isProfileOpen && (
-          <div className="absolute inset-0 overflow-auto bg-gray-50 dark:bg-gray-900">
+          <div data-agent-id="view.home" className="absolute inset-0 overflow-auto bg-gray-50 dark:bg-gray-900">
             <CourseListView onSelectCourse={handleSelectCourse} />
           </div>
         )}
 
         {/* 2. Course Detail View */}
         {activeView === 'course' && activeCourseId && !isSettingsOpen && !isProfileOpen && (
-          <div className="absolute inset-0 overflow-auto bg-gray-50 dark:bg-gray-900">
+          <div data-agent-id="view.course" className="absolute inset-0 overflow-auto bg-gray-50 dark:bg-gray-900">
             <CourseDetailView
               courseId={activeCourseId}
               onBack={handleBackToCourses}
@@ -322,6 +327,7 @@ export default function MainWindow() {
         {/* 3. Lecture View (NotesView) - KEEP ALIVE */}
         {/* 始終渲染，但通過 CSS 控制顯示/隱藏 */}
         <div
+          data-agent-id="view.lecture"
           className="absolute inset-0 bg-white dark:bg-slate-900"
           style={{
             display: (activeView === 'lecture' && !isSettingsOpen && !isProfileOpen) ? 'block' : 'none',
@@ -343,21 +349,21 @@ export default function MainWindow() {
 
         {/* 4. Settings Overlay */}
         {isSettingsOpen && (
-          <div className="absolute inset-0 z-50 bg-white dark:bg-slate-900 animate-in fade-in slide-in-from-bottom-4 duration-200">
+          <div data-agent-id="view.settings" className="absolute inset-0 z-50 bg-white dark:bg-slate-900 animate-in fade-in slide-in-from-bottom-4 duration-200">
             <SettingsView onClose={() => setIsSettingsOpen(false)} />
           </div>
         )}
 
         {/* 5. Profile Overlay */}
         {isProfileOpen && (
-          <div className="absolute inset-0 z-50 bg-white dark:bg-slate-900 animate-in fade-in slide-in-from-bottom-4 duration-200">
+          <div data-agent-id="view.profile" className="absolute inset-0 z-50 bg-white dark:bg-slate-900 animate-in fade-in slide-in-from-bottom-4 duration-200">
             <ProfileView onClose={() => setIsProfileOpen(false)} />
           </div>
         )}
 
         {/* 6. Trash Bin Overlay */}
         {showTrashView && (
-          <div className="absolute inset-0 z-50 bg-white dark:bg-slate-900 animate-in fade-in slide-in-from-bottom-4 duration-200">
+          <div data-agent-id="view.trash" className="absolute inset-0 z-50 bg-white dark:bg-slate-900 animate-in fade-in slide-in-from-bottom-4 duration-200">
             <TrashView onBack={() => setShowTrashView(false)} />
           </div>
         )}

--- a/ClassNoteAI/src/services/__tests__/agentAutomationService.test.ts
+++ b/ClassNoteAI/src/services/__tests__/agentAutomationService.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest';
+import {
+  collectAgentUiState,
+  performAgentUiAction,
+} from '../agentAutomationService';
+
+describe('agentAutomationService', () => {
+  it('collects stable renderer UI elements for the agent bridge', () => {
+    document.body.innerHTML = `
+      <main>
+        <button data-agent-id="nav.settings">Settings</button>
+        <input data-agent-id="search.box" aria-label="Search" value="CS" />
+      </main>
+    `;
+
+    const state = collectAgentUiState(document);
+
+    expect(state.schemaVersion).toBe(1);
+    expect(state.source).toBe('renderer-dom');
+    expect(state.elements.map((element) => element.id)).toEqual(
+      expect.arrayContaining(['nav.settings', 'search.box']),
+    );
+    expect(state.elements.find((element) => element.id === 'search.box')?.value).toBe('CS');
+  });
+
+  it('clicks a target by data-agent-id', async () => {
+    let clicked = false;
+    document.body.innerHTML = '<button data-agent-id="nav.home">Home</button>';
+    document.querySelector('button')?.addEventListener('click', () => {
+      clicked = true;
+    });
+
+    const result = await performAgentUiAction({ actionId: 'a1', kind: 'click', target: 'nav.home' });
+
+    expect(result.status).toBe('ok');
+    expect(clicked).toBe(true);
+  });
+
+  it('types into inputs and dispatches change events', async () => {
+    let changed = false;
+    document.body.innerHTML = '<input data-agent-id="course.name" value="Old" />';
+    document.querySelector('input')?.addEventListener('change', () => {
+      changed = true;
+    });
+
+    const result = await performAgentUiAction({
+      actionId: 'a2',
+      kind: 'type',
+      target: 'course.name',
+      text: 'New',
+      clear: true,
+    });
+
+    expect(result.status).toBe('ok');
+    expect((document.querySelector('input') as HTMLInputElement).value).toBe('New');
+    expect(changed).toBe(true);
+  });
+
+  it('waits for text to appear in the document', async () => {
+    setTimeout(() => {
+      document.body.innerHTML = '<section>Ready</section>';
+    }, 10);
+
+    const result = await performAgentUiAction({
+      actionId: 'a3',
+      kind: 'wait-for',
+      text: 'Ready',
+      timeoutMs: 500,
+    });
+
+    expect(result.status).toBe('ok');
+  });
+});

--- a/ClassNoteAI/src/services/agentAutomationService.ts
+++ b/ClassNoteAI/src/services/agentAutomationService.ts
@@ -1,0 +1,386 @@
+import { invoke } from '@tauri-apps/api/core';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { useEffect } from 'react';
+
+const UI_ACTION_EVENT = 'agent-bridge-ui-action';
+const UPDATE_COMMAND = 'agent_bridge_update_ui_state';
+const COMPLETE_COMMAND = 'agent_bridge_complete_ui_action';
+const INTERACTIVE_SELECTOR = [
+  '[data-agent-id]',
+  'button',
+  'input',
+  'textarea',
+  'select',
+  'a[href]',
+  '[role="button"]',
+  '[role="tab"]',
+  '[role="menuitem"]',
+  '[contenteditable="true"]',
+].join(',');
+
+type AgentBounds = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+export type AgentUiElement = {
+  id: string;
+  role: string;
+  tag: string;
+  text: string;
+  label: string | null;
+  enabled: boolean;
+  visible: boolean;
+  bounds: AgentBounds;
+  selector: string;
+  value?: string;
+  attributes: Record<string, string>;
+};
+
+export type AgentUiState = {
+  schemaVersion: 1;
+  type: 'ui_tree';
+  source: 'renderer-dom';
+  capturedAt: string;
+  location: {
+    path: string;
+    search: string;
+    hash: string;
+  };
+  title: string;
+  viewport: {
+    width: number;
+    height: number;
+    devicePixelRatio: number;
+  };
+  focus: {
+    id: string | null;
+    text: string;
+    tag: string | null;
+  };
+  elements: AgentUiElement[];
+  tree: {
+    role: 'application';
+    label: string;
+    children: AgentUiElement[];
+  };
+};
+
+type AgentUiAction = {
+  actionId: string;
+  kind: 'click' | 'type' | 'key' | 'navigate' | 'wait-for';
+  target?: string;
+  selector?: string;
+  text?: string;
+  path?: string;
+  key?: string;
+  clear?: boolean;
+  timeoutMs?: number;
+};
+
+type AgentActionResult = {
+  status: 'ok' | 'failed' | 'timeout';
+  message?: string;
+  state?: AgentUiState;
+};
+
+const autoIds = new WeakMap<Element, string>();
+
+export function collectAgentUiState(doc: Document = document): AgentUiState {
+  const elements = Array.from(doc.querySelectorAll(INTERACTIVE_SELECTOR))
+    .filter((element) => element instanceof HTMLElement)
+    .map((element, index) => describeElement(element as HTMLElement, index));
+  const active = doc.activeElement instanceof HTMLElement ? doc.activeElement : null;
+  const activeId = active ? getAgentId(active, 0) : null;
+
+  return {
+    schemaVersion: 1,
+    type: 'ui_tree',
+    source: 'renderer-dom',
+    capturedAt: new Date().toISOString(),
+    location: {
+      path: window.location.pathname,
+      search: window.location.search,
+      hash: window.location.hash,
+    },
+    title: doc.title,
+    viewport: {
+      width: window.innerWidth,
+      height: window.innerHeight,
+      devicePixelRatio: window.devicePixelRatio || 1,
+    },
+    focus: {
+      id: activeId,
+      text: active ? normalizeText(active.innerText || active.textContent || '') : '',
+      tag: active?.tagName.toLowerCase() ?? null,
+    },
+    elements,
+    tree: {
+      role: 'application',
+      label: doc.title || 'ClassNoteAI',
+      children: elements,
+    },
+  };
+}
+
+export async function performAgentUiAction(action: AgentUiAction, doc: Document = document): Promise<AgentActionResult> {
+  try {
+    if (action.kind === 'navigate') {
+      const path = action.path || action.text;
+      if (!path) {
+        return failed('navigate requires --path');
+      }
+      window.history.pushState({}, '', path);
+      window.dispatchEvent(new PopStateEvent('popstate'));
+      return ok(doc);
+    }
+
+    if (action.kind === 'wait-for') {
+      return waitForAction(action, doc);
+    }
+
+    if (action.kind === 'key') {
+      const key = action.key || action.text;
+      if (!key) {
+        return failed('key requires --key');
+      }
+      dispatchKeyboard(key, doc.activeElement || doc.body);
+      return ok(doc);
+    }
+
+    const target = findTarget(action, doc);
+    if (!target) {
+      return failed(`target not found: ${action.target || action.selector || ''}`);
+    }
+
+    if (action.kind === 'click') {
+      if (isDisabled(target as HTMLElement)) {
+        return failed(`target is disabled: ${action.target || action.selector || ''}`);
+      }
+      (target as HTMLElement).click();
+      return ok(doc);
+    }
+
+    if (action.kind === 'type') {
+      if (action.text == null) {
+        return failed('type requires --text');
+      }
+      setElementText(target as HTMLElement, action.text, Boolean(action.clear));
+      return ok(doc);
+    }
+
+    return failed(`unsupported action: ${action.kind}`);
+  } catch (error) {
+    return failed(error instanceof Error ? error.message : String(error));
+  }
+}
+
+export function useAgentAutomationBridge() {
+  useEffect(() => {
+    let unlisten: UnlistenFn | undefined;
+    let disposed = false;
+    let mutationObserver: MutationObserver | undefined;
+    let updateTimer: number | undefined;
+
+    const updateState = () => {
+      if (disposed) return;
+      window.clearTimeout(updateTimer);
+      updateTimer = window.setTimeout(() => {
+        void invoke(UPDATE_COMMAND, { state: collectAgentUiState() }).catch(() => {
+          // Bridge commands only exist in the desktop runtime and only matter
+          // when the opt-in agent bridge is active.
+        });
+      }, 80);
+    };
+
+    void listen<AgentUiAction>(UI_ACTION_EVENT, async (event) => {
+      const action = event.payload;
+      const result = await performAgentUiAction(action);
+      const actionId = action?.actionId;
+      if (!actionId) return;
+      await invoke(COMPLETE_COMMAND, {
+        actionId,
+        result,
+      }).catch(() => undefined);
+      updateState();
+    }).then((dispose) => {
+      unlisten = dispose;
+    }).catch(() => undefined);
+
+    updateState();
+    mutationObserver = new MutationObserver(updateState);
+    mutationObserver.observe(document.body, {
+      childList: true,
+      subtree: true,
+      attributes: true,
+      attributeFilter: ['class', 'style', 'disabled', 'aria-label', 'data-agent-id'],
+    });
+    window.addEventListener('popstate', updateState);
+    window.addEventListener('focusin', updateState);
+    window.addEventListener('resize', updateState);
+
+    return () => {
+      disposed = true;
+      window.clearTimeout(updateTimer);
+      mutationObserver?.disconnect();
+      window.removeEventListener('popstate', updateState);
+      window.removeEventListener('focusin', updateState);
+      window.removeEventListener('resize', updateState);
+      unlisten?.();
+    };
+  }, []);
+}
+
+function describeElement(element: HTMLElement, index: number): AgentUiElement {
+  const rect = element.getBoundingClientRect();
+  const text = normalizeText(element.innerText || element.textContent || '');
+  const value = element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement
+    ? (element.type === 'password' ? '' : element.value)
+    : undefined;
+  const label = element.getAttribute('aria-label') || element.getAttribute('title') || value || text || null;
+  const id = getAgentId(element, index);
+
+  return {
+    id,
+    role: element.getAttribute('role') || inferRole(element),
+    tag: element.tagName.toLowerCase(),
+    text,
+    label,
+    enabled: !isDisabled(element),
+    visible: isVisible(element),
+    bounds: {
+      x: Math.round(rect.x),
+      y: Math.round(rect.y),
+      width: Math.round(rect.width),
+      height: Math.round(rect.height),
+    },
+    selector: selectorFor(element, id),
+    ...(value !== undefined ? { value } : {}),
+    attributes: {
+      ...(element.id ? { id: element.id } : {}),
+      ...(element.getAttribute('data-agent-id') ? { agentId: element.getAttribute('data-agent-id') || '' } : {}),
+      ...(element.getAttribute('aria-label') ? { ariaLabel: element.getAttribute('aria-label') || '' } : {}),
+      ...(element.getAttribute('type') ? { type: element.getAttribute('type') || '' } : {}),
+    },
+  };
+}
+
+function getAgentId(element: Element, index: number): string {
+  const explicit = element.getAttribute('data-agent-id');
+  if (explicit) return explicit;
+  const existing = autoIds.get(element);
+  if (existing) return existing;
+  const tag = element.tagName.toLowerCase();
+  const label = normalizeText(
+    element.getAttribute('aria-label')
+    || element.getAttribute('title')
+    || element.textContent
+    || '',
+  ).slice(0, 32).replace(/[^a-z0-9]+/giu, '-').replace(/^-|-$/gu, '').toLowerCase();
+  const id = `auto:${tag}:${index}${label ? `:${label}` : ''}`;
+  autoIds.set(element, id);
+  element.setAttribute('data-agent-auto-id', id);
+  return id;
+}
+
+function selectorFor(element: Element, id: string): string {
+  const explicit = element.getAttribute('data-agent-id');
+  if (explicit) return `[data-agent-id="${cssEscape(explicit)}"]`;
+  if (element.id) return `#${cssEscape(element.id)}`;
+  return `[data-agent-auto-id="${cssEscape(id)}"]`;
+}
+
+function findTarget(action: AgentUiAction, doc: Document): Element | null {
+  if (action.selector) {
+    try {
+      return doc.querySelector(action.selector);
+    } catch {
+      return null;
+    }
+  }
+  if (!action.target) return null;
+  const explicit = doc.querySelector(`[data-agent-id="${cssEscape(action.target)}"]`);
+  if (explicit) return explicit;
+  return collectAgentUiState(doc).elements.find((element) => element.id === action.target)
+    ? Array.from(doc.querySelectorAll(INTERACTIVE_SELECTOR)).find((element, index) => getAgentId(element, index) === action.target) || null
+    : null;
+}
+
+function setElementText(element: HTMLElement, text: string, clear: boolean) {
+  element.focus();
+  if (element instanceof HTMLInputElement || element instanceof HTMLTextAreaElement) {
+    const nextValue = clear ? text : `${element.value}${text}`;
+    const setter = Object.getOwnPropertyDescriptor(Object.getPrototypeOf(element), 'value')?.set;
+    if (setter) {
+      setter.call(element, nextValue);
+    } else {
+      element.value = nextValue;
+    }
+    element.dispatchEvent(new Event('input', { bubbles: true }));
+    element.dispatchEvent(new Event('change', { bubbles: true }));
+    return;
+  }
+  if (element.isContentEditable) {
+    if (clear) element.textContent = '';
+    document.execCommand?.('insertText', false, text);
+    element.dispatchEvent(new InputEvent('input', { bubbles: true, inputType: 'insertText', data: text }));
+  }
+}
+
+async function waitForAction(action: AgentUiAction, doc: Document): Promise<AgentActionResult> {
+  const timeoutMs = Math.max(1, action.timeoutMs || 5000);
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() <= deadline) {
+    if (action.target && findTarget(action, doc)) return ok(doc);
+    if (action.selector && findTarget(action, doc)) return ok(doc);
+    if (action.text && normalizeText(doc.body.innerText || doc.body.textContent || '').includes(action.text)) {
+      return ok(doc);
+    }
+    await new Promise((resolve) => window.setTimeout(resolve, 80));
+  }
+  return { status: 'timeout', message: 'wait-for timed out', state: collectAgentUiState(doc) };
+}
+
+function dispatchKeyboard(key: string, target: Element) {
+  target.dispatchEvent(new KeyboardEvent('keydown', { key, bubbles: true }));
+  target.dispatchEvent(new KeyboardEvent('keyup', { key, bubbles: true }));
+}
+
+function ok(doc: Document): AgentActionResult {
+  return { status: 'ok', state: collectAgentUiState(doc) };
+}
+
+function failed(message: string): AgentActionResult {
+  return { status: 'failed', message };
+}
+
+function inferRole(element: HTMLElement): string {
+  const tag = element.tagName.toLowerCase();
+  if (tag === 'button') return 'button';
+  if (tag === 'a') return 'link';
+  if (tag === 'input' || tag === 'textarea') return 'textbox';
+  if (tag === 'select') return 'combobox';
+  return 'generic';
+}
+
+function isDisabled(element: HTMLElement): boolean {
+  return Boolean((element as HTMLButtonElement | HTMLInputElement).disabled || element.getAttribute('aria-disabled') === 'true');
+}
+
+function isVisible(element: HTMLElement): boolean {
+  const style = window.getComputedStyle(element);
+  return style.display !== 'none' && style.visibility !== 'hidden' && Number(style.opacity || 1) !== 0;
+}
+
+function normalizeText(text: string): string {
+  return text.replace(/\s+/gu, ' ').trim();
+}
+
+function cssEscape(value: string): string {
+  if (typeof CSS !== 'undefined' && CSS.escape) {
+    return CSS.escape(value);
+  }
+  return value.replace(/["\\]/gu, '\\$&');
+}

--- a/docs/development/AGENT_CLI.md
+++ b/docs/development/AGENT_CLI.md
@@ -29,6 +29,11 @@ node scripts/cnai-agent.mjs workflow list --json
 node scripts/cnai-agent.mjs workflow diagnostics --json
 node scripts/cnai-agent.mjs call raw get_build_features --json
 node scripts/cnai-agent.mjs ui tree --json
+node scripts/cnai-agent.mjs ui click --target nav.settings --json
+node scripts/cnai-agent.mjs ui wait-for --target view.settings --json
+node scripts/cnai-agent.mjs ui type --target course.name --text "Algorithms" --clear --json
+node scripts/cnai-agent.mjs ui key --key Escape --json
+node scripts/cnai-agent.mjs ui navigate --path / --json
 node scripts/cnai-agent.mjs smoke --profile quick --json
 node scripts/cnai-agent.mjs smoke --profile frontend --ndjson
 node scripts/cnai-agent.mjs smoke --profile release --json
@@ -71,7 +76,8 @@ Issue #112 is larger than this first CLI PR. This table keeps the scope honest:
 | Diagnostic bundle | Implemented locally and through `/v1/diag/bundle` when attached to the app bridge. |
 | Raw command plane | Implemented for a small safe allowlist: `get_build_features` and `agent_bridge_status`. |
 | High-level workflow commands | `workflow list` exposes contracts locally and through `/v1/workflows`; `workflow diagnostics` is implemented as an app-backed workflow. Media/OCR/summary/chat execution endpoints currently return structured `unsupported`. |
-| Visual snapshot / semantic UI tree | `ui tree` returns native Tauri window inventory now. Pixel screenshot and full semantic DOM/accessibility tree still require UI instrumentation. |
+| Visual snapshot / semantic UI tree | `ui tree` and `ui snapshot` now return renderer DOM state when the app is attached, with native window inventory as fallback. Pixel screenshots remain a later bridge phase. |
+| UI action plane | Implemented for renderer `click`, `type`, `key`, `navigate`, and `wait-for` actions through authenticated bridge endpoints. |
 | Cross-platform app smoke | Local CLI smoke is cross-platform; real CLI-to-running-app smoke is available through `app launch` + `app status`, and should be added to CI/manual release smoke once stable on both OSes. |
 
 ## Smoke Profiles
@@ -104,11 +110,15 @@ The first bridge-backed version provides:
 - bridge-aware commands that fail with structured `bridge_unavailable` payloads
 - authenticated attach via an app-written attach file
 - status, logs, events, diagnostic bundle, and workflow discovery endpoints
+- renderer DOM state and basic UI actions for app-driving agents
 
 The next bridge-backed commands should reuse this entry point:
 
 ```bash
 node scripts/cnai-agent.mjs app status --json
+node scripts/cnai-agent.mjs ui tree --json
+node scripts/cnai-agent.mjs ui click --target nav.settings --json
+node scripts/cnai-agent.mjs ui wait-for --target view.settings --json
 node scripts/cnai-agent.mjs events watch --ndjson
 node scripts/cnai-agent.mjs workflow import-media --file lecture.mp4 --json
 node scripts/cnai-agent.mjs diag bundle --json


### PR DESCRIPTION
## Summary

This is PR 2 for #112, stacked on #145. It turns the agent bridge from native window inventory into a renderer-aware UI action plane.

- Adds a renderer automation service that publishes DOM-based UI state and executes bridge-dispatched actions.
- Adds authenticated bridge endpoints for `ui tree`, `ui snapshot`, `ui click`, `ui type`, `ui key`, `ui navigate`, and `ui wait-for`.
- Extends `cnai-agent` with UI action commands and updates the agent CLI docs.
- Adds stable agent IDs for login, top navigation, and major app views so agents can drive the real desktop app.

## Verification

- `npx vitest run src/services/__tests__/agentAutomationService.test.ts evals/scripts/__tests__/cnai-agent.test.ts`
- `npm exec tsc -- --noEmit`
- `cargo test --lib agent_bridge`
- `cargo check --lib`
- `npx vitest run`
- `npm run build`
- `git diff --check`
- Live desktop smoke with temporary Tauri identifier/port:
  - `app status`
  - `ui tree`
  - `ui type --target auth.username --text agent-smoke --clear`
  - `ui click --target auth.submit`
  - `ui wait-for --target app.main`
  - `ui click --target nav.settings`
  - `ui wait-for --target view.settings`

## Notes

`ui snapshot` is semantic renderer state in this PR. Pixel screenshots remain a later #112 phase.

`cargo fmt` for the whole crate is currently blocked by an existing missing module path (`translation/ctranslate2.rs`). I formatted the changed bridge file with `rustfmt --edition 2021` instead.

Closes part of #112.