### PR TITLE
Add agent bridge task event streaming

### DIFF
--- a/ClassNoteAI/evals/scripts/__tests__/cnai-agent.test.ts
+++ b/ClassNoteAI/evals/scripts/__tests__/cnai-agent.test.ts
@@ -273,4 +273,114 @@ describe('cnai-agent CLI', () => {
       selector: null,
     });
   });
+
+  it('streams followed bridge events as NDJSON with a max event guard', async () => {
+    const server = createServer((req, res) => {
+      expect(req.url).toBe('/v1/events?follow=1');
+      res.writeHead(200, {
+        'content-type': 'text/event-stream; charset=utf-8',
+      });
+      res.write(
+        `event: bridge.snapshot\ndata: ${JSON.stringify({
+          schemaVersion: 1,
+          type: 'event_snapshot',
+          status: 'ok',
+          events: [],
+        })}\n\n`,
+      );
+      res.write(
+        `event: task.started\ndata: ${JSON.stringify({
+          id: 2,
+          eventType: 'task.started',
+          payload: { taskId: 'task-1' },
+        })}\n\n`,
+      );
+    });
+    await new Promise<void>((resolveListen) => server.listen(0, '127.0.0.1', resolveListen));
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('server did not bind to a TCP port');
+    }
+    const tempDir = mkdtempSync(resolve(tmpdir(), 'cnai-agent-test-'));
+    const attachFile = resolve(tempDir, 'agent-bridge.json');
+    writeFileSync(
+      attachFile,
+      JSON.stringify({
+        schemaVersion: 1,
+        apiVersion: 1,
+        url: `http://127.0.0.1:${address.port}`,
+        token: 'test-token',
+        pid: 123,
+      }),
+    );
+
+    const result = await runCliAsync([
+      'events',
+      'watch',
+      '--follow',
+      '--ndjson',
+      '--max-events',
+      '2',
+      '--attach-file',
+      attachFile,
+      '--timeout-ms',
+      '5000',
+    ]);
+    server.close();
+
+    const events = result.stdout.trim().split('\n').map((line) => JSON.parse(line));
+    expect(result.status).toBe(0);
+    expect(events.map((event: { event: string }) => event.event)).toEqual([
+      'bridge.snapshot',
+      'task.started',
+    ]);
+  });
+
+  it('lists bridge tasks through the CLI', async () => {
+    const server = createServer((req, res) => {
+      expect(req.url).toBe('/v1/tasks');
+      res.setHeader('content-type', 'application/json');
+      res.end(
+        JSON.stringify({
+          schemaVersion: 1,
+          type: 'task_list',
+          status: 'ok',
+          tasks: [{ id: 'task-1', status: 'completed' }],
+        }),
+      );
+    });
+    await new Promise<void>((resolveListen) => server.listen(0, '127.0.0.1', resolveListen));
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('server did not bind to a TCP port');
+    }
+    const tempDir = mkdtempSync(resolve(tmpdir(), 'cnai-agent-test-'));
+    const attachFile = resolve(tempDir, 'agent-bridge.json');
+    writeFileSync(
+      attachFile,
+      JSON.stringify({
+        schemaVersion: 1,
+        apiVersion: 1,
+        url: `http://127.0.0.1:${address.port}`,
+        token: 'test-token',
+        pid: 123,
+      }),
+    );
+
+    const result = await runCliAsync([
+      'tasks',
+      'list',
+      '--json',
+      '--attach-file',
+      attachFile,
+      '--timeout-ms',
+      '2000',
+    ]);
+    server.close();
+
+    const payload = JSON.parse(result.stdout);
+    expect(result.status).toBe(0);
+    expect(payload.type).toBe('tasks_list');
+    expect(payload.body.tasks[0].id).toBe('task-1');
+  });
 });

--- a/ClassNoteAI/scripts/cnai-agent.mjs
+++ b/ClassNoteAI/scripts/cnai-agent.mjs
@@ -83,7 +83,8 @@ Usage:
   node scripts/cnai-agent.mjs app attach [--json] [--attach-file PATH]
   node scripts/cnai-agent.mjs app handshake [--json] [--bridge-url URL] [--token TOKEN]
   node scripts/cnai-agent.mjs app status [--json] [--bridge-url URL] [--token TOKEN]
-  node scripts/cnai-agent.mjs events watch [--ndjson] [--bridge-url URL] [--token TOKEN]
+  node scripts/cnai-agent.mjs events watch [--ndjson] [--follow] [--max-events N] [--bridge-url URL] [--token TOKEN]
+  node scripts/cnai-agent.mjs tasks list [--json] [--bridge-url URL] [--token TOKEN]
   node scripts/cnai-agent.mjs logs tail [--json] [--follow] [--bridge-url URL] [--token TOKEN]
   node scripts/cnai-agent.mjs diag bundle [--json] [--output PATH]
   node scripts/cnai-agent.mjs workflow list [--json]
@@ -105,6 +106,7 @@ Commands:
   app handshake   Ask a running app bridge for its versioned contract.
   app status      Ask a running app bridge for app/session health.
   events watch    Stream app bridge events as NDJSON.
+  tasks list      List bridge task lifecycle records.
   logs tail       Read or follow app bridge logs.
   diag bundle     Write a local CLI diagnostic bundle.
   workflow list   Print known workflow command contracts.
@@ -127,7 +129,7 @@ Output:
 function parseArgs(argv) {
   const args = [...argv];
   let command = args.shift();
-  if (['app', 'events', 'logs', 'diag', 'workflow', 'ui', 'call'].includes(command)) {
+  if (['app', 'events', 'tasks', 'logs', 'diag', 'workflow', 'ui', 'call'].includes(command)) {
     const subcommand = args.shift();
     if (!subcommand || subcommand.startsWith('-')) {
       throw new UsageError(`Missing subcommand for: ${command}`);
@@ -149,6 +151,7 @@ function parseArgs(argv) {
     dev: false,
     port: undefined,
     file: undefined,
+    maxEvents: undefined,
     target: undefined,
     selector: undefined,
     text: undefined,
@@ -192,6 +195,13 @@ function parseArgs(argv) {
       options.output = args.shift();
     } else if (arg === '--file') {
       options.file = args.shift();
+    } else if (arg === '--max-events') {
+      const raw = args.shift();
+      const parsed = Number(raw);
+      if (!Number.isInteger(parsed) || parsed <= 0) {
+        throw new UsageError(`Invalid --max-events value: ${raw}`);
+      }
+      options.maxEvents = parsed;
     } else if (arg === '--target') {
       options.target = args.shift();
     } else if (arg === '--selector') {
@@ -268,6 +278,11 @@ function handshakePayload() {
         id: 'events.watch',
         stability: 'experimental',
         description: 'Stream structured app events from the bridge.',
+      },
+      {
+        id: 'tasks.list',
+        stability: 'experimental',
+        description: 'List bridge task lifecycle records.',
       },
       {
         id: 'logs.tail',
@@ -871,7 +886,7 @@ async function handleEventsCommand(options) {
     return 3;
   }
 
-  const endpoint = bridgeEndpoint(bridge.url, '/v1/events');
+  const endpoint = bridgeEndpoint(bridge.url, options.follow ? '/v1/events?follow=1' : '/v1/events');
   try {
     const response = await fetch(endpoint, {
       signal: AbortSignal.timeout(options.timeoutMs ?? 30_000),
@@ -880,6 +895,10 @@ async function handleEventsCommand(options) {
         ...(bridge.token ? { authorization: `Bearer ${bridge.token}` } : {}),
       },
     });
+    if (options.follow) {
+      const streamed = await streamSseEvents(response, options, bridge.url);
+      return streamed ? 0 : 1;
+    }
     const text = await response.text();
     const events = parseSse(text);
     if (options.format === 'ndjson') {
@@ -910,6 +929,61 @@ async function handleEventsCommand(options) {
     );
     return 3;
   }
+}
+
+async function handleTasksCommand(options) {
+  const subcommand = options.commandParts[1];
+  if (subcommand !== 'list') {
+    throw new UsageError(`Unknown tasks command: ${subcommand ?? ''}`);
+  }
+  const { code, payload } = await requestBridgeJson('tasks_list', options, '/v1/tasks');
+  printPayload(payload, options.format);
+  return code;
+}
+
+async function streamSseEvents(response, options, bridgeUrl) {
+  if (!response.ok || !response.body) {
+    const text = await response.text().catch(() => '');
+    printPayload(
+      {
+        schemaVersion: 1,
+        type: 'events_watch',
+        status: 'failed',
+        bridge: { url: bridgeUrl, httpStatus: response.status },
+        body: text,
+      },
+      options.format,
+    );
+    return false;
+  }
+
+  const decoder = new TextDecoder();
+  const reader = response.body.getReader();
+  let buffer = '';
+  let count = 0;
+  while (true) {
+    const { value, done } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const parts = buffer.split(/\r?\n\r?\n/u);
+    buffer = parts.pop() ?? '';
+    for (const block of parts) {
+      const events = parseSse(block);
+      for (const event of events) {
+        count += 1;
+        if (options.format === 'ndjson') {
+          process.stdout.write(`${JSON.stringify(event)}\n`);
+        } else {
+          printPayload(event, options.format);
+        }
+        if (options.maxEvents && count >= options.maxEvents) {
+          await reader.cancel();
+          return true;
+        }
+      }
+    }
+  }
+  return true;
 }
 
 async function handleLogsCommand(options) {
@@ -1015,15 +1089,21 @@ function parseSse(text) {
   return text
     .split(/\r?\n\r?\n/u)
     .filter((block) => block.trim().length > 0)
-    .map((block) => {
+    .flatMap((block) => {
       const event = { schemaVersion: 1, type: 'sse_event', event: 'message', data: null };
       const dataLines = [];
       for (const line of block.split(/\r?\n/u)) {
+        if (line.startsWith(':')) {
+          continue;
+        }
         if (line.startsWith('event:')) {
           event.event = line.slice('event:'.length).trim();
         } else if (line.startsWith('data:')) {
           dataLines.push(line.slice('data:'.length).trim());
         }
+      }
+      if (dataLines.length === 0) {
+        return [];
       }
       const dataText = dataLines.join('\n');
       try {
@@ -1031,7 +1111,7 @@ function parseSse(text) {
       } catch {
         event.data = dataText;
       }
-      return event;
+      return [event];
     });
 }
 
@@ -1159,6 +1239,9 @@ async function main() {
     }
     if (options.commandParts[0] === 'events') {
       return await handleEventsCommand(options);
+    }
+    if (options.commandParts[0] === 'tasks') {
+      return await handleTasksCommand(options);
     }
     if (options.commandParts[0] === 'logs') {
       return await handleLogsCommand(options);

--- a/ClassNoteAI/src-tauri/src/agent_bridge.rs
+++ b/ClassNoteAI/src-tauri/src/agent_bridge.rs
@@ -10,13 +10,14 @@ use serde_json::{json, Value};
 use tauri::{AppHandle, Emitter, Manager};
 use tokio::io::{AsyncReadExt, AsyncWriteExt};
 use tokio::net::{TcpListener, TcpStream};
-use tokio::sync::{oneshot, Mutex};
+use tokio::sync::{broadcast, oneshot, Mutex};
 use uuid::Uuid;
 
 const API_VERSION: u32 = 1;
 const DEFAULT_PORT: u16 = 4317;
 const MAX_REQUEST_BYTES: usize = 64 * 1024;
 const EVENT_RING_CAPACITY: usize = 128;
+const EVENT_BROADCAST_CAPACITY: usize = 256;
 const UI_ACTION_TIMEOUT_MS: u64 = 30_000;
 
 static BRIDGE_STATE: OnceLock<Arc<BridgeState>> = OnceLock::new();
@@ -43,13 +44,27 @@ struct BridgeEvent {
     payload: Value,
 }
 
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct BridgeTask {
+    id: String,
+    task_type: String,
+    status: String,
+    started_at: String,
+    updated_at: String,
+    message: Option<String>,
+    artifacts: Vec<Value>,
+}
+
 #[derive(Debug)]
 struct BridgeState {
     app: AppHandle,
     attach: AttachFile,
     started_at: String,
     events: Mutex<VecDeque<BridgeEvent>>,
+    event_tx: broadcast::Sender<BridgeEvent>,
     next_event_id: Mutex<u64>,
+    tasks: Mutex<HashMap<String, BridgeTask>>,
     ui_state: Mutex<Option<Value>>,
     pending_ui_actions: Mutex<HashMap<String, oneshot::Sender<Value>>>,
 }
@@ -118,12 +133,15 @@ async fn run_server(app: AppHandle, requested_port: u16, token: String) -> Resul
 
     write_attach_file(&app, &attach)?;
 
+    let (event_tx, _) = broadcast::channel(EVENT_BROADCAST_CAPACITY);
     let state = Arc::new(BridgeState {
         app,
         attach,
         started_at: created_at,
         events: Mutex::new(VecDeque::with_capacity(EVENT_RING_CAPACITY)),
+        event_tx,
         next_event_id: Mutex::new(1),
+        tasks: Mutex::new(HashMap::new()),
         ui_state: Mutex::new(None),
         pending_ui_actions: Mutex::new(HashMap::new()),
     });
@@ -168,7 +186,84 @@ async fn push_event(state: &Arc<BridgeState>, event_type: &str, payload: Value) 
     if events.len() >= EVENT_RING_CAPACITY {
         events.pop_front();
     }
-    events.push_back(event);
+    events.push_back(event.clone());
+    let _ = state.event_tx.send(event);
+}
+
+async fn start_task(state: &Arc<BridgeState>, task_id: String, task_type: &str, payload: Value) {
+    let timestamp = now();
+    let task = BridgeTask {
+        id: task_id.clone(),
+        task_type: task_type.to_string(),
+        status: "running".to_string(),
+        started_at: timestamp.clone(),
+        updated_at: timestamp,
+        message: None,
+        artifacts: Vec::new(),
+    };
+    state
+        .tasks
+        .lock()
+        .await
+        .insert(task_id.clone(), task.clone());
+    push_event(
+        state,
+        "task.started",
+        json!({
+            "taskId": task_id,
+            "taskType": task_type,
+            "task": task,
+            "payload": payload,
+        }),
+    )
+    .await;
+}
+
+async fn finish_task(
+    state: &Arc<BridgeState>,
+    task_id: &str,
+    status: &str,
+    message: Option<String>,
+    artifacts: Vec<Value>,
+    payload: Value,
+) {
+    let updated_at = now();
+    let mut tasks = state.tasks.lock().await;
+    let task = tasks
+        .entry(task_id.to_string())
+        .or_insert_with(|| BridgeTask {
+            id: task_id.to_string(),
+            task_type: "unknown".to_string(),
+            status: status.to_string(),
+            started_at: updated_at.clone(),
+            updated_at: updated_at.clone(),
+            message: None,
+            artifacts: Vec::new(),
+        });
+    task.status = status.to_string();
+    task.updated_at = updated_at;
+    task.message = message.clone();
+    task.artifacts = artifacts;
+    let task_snapshot = task.clone();
+    drop(tasks);
+
+    let event_type = match status {
+        "completed" => "task.completed",
+        "failed" => "task.failed",
+        "timeout" => "task.timeout",
+        _ => "task.updated",
+    };
+    push_event(
+        state,
+        event_type,
+        json!({
+            "taskId": task_id,
+            "taskType": task_snapshot.task_type,
+            "task": task_snapshot,
+            "payload": payload,
+        }),
+    )
+    .await;
 }
 
 #[tauri::command]
@@ -228,6 +323,10 @@ fn generate_token() -> String {
 
 async fn handle_connection(mut stream: TcpStream, state: Arc<BridgeState>) -> Result<(), String> {
     let request = read_request(&mut stream).await?;
+    if is_events_follow_request(&request) && is_authorized(&request, &state.attach.token) {
+        write_events_stream(&mut stream, state).await?;
+        return Ok(());
+    }
     let response = route_request(request, state).await;
     stream
         .write_all(&response)
@@ -300,6 +399,7 @@ async fn route_request(request: HttpRequest, state: Arc<BridgeState>) -> Vec<u8>
         ("GET", "/v1/status") => json_response(200, status_payload(&state).await),
         ("GET", "/v1/logs") => json_response(200, logs_payload(&state, &request).await),
         ("GET", "/v1/events") => events_response(&state).await,
+        ("GET", "/v1/tasks") => json_response(200, tasks_payload(&state).await),
         ("POST", "/v1/diag/bundle") => diag_bundle_response(&state).await,
         ("GET", "/v1/workflows") => json_response(200, workflow_payload()),
         ("POST", "/v1/call/raw") => raw_command_response(&state, &request).await,
@@ -348,6 +448,8 @@ fn handshake_payload(state: &BridgeState) -> Value {
             {"id": "app.status", "stability": "stable"},
             {"id": "logs.tail", "stability": "experimental"},
             {"id": "events.watch", "stability": "experimental"},
+            {"id": "events.follow", "stability": "experimental"},
+            {"id": "tasks.list", "stability": "experimental"},
             {"id": "diag.bundle", "stability": "experimental"},
             {"id": "workflow.list", "stability": "experimental"},
             {"id": "call.raw", "stability": "planned"},
@@ -369,6 +471,7 @@ fn handshake_payload(state: &BridgeState) -> Value {
 
 async fn status_payload(state: &Arc<BridgeState>) -> Value {
     let events = state.events.lock().await;
+    let tasks = state.tasks.lock().await;
     let window_count = state.app.webview_windows().len();
     let log_dir = state
         .app
@@ -397,6 +500,8 @@ async fn status_payload(state: &Arc<BridgeState>) -> Value {
             "apiVersion": API_VERSION,
             "startedAt": state.started_at,
             "eventCount": events.len(),
+            "taskCount": tasks.len(),
+            "runningTaskCount": tasks.values().filter(|task| task.status == "running").count(),
         },
         "paths": {
             "appDataDir": app_data_dir,
@@ -445,7 +550,116 @@ async fn events_response(state: &Arc<BridgeState>) -> Vec<u8> {
     )
 }
 
+async fn tasks_payload(state: &Arc<BridgeState>) -> Value {
+    let tasks = state.tasks.lock().await;
+    json!({
+        "schemaVersion": 1,
+        "type": "task_list",
+        "status": "ok",
+        "tasks": tasks.values().collect::<Vec<_>>(),
+    })
+}
+
+fn is_events_follow_request(request: &HttpRequest) -> bool {
+    request.method == "GET"
+        && request.path == "/v1/events"
+        && request
+            .query
+            .get("follow")
+            .map(|value| matches!(value.as_str(), "1" | "true" | "yes"))
+            .unwrap_or(false)
+}
+
+async fn write_events_stream(
+    stream: &mut TcpStream,
+    state: Arc<BridgeState>,
+) -> Result<(), String> {
+    let mut receiver = state.event_tx.subscribe();
+    let snapshot = {
+        let events = state.events.lock().await;
+        json!({
+            "schemaVersion": 1,
+            "type": "event_snapshot",
+            "status": "ok",
+            "events": events.iter().collect::<Vec<_>>(),
+        })
+    };
+
+    let headers = "HTTP/1.1 200 OK\r\n\
+         Content-Type: text/event-stream; charset=utf-8\r\n\
+         Cache-Control: no-cache\r\n\
+         Access-Control-Allow-Origin: http://localhost\r\n\
+         Access-Control-Allow-Headers: authorization, content-type\r\n\
+         Access-Control-Allow-Methods: GET, POST, OPTIONS\r\n\
+         Connection: close\r\n\r\n";
+    stream
+        .write_all(headers.as_bytes())
+        .await
+        .map_err(|e| format!("write event stream headers: {e}"))?;
+    write_sse_event(stream, "bridge.snapshot", &snapshot).await?;
+
+    let mut heartbeat = tokio::time::interval(Duration::from_secs(15));
+    loop {
+        tokio::select! {
+            event = receiver.recv() => {
+                match event {
+                    Ok(event) => {
+                        let payload = serde_json::to_value(&event)
+                            .map_err(|e| format!("serialize event: {e}"))?;
+                        write_sse_event(stream, &event.event_type, &payload).await?;
+                    }
+                    Err(broadcast::error::RecvError::Lagged(skipped)) => {
+                        write_sse_event(
+                            stream,
+                            "bridge.events.lagged",
+                            &json!({
+                                "schemaVersion": 1,
+                                "type": "event_lagged",
+                                "status": "warning",
+                                "skipped": skipped,
+                            }),
+                        ).await?;
+                    }
+                    Err(broadcast::error::RecvError::Closed) => return Ok(()),
+                }
+            }
+            _ = heartbeat.tick() => {
+                write_sse_comment(stream, "keepalive").await?;
+            }
+        }
+    }
+}
+
+async fn write_sse_event(
+    stream: &mut TcpStream,
+    event_type: &str,
+    payload: &Value,
+) -> Result<(), String> {
+    let data = serde_json::to_string(payload).map_err(|e| format!("serialize sse data: {e}"))?;
+    let text = format!("event: {event_type}\ndata: {data}\n\n");
+    stream
+        .write_all(text.as_bytes())
+        .await
+        .map_err(|e| format!("write sse event: {e}"))
+}
+
+async fn write_sse_comment(stream: &mut TcpStream, comment: &str) -> Result<(), String> {
+    let text = format!(": {comment}\n\n");
+    stream
+        .write_all(text.as_bytes())
+        .await
+        .map_err(|e| format!("write sse heartbeat: {e}"))
+}
+
 async fn diag_bundle_response(state: &Arc<BridgeState>) -> Vec<u8> {
+    let task_id = format!("diag-{}", Uuid::new_v4());
+    start_task(
+        state,
+        task_id.clone(),
+        "workflow.diagnostics",
+        json!({ "source": "agent_bridge" }),
+    )
+    .await;
     let log_text = read_recent_log_lines(&state.app, 2000).unwrap_or_default();
     let input = crate::diagnostics::DiagnosticPackageInput {
         lecture_meta_json: "{}".to_string(),
@@ -467,24 +681,55 @@ async fn diag_bundle_response(state: &Arc<BridgeState>) -> Vec<u8> {
         .unwrap_or_else(|_| "{}".to_string()),
     };
     match crate::diagnostics::build_diagnostic_zip(input, false) {
-        Ok(path) => json_response(
-            200,
-            json!({
-                "schemaVersion": 1,
-                "type": "diag_bundle",
-                "status": "ok",
-                "path": path.to_string_lossy(),
-            }),
-        ),
-        Err(error) => json_response(
-            500,
-            json!({
-                "schemaVersion": 1,
-                "type": "diag_bundle",
-                "status": "failed",
-                "message": error,
-            }),
-        ),
+        Ok(path) => {
+            let path_text = path.to_string_lossy().to_string();
+            let artifact = json!({
+                "type": "diagnostic_bundle",
+                "path": path_text,
+            });
+            finish_task(
+                state,
+                &task_id,
+                "completed",
+                None,
+                vec![artifact.clone()],
+                json!({ "path": path_text }),
+            )
+            .await;
+            json_response(
+                200,
+                json!({
+                    "schemaVersion": 1,
+                    "type": "diag_bundle",
+                    "status": "ok",
+                    "taskId": task_id,
+                    "path": path_text,
+                    "artifacts": [artifact],
+                }),
+            )
+        }
+        Err(error) => {
+            let error_text = error;
+            finish_task(
+                state,
+                &task_id,
+                "failed",
+                Some(error_text.clone()),
+                Vec::new(),
+                json!({ "message": error_text.clone() }),
+            )
+            .await;
+            json_response(
+                500,
+                json!({
+                    "schemaVersion": 1,
+                    "type": "diag_bundle",
+                    "status": "failed",
+                    "taskId": task_id,
+                    "message": error_text,
+                }),
+            )
+        }
     }
 }
 
@@ -614,10 +859,33 @@ async fn ui_action_response(
 ) -> Vec<u8> {
     let mut payload: Value = serde_json::from_slice(&request.body).unwrap_or_else(|_| json!({}));
     let action_id = Uuid::new_v4().to_string();
+    let task_id = payload
+        .get("taskId")
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+        .unwrap_or_else(|| format!("ui-{action_id}"));
     payload["actionId"] = json!(action_id);
+    payload["taskId"] = json!(task_id);
     payload["kind"] = json!(kind);
 
+    start_task(
+        state,
+        task_id.clone(),
+        &format!("ui.{kind}"),
+        payload.clone(),
+    )
+    .await;
+
     let Some(window) = state.app.get_webview_window("main") else {
+        finish_task(
+            state,
+            &task_id,
+            "failed",
+            Some("main webview window is not available".to_string()),
+            Vec::new(),
+            json!({ "kind": kind }),
+        )
+        .await;
         return json_response(
             500,
             json!({
@@ -626,6 +894,7 @@ async fn ui_action_response(
                 "status": "failed",
                 "kind": kind,
                 "message": "main webview window is not available",
+                "taskId": task_id,
             }),
         );
     };
@@ -649,6 +918,16 @@ async fn ui_action_response(
 
     if let Err(error) = window.emit("agent-bridge-ui-action", payload.clone()) {
         let _ = state.pending_ui_actions.lock().await.remove(&action_id);
+        let message = format!("emit ui action: {error}");
+        finish_task(
+            state,
+            &task_id,
+            "failed",
+            Some(message.clone()),
+            Vec::new(),
+            json!({ "kind": kind, "actionId": action_id }),
+        )
+        .await;
         return json_response(
             500,
             json!({
@@ -657,7 +936,8 @@ async fn ui_action_response(
                 "status": "failed",
                 "kind": kind,
                 "actionId": action_id,
-                "message": format!("emit ui action: {error}"),
+                "taskId": task_id,
+                "message": message,
             }),
         );
     }
@@ -679,6 +959,24 @@ async fn ui_action_response(
                 .and_then(Value::as_str)
                 .map(|status| status == "ok")
                 .unwrap_or(false);
+            let task_status = if ok { "completed" } else { "failed" };
+            let message = result
+                .get("message")
+                .and_then(Value::as_str)
+                .map(ToString::to_string);
+            finish_task(
+                state,
+                &task_id,
+                task_status,
+                message,
+                Vec::new(),
+                json!({
+                    "kind": kind,
+                    "actionId": action_id,
+                    "result": result,
+                }),
+            )
+            .await;
             json_response(
                 if ok { 200 } else { 500 },
                 json!({
@@ -687,23 +985,45 @@ async fn ui_action_response(
                     "status": if ok { "ok" } else { "failed" },
                     "kind": kind,
                     "actionId": action_id,
+                    "taskId": task_id,
                     "result": result,
                 }),
             )
         }
-        Ok(Err(_)) => json_response(
-            500,
-            json!({
-                "schemaVersion": 1,
-                "type": "ui_action",
-                "status": "failed",
-                "kind": kind,
-                "actionId": action_id,
-                "message": "renderer dropped ui action response",
-            }),
-        ),
+        Ok(Err(_)) => {
+            finish_task(
+                state,
+                &task_id,
+                "failed",
+                Some("renderer dropped ui action response".to_string()),
+                Vec::new(),
+                json!({ "kind": kind, "actionId": action_id }),
+            )
+            .await;
+            json_response(
+                500,
+                json!({
+                    "schemaVersion": 1,
+                    "type": "ui_action",
+                    "status": "failed",
+                    "kind": kind,
+                    "actionId": action_id,
+                    "taskId": task_id,
+                    "message": "renderer dropped ui action response",
+                }),
+            )
+        }
         Err(_) => {
             let _ = state.pending_ui_actions.lock().await.remove(&action_id);
+            finish_task(
+                state,
+                &task_id,
+                "timeout",
+                Some("renderer did not complete ui action before timeout".to_string()),
+                Vec::new(),
+                json!({ "kind": kind, "actionId": action_id }),
+            )
+            .await;
             json_response(
                 504,
                 json!({
@@ -712,6 +1032,7 @@ async fn ui_action_response(
                     "status": "timeout",
                     "kind": kind,
                     "actionId": action_id,
+                    "taskId": task_id,
                     "message": "renderer did not complete ui action before timeout",
                 }),
             )
@@ -908,6 +1229,21 @@ mod tests {
                 .unwrap(),
             25
         );
+    }
+
+    #[test]
+    fn detects_events_follow_requests() {
+        let request = parse_http_request(
+            b"GET /v1/events?follow=1 HTTP/1.1\r\nAuthorization: Bearer abc\r\n\r\n",
+        )
+        .unwrap();
+
+        assert!(is_events_follow_request(&request));
+
+        let snapshot =
+            parse_http_request(b"GET /v1/events HTTP/1.1\r\nAuthorization: Bearer abc\r\n\r\n")
+                .unwrap();
+        assert!(!is_events_follow_request(&snapshot));
     }
 
     #[test]

--- a/docs/development/AGENT_CLI.md
+++ b/docs/development/AGENT_CLI.md
@@ -23,6 +23,8 @@ node scripts/cnai-agent.mjs app attach --json
 node scripts/cnai-agent.mjs app status --json
 node scripts/cnai-agent.mjs app handshake --json --bridge-url http://127.0.0.1:4317
 node scripts/cnai-agent.mjs events watch --ndjson --bridge-url http://127.0.0.1:4317
+node scripts/cnai-agent.mjs events watch --follow --ndjson --max-events 10
+node scripts/cnai-agent.mjs tasks list --json
 node scripts/cnai-agent.mjs logs tail --json --bridge-url http://127.0.0.1:4317
 node scripts/cnai-agent.mjs diag bundle --json
 node scripts/cnai-agent.mjs workflow list --json
@@ -72,7 +74,8 @@ Issue #112 is larger than this first CLI PR. This table keeps the scope honest:
 | App launch / attach / authenticated local bridge | Implemented behind opt-in `CNAI_AGENT_BRIDGE=1`; `app launch` starts dev mode with the bridge, `app attach` reads the attach file, and app-backed commands send bearer auth. |
 | App status | Implemented through `/v1/status`. |
 | Log tail | Implemented through `/v1/logs` for recent logs. Continuous follow is part of the command contract but currently returns the current log snapshot. |
-| Structured event streaming | Implemented through `/v1/events` as a bridge SSE snapshot. Long-lived streaming is the next bridge increment. |
+| Structured event streaming | Implemented through `/v1/events`; add `?follow=1` or CLI `events watch --follow --ndjson` for a long-lived stream. |
+| Task lifecycle records | Implemented through `/v1/tasks` and `tasks list`; bridge-backed workflows/actions emit `task.started` and terminal task events. |
 | Diagnostic bundle | Implemented locally and through `/v1/diag/bundle` when attached to the app bridge. |
 | Raw command plane | Implemented for a small safe allowlist: `get_build_features` and `agent_bridge_status`. |
 | High-level workflow commands | `workflow list` exposes contracts locally and through `/v1/workflows`; `workflow diagnostics` is implemented as an app-backed workflow. Media/OCR/summary/chat execution endpoints currently return structured `unsupported`. |
@@ -111,6 +114,7 @@ The first bridge-backed version provides:
 - authenticated attach via an app-written attach file
 - status, logs, events, diagnostic bundle, and workflow discovery endpoints
 - renderer DOM state and basic UI actions for app-driving agents
+- task lifecycle records and long-lived event follow mode for action/workflow correlation
 
 The next bridge-backed commands should reuse this entry point:
 
@@ -119,7 +123,8 @@ node scripts/cnai-agent.mjs app status --json
 node scripts/cnai-agent.mjs ui tree --json
 node scripts/cnai-agent.mjs ui click --target nav.settings --json
 node scripts/cnai-agent.mjs ui wait-for --target view.settings --json
-node scripts/cnai-agent.mjs events watch --ndjson
+node scripts/cnai-agent.mjs events watch --follow --ndjson
+node scripts/cnai-agent.mjs tasks list --json
 node scripts/cnai-agent.mjs workflow import-media --file lecture.mp4 --json
 node scripts/cnai-agent.mjs diag bundle --json
 ```


### PR DESCRIPTION
## Summary

PR 3 for #112, stacked on #146.

- Adds a bridge task registry and `/v1/tasks` / `tasks list` CLI surface.
- Adds long-lived `/v1/events?follow=1` SSE streaming and `events watch --follow --ndjson` support.
- Emits task lifecycle records for bridge-backed UI actions and diagnostic workflow execution.
- Adds CLI `--max-events` guard for deterministic agent/test consumption.
- Updates the Agent CLI docs with event follow and task lifecycle coverage.

## Verification

- `npx vitest run evals/scripts/__tests__/cnai-agent.test.ts`
- `npm exec tsc -- --noEmit`
- `cargo test --lib agent_bridge`
- `cargo check --lib`
- `npx vitest run`
- `npm run build`
- `git diff --check`
- Live desktop smoke with temporary Tauri identifier/port:
  - start app bridge
  - `events watch --follow --ndjson --max-events 3`
  - `ui type --target auth.username --text agent-events --clear`
  - `tasks list`
  - second event-follow smoke confirmed terminal `task.completed` event

## Notes

This completes the task/event streaming layer needed before first-class workflow commands. Next stack target for #112 is the workflow pack.

Part of #112.