### PR TITLE
Add app-backed agent workflow pack

### DIFF
--- a/ClassNoteAI/README.md
+++ b/ClassNoteAI/README.md
@@ -25,6 +25,13 @@ This README is for the app workspace. For the project overview, release links, a
 - Add PDFs, notes, or syllabus material to the course.
 - Search across course material and ask the AI assistant contextual questions.
 
+### Agent-Assisted Debugging
+
+- Launch the desktop app with an opt-in automation bridge for local debugging.
+- Inspect app state, recent events, logs, task progress, and visible UI controls.
+- Run high-level app workflows such as media import, course indexing, and lecture summaries from the agent CLI.
+- Use dry runs when validating automation contracts without changing app data.
+
 ## Local Data
 
 The app keeps course data, lecture metadata, captions, notes, and local indexes on your machine. Some optional AI actions may send selected content to the provider you configure.
@@ -63,6 +70,12 @@ Run a production frontend build:
 
 ```bash
 npm run build
+```
+
+Run the agent CLI handshake:
+
+```bash
+npm run agent:handshake
 ```
 
 Rust checks live under `src-tauri`:

--- a/ClassNoteAI/evals/scripts/__tests__/cnai-agent.test.ts
+++ b/ClassNoteAI/evals/scripts/__tests__/cnai-agent.test.ts
@@ -274,6 +274,72 @@ describe('cnai-agent CLI', () => {
     });
   });
 
+  it('posts app workflow arguments to the bridge', async () => {
+    let requestBody = '';
+    const server = createServer((req, res) => {
+      expect(req.url).toBe('/v1/workflow/import-media');
+      req.on('data', (chunk) => {
+        requestBody += chunk.toString();
+      });
+      req.on('end', () => {
+        res.setHeader('content-type', 'application/json');
+        res.end(
+          JSON.stringify({
+            schemaVersion: 1,
+            type: 'workflow_result',
+            status: 'ok',
+            workflowId: 'import-media',
+          }),
+        );
+      });
+    });
+    await new Promise<void>((resolveListen) => server.listen(0, '127.0.0.1', resolveListen));
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('server did not bind to a TCP port');
+    }
+    const tempDir = mkdtempSync(resolve(tmpdir(), 'cnai-agent-test-'));
+    const attachFile = resolve(tempDir, 'agent-bridge.json');
+    writeFileSync(
+      attachFile,
+      JSON.stringify({
+        schemaVersion: 1,
+        apiVersion: 1,
+        url: `http://127.0.0.1:${address.port}`,
+        token: 'test-token',
+        pid: 123,
+      }),
+    );
+
+    const result = await runCliAsync([
+      'workflow',
+      'import-media',
+      '--lecture-id',
+      'lecture-1',
+      '--file',
+      'D:/input/class.mp4',
+      '--language',
+      'auto',
+      '--dry-run',
+      '--json',
+      '--attach-file',
+      attachFile,
+      '--timeout-ms',
+      '2000',
+    ]);
+    server.close();
+
+    const payload = JSON.parse(result.stdout);
+    expect(result.status).toBe(0);
+    expect(payload.type).toBe('workflow_import-media');
+    expect(JSON.parse(requestBody)).toEqual(expect.objectContaining({
+      lectureId: 'lecture-1',
+      file: 'D:/input/class.mp4',
+      language: 'auto',
+      dryRun: true,
+    }));
+  });
+
   it('streams followed bridge events as NDJSON with a max event guard', async () => {
     const server = createServer((req, res) => {
       expect(req.url).toBe('/v1/events?follow=1');

--- a/ClassNoteAI/scripts/cnai-agent.mjs
+++ b/ClassNoteAI/scripts/cnai-agent.mjs
@@ -88,7 +88,9 @@ Usage:
   node scripts/cnai-agent.mjs logs tail [--json] [--follow] [--bridge-url URL] [--token TOKEN]
   node scripts/cnai-agent.mjs diag bundle [--json] [--output PATH]
   node scripts/cnai-agent.mjs workflow list [--json]
-  node scripts/cnai-agent.mjs workflow import-media --json [--file PATH]
+  node scripts/cnai-agent.mjs workflow import-media --json --lecture-id ID --file PATH [--language auto|en|zh] [--dry-run]
+  node scripts/cnai-agent.mjs workflow ocr-index --json --lecture-id ID [--pdf-path PATH] [--transcript-text TEXT] [--force-refresh] [--dry-run]
+  node scripts/cnai-agent.mjs workflow summarize --json [--lecture-id ID|--content TEXT] [--language zh|en] [--write-note] [--dry-run]
   node scripts/cnai-agent.mjs ui snapshot [--json]
   node scripts/cnai-agent.mjs ui tree [--json]
   node scripts/cnai-agent.mjs ui click --target ID [--json]
@@ -151,6 +153,15 @@ function parseArgs(argv) {
     dev: false,
     port: undefined,
     file: undefined,
+    lectureId: undefined,
+    courseId: undefined,
+    noteId: undefined,
+    pdfPath: undefined,
+    transcriptText: undefined,
+    content: undefined,
+    language: undefined,
+    forceRefresh: false,
+    writeNote: undefined,
     maxEvents: undefined,
     target: undefined,
     selector: undefined,
@@ -195,6 +206,26 @@ function parseArgs(argv) {
       options.output = args.shift();
     } else if (arg === '--file') {
       options.file = args.shift();
+    } else if (arg === '--lecture-id') {
+      options.lectureId = args.shift();
+    } else if (arg === '--course-id') {
+      options.courseId = args.shift();
+    } else if (arg === '--note-id') {
+      options.noteId = args.shift();
+    } else if (arg === '--pdf-path') {
+      options.pdfPath = args.shift();
+    } else if (arg === '--transcript-text') {
+      options.transcriptText = args.shift();
+    } else if (arg === '--content') {
+      options.content = args.shift();
+    } else if (arg === '--language') {
+      options.language = args.shift();
+    } else if (arg === '--force-refresh') {
+      options.forceRefresh = true;
+    } else if (arg === '--write-note') {
+      options.writeNote = true;
+    } else if (arg === '--no-write-note') {
+      options.writeNote = false;
     } else if (arg === '--max-events') {
       const raw = args.shift();
       const parsed = Number(raw);
@@ -298,6 +329,21 @@ function handshakePayload() {
         id: 'workflow.list',
         stability: 'experimental',
         description: 'List workflow command contracts exposed by this CLI.',
+      },
+      {
+        id: 'workflow.import-media',
+        stability: 'experimental',
+        description: 'Import audio/video media through the app bridge.',
+      },
+      {
+        id: 'workflow.ocr-index',
+        stability: 'experimental',
+        description: 'Build a lecture OCR/RAG index through the app bridge.',
+      },
+      {
+        id: 'workflow.summarize',
+        stability: 'experimental',
+        description: 'Generate a lecture summary through the app bridge.',
       },
       {
         id: 'call.raw',
@@ -781,21 +827,21 @@ function workflowContracts() {
       },
       {
         id: 'import-media',
-        stability: 'planned',
-        command: ['workflow', 'import-media', '--file', '<path>'],
+        stability: 'experimental',
+        command: ['workflow', 'import-media', '--lecture-id', '<id>', '--file', '<path>'],
         requiresBridge: true,
         description: 'Import an audio/video file into a lecture through the app bridge.',
       },
       {
         id: 'ocr-index',
-        stability: 'planned',
-        command: ['workflow', 'ocr-index', '--course-id', '<id>'],
+        stability: 'experimental',
+        command: ['workflow', 'ocr-index', '--lecture-id', '<id>', '--pdf-path', '<path>'],
         requiresBridge: true,
         description: 'Index course material through the app bridge.',
       },
       {
         id: 'summarize',
-        stability: 'planned',
+        stability: 'experimental',
         command: ['workflow', 'summarize', '--lecture-id', '<id>'],
         requiresBridge: true,
         description: 'Generate a lecture summary through the app bridge.',
@@ -1075,6 +1121,16 @@ async function handleWorkflowCommand(options) {
         method: 'POST',
         body: {
           file: options.file ?? null,
+          lectureId: options.lectureId ?? null,
+          courseId: options.courseId ?? null,
+          noteId: options.noteId ?? null,
+          pdfPath: options.pdfPath ?? null,
+          transcriptText: options.transcriptText ?? null,
+          content: options.content ?? null,
+          language: options.language ?? null,
+          forceRefresh: options.forceRefresh,
+          writeNote: options.writeNote ?? null,
+          dryRun: options.dryRun,
         },
       },
     );

--- a/ClassNoteAI/src-tauri/src/agent_bridge.rs
+++ b/ClassNoteAI/src-tauri/src/agent_bridge.rs
@@ -19,6 +19,7 @@ const MAX_REQUEST_BYTES: usize = 64 * 1024;
 const EVENT_RING_CAPACITY: usize = 128;
 const EVENT_BROADCAST_CAPACITY: usize = 256;
 const UI_ACTION_TIMEOUT_MS: u64 = 30_000;
+const WORKFLOW_TIMEOUT_MS: u64 = 15 * 60_000;
 
 static BRIDGE_STATE: OnceLock<Arc<BridgeState>> = OnceLock::new();
 
@@ -67,6 +68,7 @@ struct BridgeState {
     tasks: Mutex<HashMap<String, BridgeTask>>,
     ui_state: Mutex<Option<Value>>,
     pending_ui_actions: Mutex<HashMap<String, oneshot::Sender<Value>>>,
+    pending_workflows: Mutex<HashMap<String, oneshot::Sender<Value>>>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -144,6 +146,7 @@ async fn run_server(app: AppHandle, requested_port: u16, token: String) -> Resul
         tasks: Mutex::new(HashMap::new()),
         ui_state: Mutex::new(None),
         pending_ui_actions: Mutex::new(HashMap::new()),
+        pending_workflows: Mutex::new(HashMap::new()),
     });
     let _ = BRIDGE_STATE.set(state.clone());
 
@@ -295,6 +298,55 @@ pub async fn agent_bridge_complete_ui_action(
     Ok(())
 }
 
+#[tauri::command]
+pub async fn agent_bridge_workflow_progress(
+    task_id: String,
+    message: Option<String>,
+    payload: Value,
+) -> Result<(), String> {
+    let Some(bridge_state) = BRIDGE_STATE.get() else {
+        return Ok(());
+    };
+    if let Some(message) = message.clone() {
+        let updated_at = now();
+        let mut tasks = bridge_state.tasks.lock().await;
+        if let Some(task) = tasks.get_mut(&task_id) {
+            task.updated_at = updated_at;
+            task.message = Some(message);
+        }
+    }
+    push_event(
+        bridge_state,
+        "task.progress",
+        json!({
+            "taskId": task_id,
+            "message": message,
+            "payload": payload,
+        }),
+    )
+    .await;
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn agent_bridge_complete_workflow(
+    task_id: String,
+    result: Value,
+) -> Result<(), String> {
+    let Some(bridge_state) = BRIDGE_STATE.get() else {
+        return Ok(());
+    };
+    let sender = bridge_state
+        .pending_workflows
+        .lock()
+        .await
+        .remove(&task_id);
+    if let Some(sender) = sender {
+        let _ = sender.send(result);
+    }
+    Ok(())
+}
+
 fn write_attach_file(app: &AppHandle, attach: &AttachFile) -> Result<(), String> {
     let path = attach_file_path(app)?;
     if let Some(parent) = path.parent() {
@@ -404,9 +456,11 @@ async fn route_request(request: HttpRequest, state: Arc<BridgeState>) -> Vec<u8>
         ("GET", "/v1/workflows") => json_response(200, workflow_payload()),
         ("POST", "/v1/call/raw") => raw_command_response(&state, &request).await,
         ("POST", "/v1/workflow/diagnostics") => diag_bundle_response(&state).await,
-        ("POST", "/v1/workflow/import-media") => unsupported_response("workflow.import-media"),
-        ("POST", "/v1/workflow/ocr-index") => unsupported_response("workflow.ocr-index"),
-        ("POST", "/v1/workflow/summarize") => unsupported_response("workflow.summarize"),
+        ("POST", "/v1/workflow/import-media") => {
+            workflow_response(&state, "import-media", &request).await
+        }
+        ("POST", "/v1/workflow/ocr-index") => workflow_response(&state, "ocr-index", &request).await,
+        ("POST", "/v1/workflow/summarize") => workflow_response(&state, "summarize", &request).await,
         ("POST", "/v1/workflow/chat") => unsupported_response("workflow.chat"),
         ("GET", "/v1/ui/snapshot") => json_response(200, ui_snapshot_payload(&state).await),
         ("GET", "/v1/ui/tree") => json_response(200, ui_tree_payload(&state).await),
@@ -453,10 +507,10 @@ fn handshake_payload(state: &BridgeState) -> Value {
             {"id": "diag.bundle", "stability": "experimental"},
             {"id": "workflow.list", "stability": "experimental"},
             {"id": "call.raw", "stability": "planned"},
-            {"id": "workflow.import-media", "stability": "planned"},
+            {"id": "workflow.import-media", "stability": "experimental"},
             {"id": "workflow.diagnostics", "stability": "experimental"},
-            {"id": "workflow.ocr-index", "stability": "planned"},
-            {"id": "workflow.summarize", "stability": "planned"},
+            {"id": "workflow.ocr-index", "stability": "experimental"},
+            {"id": "workflow.summarize", "stability": "experimental"},
             {"id": "workflow.chat", "stability": "planned"},
             {"id": "ui.snapshot", "stability": "experimental"},
             {"id": "ui.tree", "stability": "experimental"},
@@ -733,6 +787,197 @@ async fn diag_bundle_response(state: &Arc<BridgeState>) -> Vec<u8> {
     }
 }
 
+async fn workflow_response(
+    state: &Arc<BridgeState>,
+    workflow_id: &str,
+    request: &HttpRequest,
+) -> Vec<u8> {
+    let mut payload: Value = serde_json::from_slice(&request.body).unwrap_or_else(|_| json!({}));
+    let task_id = payload
+        .get("taskId")
+        .and_then(Value::as_str)
+        .map(ToString::to_string)
+        .unwrap_or_else(|| format!("workflow-{workflow_id}-{}", Uuid::new_v4()));
+    payload["taskId"] = json!(task_id);
+    payload["workflowId"] = json!(workflow_id);
+
+    start_task(
+        state,
+        task_id.clone(),
+        &format!("workflow.{workflow_id}"),
+        payload.clone(),
+    )
+    .await;
+
+    let Some(window) = state.app.get_webview_window("main") else {
+        let message = "main webview window is not available".to_string();
+        finish_task(
+            state,
+            &task_id,
+            "failed",
+            Some(message.clone()),
+            Vec::new(),
+            json!({ "workflowId": workflow_id }),
+        )
+        .await;
+        return json_response(
+            500,
+            json!({
+                "schemaVersion": 1,
+                "type": "workflow_result",
+                "status": "failed",
+                "workflowId": workflow_id,
+                "taskId": task_id,
+                "message": message,
+            }),
+        );
+    };
+
+    let (sender, receiver) = oneshot::channel();
+    state
+        .pending_workflows
+        .lock()
+        .await
+        .insert(task_id.clone(), sender);
+
+    push_event(
+        state,
+        "workflow.dispatched",
+        json!({
+            "workflowId": workflow_id,
+            "taskId": task_id,
+        }),
+    )
+    .await;
+
+    if let Err(error) = window.emit("agent-bridge-workflow", payload.clone()) {
+        let _ = state.pending_workflows.lock().await.remove(&task_id);
+        let message = format!("emit workflow: {error}");
+        finish_task(
+            state,
+            &task_id,
+            "failed",
+            Some(message.clone()),
+            Vec::new(),
+            json!({ "workflowId": workflow_id }),
+        )
+        .await;
+        return json_response(
+            500,
+            json!({
+                "schemaVersion": 1,
+                "type": "workflow_result",
+                "status": "failed",
+                "workflowId": workflow_id,
+                "taskId": task_id,
+                "message": message,
+            }),
+        );
+    }
+
+    match tokio::time::timeout(Duration::from_millis(WORKFLOW_TIMEOUT_MS), receiver).await {
+        Ok(Ok(result)) => {
+            let status = result
+                .get("status")
+                .and_then(Value::as_str)
+                .unwrap_or("failed");
+            let task_status = match status {
+                "ok" => "completed",
+                "timeout" => "timeout",
+                _ => "failed",
+            };
+            let http_status = match status {
+                "ok" => 200,
+                "needs_input" => 400,
+                "unsupported" => 501,
+                "timeout" => 504,
+                _ => 500,
+            };
+            let message = result
+                .get("message")
+                .and_then(Value::as_str)
+                .map(ToString::to_string);
+            let artifacts = result
+                .get("artifacts")
+                .and_then(Value::as_array)
+                .cloned()
+                .unwrap_or_default();
+            finish_task(
+                state,
+                &task_id,
+                task_status,
+                message.clone(),
+                artifacts.clone(),
+                json!({
+                    "workflowId": workflow_id,
+                    "result": result,
+                }),
+            )
+            .await;
+            json_response(
+                http_status,
+                json!({
+                    "schemaVersion": 1,
+                    "type": "workflow_result",
+                    "status": status,
+                    "workflowId": workflow_id,
+                    "taskId": task_id,
+                    "message": message,
+                    "result": result,
+                    "artifacts": artifacts,
+                }),
+            )
+        }
+        Ok(Err(_)) => {
+            let message = "renderer dropped workflow response".to_string();
+            finish_task(
+                state,
+                &task_id,
+                "failed",
+                Some(message.clone()),
+                Vec::new(),
+                json!({ "workflowId": workflow_id }),
+            )
+            .await;
+            json_response(
+                500,
+                json!({
+                    "schemaVersion": 1,
+                    "type": "workflow_result",
+                    "status": "failed",
+                    "workflowId": workflow_id,
+                    "taskId": task_id,
+                    "message": message,
+                }),
+            )
+        }
+        Err(_) => {
+            let _ = state.pending_workflows.lock().await.remove(&task_id);
+            let message = "renderer did not complete workflow before timeout".to_string();
+            finish_task(
+                state,
+                &task_id,
+                "timeout",
+                Some(message.clone()),
+                Vec::new(),
+                json!({ "workflowId": workflow_id }),
+            )
+            .await;
+            json_response(
+                504,
+                json!({
+                    "schemaVersion": 1,
+                    "type": "workflow_result",
+                    "status": "timeout",
+                    "workflowId": workflow_id,
+                    "taskId": task_id,
+                    "message": message,
+                }),
+            )
+        }
+    }
+}
+
 fn workflow_payload() -> Value {
     json!({
         "schemaVersion": 1,
@@ -740,9 +985,9 @@ fn workflow_payload() -> Value {
         "status": "ok",
         "workflows": [
             {"id": "diagnostics", "stability": "experimental", "requiresBridge": true},
-            {"id": "import-media", "stability": "planned", "requiresBridge": true},
-            {"id": "ocr-index", "stability": "planned", "requiresBridge": true},
-            {"id": "summarize", "stability": "planned", "requiresBridge": true},
+            {"id": "import-media", "stability": "experimental", "requiresBridge": true},
+            {"id": "ocr-index", "stability": "experimental", "requiresBridge": true},
+            {"id": "summarize", "stability": "experimental", "requiresBridge": true},
             {"id": "chat", "stability": "planned", "requiresBridge": true}
         ]
     })
@@ -1184,6 +1429,7 @@ fn reason(status: u16) -> &'static str {
     match status {
         200 => "OK",
         204 => "No Content",
+        400 => "Bad Request",
         401 => "Unauthorized",
         404 => "Not Found",
         504 => "Gateway Timeout",
@@ -1261,5 +1507,25 @@ mod tests {
         let token = generate_token();
         assert_eq!(token.len(), 64);
         assert!(token.chars().all(|ch| ch.is_ascii_hexdigit()));
+    }
+
+    #[test]
+    fn workflow_contract_marks_app_workflows_experimental() {
+        let payload = workflow_payload();
+        let workflows = payload
+            .get("workflows")
+            .and_then(Value::as_array)
+            .unwrap();
+
+        for id in ["import-media", "ocr-index", "summarize"] {
+            let workflow = workflows
+                .iter()
+                .find(|item| item.get("id").and_then(Value::as_str) == Some(id))
+                .unwrap();
+            assert_eq!(
+                workflow.get("stability").and_then(Value::as_str),
+                Some("experimental")
+            );
+        }
     }
 }

--- a/ClassNoteAI/src-tauri/src/lib.rs
+++ b/ClassNoteAI/src-tauri/src/lib.rs
@@ -2779,6 +2779,8 @@ pub fn run() {
             close_devtools,
             agent_bridge::agent_bridge_update_ui_state,
             agent_bridge::agent_bridge_complete_ui_action,
+            agent_bridge::agent_bridge_workflow_progress,
+            agent_bridge::agent_bridge_complete_workflow,
             read_recent_log,
             open_log_folder,
             export_diagnostic_package,

--- a/ClassNoteAI/src/App.tsx
+++ b/ClassNoteAI/src/App.tsx
@@ -15,6 +15,7 @@ import { toastService } from "./services/toastService";
 import { buildInterruptedRecordingNotice } from "./services/recordingInterruptionNotice";
 import { audioDeviceService } from "./services/audioDeviceService";
 import { useAgentAutomationBridge } from "./services/agentAutomationService";
+import { useAgentWorkflowBridge } from "./services/agentWorkflowService";
 import { useAuth } from "./contexts/AuthContext";
 
 type AppState = 'loading' | 'setup' | 'ready';
@@ -24,6 +25,7 @@ function App() {
   const [recoverableSessions, setRecoverableSessions] = useState<RecoverableSession[]>([]);
   const { user } = useAuth();
   useAgentAutomationBridge();
+  useAgentWorkflowBridge();
 
   // Detached AI 助教 webview: spawned by openDetachedAiTutor with the
   // `?aiTutorWindow=1` query flag. That window shares this bundle

--- a/ClassNoteAI/src/services/__tests__/agentWorkflowService.test.ts
+++ b/ClassNoteAI/src/services/__tests__/agentWorkflowService.test.ts
@@ -1,0 +1,159 @@
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../videoImportService', () => ({
+  videoImportService: { importVideo: vi.fn() },
+}));
+
+vi.mock('../ragService', () => ({
+  ragService: { indexLectureWithOCR: vi.fn() },
+}));
+
+vi.mock('../storageService', () => ({
+  storageService: {
+    getLecture: vi.fn(),
+    getSubtitles: vi.fn(),
+    getNote: vi.fn(),
+    saveNote: vi.fn(),
+  },
+}));
+
+vi.mock('../llm', () => ({
+  summarizeStream: vi.fn(),
+}));
+
+import {
+  runAgentWorkflow,
+  type AgentWorkflowRequest,
+} from '../agentWorkflowService';
+
+function deps(overrides: Partial<Parameters<typeof runAgentWorkflow>[1]> = {}) {
+  return {
+    importVideo: vi.fn(),
+    indexLectureWithOCR: vi.fn(),
+    summarizeStream: vi.fn(),
+    getLecture: vi.fn(),
+    getSubtitles: vi.fn(),
+    getNote: vi.fn(),
+    saveNote: vi.fn(),
+    readBinaryFile: vi.fn(),
+    progress: vi.fn(),
+    ...overrides,
+  } as NonNullable<Parameters<typeof runAgentWorkflow>[1]>;
+}
+
+async function* summaryEvents() {
+  yield { phase: 'reduce-start' as const };
+  yield { phase: 'reduce-delta' as const, delta: 'Summary' };
+  yield { phase: 'done' as const, fullText: 'Summary' };
+}
+
+describe('agentWorkflowService', () => {
+  it('accepts workflow dry-runs without touching app services', async () => {
+    const d = deps();
+
+    const result = await runAgentWorkflow({
+      taskId: 'task-1',
+      workflowId: 'import-media',
+      dryRun: true,
+      lectureId: 'lecture-1',
+      file: 'D:/class.mp4',
+    }, d);
+
+    expect(result.status).toBe('ok');
+    expect(result.data?.dryRun).toBe(true);
+    expect(d.importVideo).not.toHaveBeenCalled();
+  });
+
+  it('imports media through the existing video import service', async () => {
+    const d = deps({
+      importVideo: vi.fn(async (_lectureId, _file, options) => {
+        options.onProgress?.({ stage: 'transcribing', message: 'working', transcribed: 1 });
+        return { videoPath: 'D:/stored/class.mp4', segmentCount: 2, durationMs: 3000 };
+      }),
+    });
+
+    const result = await runAgentWorkflow({
+      taskId: 'task-2',
+      workflowId: 'import-media',
+      lectureId: 'lecture-1',
+      file: 'D:/class.mp4',
+      language: 'auto',
+    }, d);
+
+    expect(result.status).toBe('ok');
+    expect(d.importVideo).toHaveBeenCalledWith('lecture-1', 'D:/class.mp4', expect.objectContaining({
+      language: 'auto',
+    }));
+    expect(d.progress).toHaveBeenCalledWith('task-2', 'working', expect.objectContaining({
+      stage: 'transcribing',
+    }));
+  });
+
+  it('indexes OCR from a PDF path and lecture subtitles', async () => {
+    const d = deps({
+      readBinaryFile: vi.fn(async () => new Uint8Array([1, 2, 3]).buffer),
+      getSubtitles: vi.fn(async () => [
+        { id: 's1', lecture_id: 'lecture-1', timestamp: 2, text_en: 'second', type: 'rough' as const, created_at: '' },
+        { id: 's0', lecture_id: 'lecture-1', timestamp: 1, text_en: 'first', type: 'rough' as const, created_at: '' },
+      ]),
+      indexLectureWithOCR: vi.fn(async () => ({ chunksCount: 4, success: true })),
+    });
+
+    const result = await runAgentWorkflow({
+      taskId: 'task-3',
+      workflowId: 'ocr-index',
+      lectureId: 'lecture-1',
+      pdfPath: 'D:/slides.pdf',
+      forceRefresh: true,
+    }, d);
+
+    expect(result.status).toBe('ok');
+    expect(d.readBinaryFile).toHaveBeenCalledWith('D:/slides.pdf');
+    expect(d.indexLectureWithOCR).toHaveBeenCalledWith(
+      'lecture-1',
+      expect.any(ArrayBuffer),
+      'first\nsecond',
+      expect.any(Function),
+      true,
+    );
+  });
+
+  it('summarizes supplied content and can persist the lecture note', async () => {
+    const d = deps({
+      summarizeStream: vi.fn(() => summaryEvents()),
+      getLecture: vi.fn(async () => ({
+        id: 'lecture-1',
+        course_id: 'course-1',
+        title: 'Queues',
+        date: '2026-04-26',
+        duration: 0,
+        status: 'completed' as const,
+        created_at: '2026-04-26T00:00:00.000Z',
+        updated_at: '2026-04-26T00:00:00.000Z',
+      })),
+      getNote: vi.fn(async () => null),
+      saveNote: vi.fn(async () => undefined),
+    });
+
+    const request: AgentWorkflowRequest = {
+      taskId: 'task-4',
+      workflowId: 'summarize',
+      lectureId: 'lecture-1',
+      content: 'Queues use FIFO ordering.',
+      language: 'en',
+    };
+    const result = await runAgentWorkflow(request, d);
+
+    expect(result.status).toBe('ok');
+    expect(result.data?.summary).toBe('Summary');
+    expect(d.summarizeStream).toHaveBeenCalledWith(expect.objectContaining({
+      content: 'Queues use FIFO ordering.',
+      language: 'en',
+      title: 'Queues',
+    }));
+    expect(d.saveNote).toHaveBeenCalledWith(expect.objectContaining({
+      lecture_id: 'lecture-1',
+      summary: 'Summary',
+    }));
+  });
+});

--- a/ClassNoteAI/src/services/agentWorkflowService.ts
+++ b/ClassNoteAI/src/services/agentWorkflowService.ts
@@ -1,0 +1,332 @@
+import { invoke } from '@tauri-apps/api/core';
+import { listen, type UnlistenFn } from '@tauri-apps/api/event';
+import { useEffect } from 'react';
+
+import { summarizeStream } from './llm';
+import { ragService } from './ragService';
+import { storageService } from './storageService';
+import { videoImportService, type ImportProgress } from './videoImportService';
+import type { Note, Subtitle } from '../types';
+
+const WORKFLOW_EVENT = 'agent-bridge-workflow';
+const COMPLETE_COMMAND = 'agent_bridge_complete_workflow';
+const PROGRESS_COMMAND = 'agent_bridge_workflow_progress';
+
+type WorkflowStatus = 'ok' | 'failed' | 'unsupported' | 'needs_input';
+
+export type AgentWorkflowRequest = {
+  taskId: string;
+  workflowId: 'import-media' | 'ocr-index' | 'summarize' | string;
+  dryRun?: boolean;
+  file?: string | null;
+  lectureId?: string | null;
+  pdfPath?: string | null;
+  transcriptText?: string | null;
+  content?: string | null;
+  title?: string | null;
+  language?: 'zh' | 'en' | 'auto' | string | null;
+  forceRefresh?: boolean;
+  writeNote?: boolean;
+};
+
+export type AgentWorkflowResult = {
+  status: WorkflowStatus;
+  workflowId: string;
+  taskId: string;
+  message?: string;
+  data?: Record<string, unknown>;
+  artifacts?: Array<Record<string, unknown>>;
+};
+
+type WorkflowDeps = {
+  importVideo: typeof videoImportService.importVideo;
+  indexLectureWithOCR: typeof ragService.indexLectureWithOCR;
+  summarizeStream: typeof summarizeStream;
+  getLecture: typeof storageService.getLecture;
+  getSubtitles: typeof storageService.getSubtitles;
+  getNote: typeof storageService.getNote;
+  saveNote: typeof storageService.saveNote;
+  readBinaryFile: (path: string) => Promise<ArrayBuffer>;
+  progress: (taskId: string, message: string, payload?: Record<string, unknown>) => Promise<void>;
+};
+
+const defaultDeps: WorkflowDeps = {
+  importVideo: videoImportService.importVideo.bind(videoImportService),
+  indexLectureWithOCR: ragService.indexLectureWithOCR.bind(ragService),
+  summarizeStream,
+  getLecture: storageService.getLecture.bind(storageService),
+  getSubtitles: storageService.getSubtitles.bind(storageService),
+  getNote: storageService.getNote.bind(storageService),
+  saveNote: storageService.saveNote.bind(storageService),
+  readBinaryFile: async (path: string) => {
+    const bytes = await invoke<number[]>('read_binary_file', { path });
+    return new Uint8Array(bytes).buffer;
+  },
+  progress: emitWorkflowProgress,
+};
+
+export async function runAgentWorkflow(
+  request: AgentWorkflowRequest,
+  deps: WorkflowDeps = defaultDeps,
+): Promise<AgentWorkflowResult> {
+  const base = {
+    workflowId: request.workflowId,
+    taskId: request.taskId,
+  };
+
+  try {
+    if (!request.taskId) {
+      return { ...base, taskId: '', status: 'needs_input', message: 'workflow request requires taskId' };
+    }
+
+    if (request.dryRun) {
+      return {
+        ...base,
+        status: 'ok',
+        message: 'dry-run workflow accepted',
+        data: {
+          dryRun: true,
+          acceptedInputs: publicInputs(request),
+        },
+      };
+    }
+
+    if (request.workflowId === 'import-media') {
+      return importMediaWorkflow(request, deps);
+    }
+    if (request.workflowId === 'ocr-index') {
+      return ocrIndexWorkflow(request, deps);
+    }
+    if (request.workflowId === 'summarize') {
+      return summarizeWorkflow(request, deps);
+    }
+
+    return {
+      ...base,
+      status: 'unsupported',
+      message: `Unsupported workflow: ${request.workflowId}`,
+    };
+  } catch (error) {
+    return {
+      ...base,
+      status: 'failed',
+      message: error instanceof Error ? error.message : String(error),
+    };
+  }
+}
+
+export function useAgentWorkflowBridge() {
+  useEffect(() => {
+    let unlisten: UnlistenFn | undefined;
+    void listen<AgentWorkflowRequest>(WORKFLOW_EVENT, async (event) => {
+      const request = event.payload;
+      const result = await runAgentWorkflow(request);
+      if (!request?.taskId) return;
+      await invoke(COMPLETE_COMMAND, {
+        taskId: request.taskId,
+        result,
+      }).catch(() => undefined);
+    }).then((dispose) => {
+      unlisten = dispose;
+    }).catch(() => undefined);
+
+    return () => {
+      unlisten?.();
+    };
+  }, []);
+}
+
+async function importMediaWorkflow(
+  request: AgentWorkflowRequest,
+  deps: WorkflowDeps,
+): Promise<AgentWorkflowResult> {
+  const base = { workflowId: request.workflowId, taskId: request.taskId };
+  if (!request.lectureId) {
+    return { ...base, status: 'needs_input', message: 'import-media requires --lecture-id' };
+  }
+  if (!request.file) {
+    return { ...base, status: 'needs_input', message: 'import-media requires --file' };
+  }
+
+  await deps.progress(request.taskId, 'Importing media', { stage: 'starting' });
+  const result = await deps.importVideo(request.lectureId, request.file, {
+    language: request.language === 'auto' ? 'auto' : request.language ?? undefined,
+    onProgress: (progress) => {
+      void deps.progress(request.taskId, progress.message, importProgressPayload(progress));
+    },
+  });
+
+  return {
+    ...base,
+    status: 'ok',
+    message: 'media import completed',
+    data: result,
+    artifacts: [{ type: 'media', path: result.videoPath }],
+  };
+}
+
+async function ocrIndexWorkflow(
+  request: AgentWorkflowRequest,
+  deps: WorkflowDeps,
+): Promise<AgentWorkflowResult> {
+  const base = { workflowId: request.workflowId, taskId: request.taskId };
+  if (!request.lectureId) {
+    return { ...base, status: 'needs_input', message: 'ocr-index requires --lecture-id' };
+  }
+
+  await deps.progress(request.taskId, 'Preparing OCR index input', {
+    pdfPath: request.pdfPath ?? null,
+  });
+  const pdfData = request.pdfPath ? await deps.readBinaryFile(request.pdfPath) : null;
+  const transcriptText = request.transcriptText ?? await transcriptForLecture(request.lectureId, deps);
+  const result = await deps.indexLectureWithOCR(
+    request.lectureId,
+    pdfData,
+    transcriptText,
+    (progress) => {
+      void deps.progress(request.taskId, progress.message, {
+        stage: progress.stage,
+        current: progress.current,
+        total: progress.total,
+      });
+    },
+    Boolean(request.forceRefresh),
+  );
+
+  return {
+    ...base,
+    status: result.success ? 'ok' : 'failed',
+    message: result.success ? 'OCR index completed' : 'OCR index failed',
+    data: result,
+  };
+}
+
+async function summarizeWorkflow(
+  request: AgentWorkflowRequest,
+  deps: WorkflowDeps,
+): Promise<AgentWorkflowResult> {
+  const base = { workflowId: request.workflowId, taskId: request.taskId };
+  const language = request.language === 'en' ? 'en' : 'zh';
+  const content = request.content ?? (
+    request.lectureId ? await transcriptOrNoteText(request.lectureId, deps) : ''
+  );
+
+  if (!content.trim()) {
+    return {
+      ...base,
+      status: 'needs_input',
+      message: 'summarize requires --content or a lecture with subtitles/notes',
+    };
+  }
+
+  const title = request.title ?? (request.lectureId ? (await deps.getLecture(request.lectureId))?.title : undefined);
+  await deps.progress(request.taskId, 'Generating summary', {
+    contentChars: content.length,
+    language,
+  });
+
+  let summary = '';
+  for await (const event of deps.summarizeStream({
+    content,
+    language,
+    title: title ?? undefined,
+  })) {
+    if (event.phase === 'reduce-delta' && event.delta) {
+      summary += event.delta;
+    }
+    if (event.phase === 'done') {
+      summary = event.fullText ?? summary;
+    }
+    await deps.progress(request.taskId, `summary ${event.phase}`, {
+      phase: event.phase,
+      sectionCount: event.sectionCount,
+      sectionIndex: event.sectionIndex,
+      summaryChars: summary.length,
+    });
+  }
+
+  if (request.lectureId && request.writeNote !== false) {
+    const existing = await deps.getNote(request.lectureId);
+    const note: Note = existing ?? {
+      lecture_id: request.lectureId,
+      title: title ?? 'Lecture Summary',
+      sections: [],
+      qa_records: [],
+      generated_at: new Date().toISOString(),
+    };
+    await deps.saveNote({
+      ...note,
+      summary,
+      generated_at: new Date().toISOString(),
+    });
+  }
+
+  return {
+    ...base,
+    status: 'ok',
+    message: 'summary completed',
+    data: {
+      summary,
+      summaryChars: summary.length,
+      wroteNote: Boolean(request.lectureId && request.writeNote !== false),
+    },
+  };
+}
+
+async function transcriptOrNoteText(lectureId: string, deps: WorkflowDeps): Promise<string> {
+  const transcript = await transcriptForLecture(lectureId, deps);
+  if (transcript.trim()) return transcript;
+
+  const note = await deps.getNote(lectureId);
+  return note?.sections.map((section) => section.content).join('\n\n') ?? '';
+}
+
+async function transcriptForLecture(lectureId: string, deps: WorkflowDeps): Promise<string> {
+  const subtitles = await deps.getSubtitles(lectureId);
+  return subtitlesToText(subtitles);
+}
+
+function subtitlesToText(subtitles: Subtitle[]): string {
+  return subtitles
+    .slice()
+    .sort((a, b) => a.timestamp - b.timestamp)
+    .map((subtitle) => subtitle.text_en || subtitle.text_zh || '')
+    .filter((text) => text.trim().length > 0)
+    .join('\n');
+}
+
+async function emitWorkflowProgress(
+  taskId: string,
+  message: string,
+  payload: Record<string, unknown> = {},
+): Promise<void> {
+  await invoke(PROGRESS_COMMAND, {
+    taskId,
+    message,
+    payload,
+  }).catch(() => undefined);
+}
+
+function importProgressPayload(progress: ImportProgress): Record<string, unknown> {
+  return {
+    stage: progress.stage,
+    videoPath: progress.videoPath,
+    transcribed: progress.transcribed,
+    translated: progress.translated,
+    total: progress.total,
+    subtitlesChanged: progress.subtitlesChanged,
+  };
+}
+
+function publicInputs(request: AgentWorkflowRequest): Record<string, unknown> {
+  return {
+    file: request.file ?? null,
+    lectureId: request.lectureId ?? null,
+    pdfPath: request.pdfPath ?? null,
+    hasTranscriptText: Boolean(request.transcriptText),
+    hasContent: Boolean(request.content),
+    language: request.language ?? null,
+    forceRefresh: Boolean(request.forceRefresh),
+    writeNote: request.writeNote ?? null,
+  };
+}

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ npm install
 npm run tauri:dev
 ```
 
+The app workspace also includes an opt-in agent CLI for local debugging, smoke checks, and high-level workflow validation.
+
 ## License
 
 [MIT License](LICENSE)


### PR DESCRIPTION
## Summary
- dispatch `import-media`, `ocr-index`, and `summarize` bridge workflows into the renderer app instead of returning unsupported
- add renderer workflow handlers that reuse existing media import, OCR indexing, and summary services, with dry-run support for deterministic agent smoke checks
- expand `cnai-agent workflow` arguments, task/event correlation, and README coverage for the agent workflow path

## Verification
- `npx vitest run src/services/__tests__/agentWorkflowService.test.ts evals/scripts/__tests__/cnai-agent.test.ts`
- `npm exec tsc -- --noEmit`
- `cargo test --lib agent_bridge`
- `npx vitest run`
- `npm run build`
- `cargo check --lib`
- live Tauri smoke: `workflow import-media --dry-run` returned `status: ok`; `/tasks` and `/events` showed `workflow.import-media` started/completed

Part of #112. Stacked on #147.