### PR TITLE
Expose shared AI readiness to agent bridge

### DIFF
--- a/ClassNoteAI/README.md
+++ b/ClassNoteAI/README.md
@@ -86,6 +86,8 @@ npm run agent:smoke:app -- --dry-run
 
 When you need a real desktop smoke, run the same profile with `--launch-app`; it starts the app with the local bridge enabled, checks status/logs/events/UI/workflow paths, then stops the app it launched.
 
+For workflow debugging, `app ai-status` reports whether the running app has a configured AI provider for text or vision tasks without exposing credentials.
+
 Rust checks live under `src-tauri`:
 
 ```bash

--- a/ClassNoteAI/evals/scripts/__tests__/cnai-agent.test.ts
+++ b/ClassNoteAI/evals/scripts/__tests__/cnai-agent.test.ts
@@ -77,6 +77,7 @@ describe('cnai-agent CLI', () => {
         'app.launch',
         'app.attach',
         'app.status',
+        'app.ai-status',
         'events.watch',
         'logs.tail',
         'diag.bundle',
@@ -467,5 +468,53 @@ describe('cnai-agent CLI', () => {
     expect(result.status).toBe(0);
     expect(payload.type).toBe('tasks_list');
     expect(payload.body.tasks[0].id).toBe('task-1');
+  });
+
+  it('reads bridge AI readiness through the CLI', async () => {
+    const server = createServer((req, res) => {
+      expect(req.url).toBe('/v1/config/ai');
+      res.setHeader('content-type', 'application/json');
+      res.end(
+        JSON.stringify({
+          schemaVersion: 1,
+          type: 'ai_config',
+          status: 'ok',
+          state: { readyForText: true, activeProviderId: 'github-models' },
+        }),
+      );
+    });
+    await new Promise<void>((resolveListen) => server.listen(0, '127.0.0.1', resolveListen));
+    const address = server.address();
+    if (!address || typeof address === 'string') {
+      throw new Error('server did not bind to a TCP port');
+    }
+    const tempDir = mkdtempSync(resolve(tmpdir(), 'cnai-agent-test-'));
+    const attachFile = resolve(tempDir, 'agent-bridge.json');
+    writeFileSync(
+      attachFile,
+      JSON.stringify({
+        schemaVersion: 1,
+        apiVersion: 1,
+        url: `http://127.0.0.1:${address.port}`,
+        token: 'test-token',
+        pid: 123,
+      }),
+    );
+
+    const result = await runCliAsync([
+      'app',
+      'ai-status',
+      '--json',
+      '--attach-file',
+      attachFile,
+      '--timeout-ms',
+      '2000',
+    ]);
+    server.close();
+
+    const payload = JSON.parse(result.stdout);
+    expect(result.status).toBe(0);
+    expect(payload.type).toBe('app_ai_status');
+    expect(payload.body.state.readyForText).toBe(true);
   });
 });

--- a/ClassNoteAI/scripts/cnai-agent.mjs
+++ b/ClassNoteAI/scripts/cnai-agent.mjs
@@ -83,6 +83,7 @@ Usage:
   node scripts/cnai-agent.mjs app attach [--json] [--attach-file PATH]
   node scripts/cnai-agent.mjs app handshake [--json] [--bridge-url URL] [--token TOKEN]
   node scripts/cnai-agent.mjs app status [--json] [--bridge-url URL] [--token TOKEN]
+  node scripts/cnai-agent.mjs app ai-status [--json] [--bridge-url URL] [--token TOKEN]
   node scripts/cnai-agent.mjs events watch [--ndjson] [--follow] [--max-events N] [--bridge-url URL] [--token TOKEN]
   node scripts/cnai-agent.mjs tasks list [--json] [--bridge-url URL] [--token TOKEN]
   node scripts/cnai-agent.mjs logs tail [--json] [--follow] [--bridge-url URL] [--token TOKEN]
@@ -107,6 +108,7 @@ Commands:
   app attach      Read the app bridge attach file.
   app handshake   Ask a running app bridge for its versioned contract.
   app status      Ask a running app bridge for app/session health.
+  app ai-status   Ask a running app bridge for AI provider readiness.
   events watch    Stream app bridge events as NDJSON.
   tasks list      List bridge task lifecycle records.
   logs tail       Read or follow app bridge logs.
@@ -300,6 +302,11 @@ function handshakePayload() {
         id: 'app.status',
         stability: 'experimental',
         description: 'Inspect a running app bridge state.',
+      },
+      {
+        id: 'app.ai-status',
+        stability: 'experimental',
+        description: 'Inspect AI provider readiness reported by the app bridge.',
       },
       {
         id: 'app.launch',
@@ -764,6 +771,7 @@ function appBridgeSmokeStepIds() {
     'raw-command',
     'ui-tree',
     'ui-ready',
+    'ai-config',
     'ui-snapshot',
     'workflow-import-media',
     'tasks',
@@ -944,6 +952,9 @@ async function runAppBridgeCheck(stepId, options) {
   if (stepId === 'ui-ready') {
     return waitForRendererUi(options);
   }
+  if (stepId === 'ai-config') {
+    return waitForAiConfig(options);
+  }
 
   const check = checks[stepId];
   if (!check) {
@@ -960,6 +971,27 @@ async function runAppBridgeCheck(stepId, options) {
     message: `${stepId} passed`,
     data: summarizeSmokePayload(payload),
   };
+}
+
+async function waitForAiConfig(options) {
+  const deadline = Date.now() + (options.timeoutMs ?? 30_000);
+  let lastStatus = null;
+  while (Date.now() <= deadline) {
+    const { code, payload } = await requestBridgeJson('app_ai_status', {
+      ...options,
+      timeoutMs: Math.min(options.timeoutMs ?? 5000, 5000),
+    }, '/v1/config/ai');
+    lastStatus = payload.body?.status ?? null;
+    if (code === 0 && lastStatus === 'ok') {
+      return {
+        status: 'passed',
+        message: 'AI provider state registered',
+        data: summarizeSmokePayload(payload),
+      };
+    }
+    await sleep(250);
+  }
+  throw new Error(`AI provider state did not register before timeout; last status: ${lastStatus ?? 'unknown'}`);
 }
 
 async function waitForRendererUi(options) {
@@ -1252,6 +1284,16 @@ async function handleAppCommand(options) {
       'app_status',
       options,
       '/v1/status',
+    );
+    printPayload(payload, options.format);
+    return code;
+  }
+
+  if (subcommand === 'ai-status') {
+    const { code, payload } = await requestBridgeJson(
+      'app_ai_status',
+      options,
+      '/v1/config/ai',
     );
     printPayload(payload, options.format);
     return code;

--- a/ClassNoteAI/src-tauri/src/agent_bridge.rs
+++ b/ClassNoteAI/src-tauri/src/agent_bridge.rs
@@ -67,6 +67,7 @@ struct BridgeState {
     next_event_id: Mutex<u64>,
     tasks: Mutex<HashMap<String, BridgeTask>>,
     ui_state: Mutex<Option<Value>>,
+    ai_state: Mutex<Option<Value>>,
     pending_ui_actions: Mutex<HashMap<String, oneshot::Sender<Value>>>,
     pending_workflows: Mutex<HashMap<String, oneshot::Sender<Value>>>,
 }
@@ -145,6 +146,7 @@ async fn run_server(app: AppHandle, requested_port: u16, token: String) -> Resul
         next_event_id: Mutex::new(1),
         tasks: Mutex::new(HashMap::new()),
         ui_state: Mutex::new(None),
+        ai_state: Mutex::new(None),
         pending_ui_actions: Mutex::new(HashMap::new()),
         pending_workflows: Mutex::new(HashMap::new()),
     });
@@ -275,6 +277,16 @@ pub async fn agent_bridge_update_ui_state(state: Value) -> Result<(), String> {
         return Ok(());
     };
     let mut slot = bridge_state.ui_state.lock().await;
+    *slot = Some(state);
+    Ok(())
+}
+
+#[tauri::command]
+pub async fn agent_bridge_update_ai_state(state: Value) -> Result<(), String> {
+    let Some(bridge_state) = BRIDGE_STATE.get() else {
+        return Ok(());
+    };
+    let mut slot = bridge_state.ai_state.lock().await;
     *slot = Some(state);
     Ok(())
 }
@@ -452,6 +464,7 @@ async fn route_request(request: HttpRequest, state: Arc<BridgeState>) -> Vec<u8>
         ("GET", "/v1/logs") => json_response(200, logs_payload(&state, &request).await),
         ("GET", "/v1/events") => events_response(&state).await,
         ("GET", "/v1/tasks") => json_response(200, tasks_payload(&state).await),
+        ("GET", "/v1/config/ai") => json_response(200, ai_config_payload(&state).await),
         ("POST", "/v1/diag/bundle") => diag_bundle_response(&state).await,
         ("GET", "/v1/workflows") => json_response(200, workflow_payload()),
         ("POST", "/v1/call/raw") => raw_command_response(&state, &request).await,
@@ -504,6 +517,7 @@ fn handshake_payload(state: &BridgeState) -> Value {
             {"id": "events.watch", "stability": "experimental"},
             {"id": "events.follow", "stability": "experimental"},
             {"id": "tasks.list", "stability": "experimental"},
+            {"id": "config.ai", "stability": "experimental"},
             {"id": "diag.bundle", "stability": "experimental"},
             {"id": "workflow.list", "stability": "experimental"},
             {"id": "call.raw", "stability": "planned"},
@@ -526,6 +540,7 @@ fn handshake_payload(state: &BridgeState) -> Value {
 async fn status_payload(state: &Arc<BridgeState>) -> Value {
     let events = state.events.lock().await;
     let tasks = state.tasks.lock().await;
+    let ai_state = state.ai_state.lock().await.clone();
     let window_count = state.app.webview_windows().len();
     let log_dir = state
         .app
@@ -556,6 +571,24 @@ async fn status_payload(state: &Arc<BridgeState>) -> Value {
             "eventCount": events.len(),
             "taskCount": tasks.len(),
             "runningTaskCount": tasks.values().filter(|task| task.status == "running").count(),
+        },
+        "ai": {
+            "registered": ai_state.is_some(),
+            "readyForText": ai_state
+                .as_ref()
+                .and_then(|state| state.get("readyForText"))
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+            "readyForVision": ai_state
+                .as_ref()
+                .and_then(|state| state.get("readyForVision"))
+                .and_then(Value::as_bool)
+                .unwrap_or(false),
+            "activeProviderId": ai_state
+                .as_ref()
+                .and_then(|state| state.get("activeProviderId"))
+                .cloned()
+                .unwrap_or_else(|| json!(null)),
         },
         "paths": {
             "appDataDir": app_data_dir,
@@ -1094,6 +1127,27 @@ async fn ui_snapshot_payload(state: &Arc<BridgeState>) -> Value {
         "source": "tauri-window-inventory",
         "note": "Renderer DOM state has not registered yet; pixel capture is reserved for a later bridge phase.",
         "state": ui_tree_payload(state).await,
+    })
+}
+
+async fn ai_config_payload(state: &Arc<BridgeState>) -> Value {
+    if let Some(renderer_state) = state.ai_state.lock().await.clone() {
+        return json!({
+            "schemaVersion": 1,
+            "type": "ai_config",
+            "status": "ok",
+            "source": "renderer-llm",
+            "state": renderer_state,
+        });
+    }
+
+    json!({
+        "schemaVersion": 1,
+        "type": "ai_config",
+        "status": "unavailable",
+        "source": "bridge",
+        "message": "Renderer AI provider state has not registered yet.",
+        "state": null,
     })
 }
 

--- a/ClassNoteAI/src-tauri/src/lib.rs
+++ b/ClassNoteAI/src-tauri/src/lib.rs
@@ -2778,6 +2778,7 @@ pub fn run() {
             open_devtools,
             close_devtools,
             agent_bridge::agent_bridge_update_ui_state,
+            agent_bridge::agent_bridge_update_ai_state,
             agent_bridge::agent_bridge_complete_ui_action,
             agent_bridge::agent_bridge_workflow_progress,
             agent_bridge::agent_bridge_complete_workflow,

--- a/ClassNoteAI/src/App.tsx
+++ b/ClassNoteAI/src/App.tsx
@@ -15,6 +15,7 @@ import { toastService } from "./services/toastService";
 import { buildInterruptedRecordingNotice } from "./services/recordingInterruptionNotice";
 import { audioDeviceService } from "./services/audioDeviceService";
 import { useAgentAutomationBridge } from "./services/agentAutomationService";
+import { useAgentAiStateBridge } from "./services/agentAiStateService";
 import { useAgentWorkflowBridge } from "./services/agentWorkflowService";
 import { useAuth } from "./contexts/AuthContext";
 
@@ -25,6 +26,7 @@ function App() {
   const [recoverableSessions, setRecoverableSessions] = useState<RecoverableSession[]>([]);
   const { user } = useAuth();
   useAgentAutomationBridge();
+  useAgentAiStateBridge();
   useAgentWorkflowBridge();
 
   // Detached AI 助教 webview: spawned by openDetachedAiTutor with the

--- a/ClassNoteAI/src/services/__tests__/agentAiStateService.test.ts
+++ b/ClassNoteAI/src/services/__tests__/agentAiStateService.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it, vi } from 'vitest';
+
+const githubProvider = {
+  descriptor: { id: 'github-models' },
+  isConfigured: vi.fn(async () => true),
+  listModels: vi.fn(async () => [
+    { id: 'text-model', displayName: 'Text', capabilities: { streaming: true } },
+  ]),
+};
+const chatgptProvider = {
+  descriptor: { id: 'chatgpt-oauth' },
+  isConfigured: vi.fn(async () => false),
+  listModels: vi.fn(async () => []),
+};
+
+vi.mock('../llm', () => ({
+  listProviders: vi.fn(() => [
+    { id: 'github-models', displayName: 'GitHub Models', authType: 'pat' },
+    { id: 'chatgpt-oauth', displayName: 'ChatGPT', authType: 'oauth' },
+  ]),
+  getProvider: vi.fn((id: string) => (id === 'github-models' ? githubProvider : chatgptProvider)),
+  readPreferredProviderId: vi.fn(async () => 'github-models'),
+  resolveActiveProvider: vi.fn(async () => githubProvider),
+}));
+
+import { collectAgentAiState } from '../agentAiStateService';
+
+describe('agentAiStateService', () => {
+  it('reports provider readiness without exposing credentials', async () => {
+    const state = await collectAgentAiState();
+
+    expect(state.type).toBe('ai_config');
+    expect(state.defaultProviderId).toBe('github-models');
+    expect(state.activeProviderId).toBe('github-models');
+    expect(state.readyForText).toBe(true);
+    expect(state.readyForVision).toBe(false);
+    expect(state.providers).toEqual([
+      { id: 'github-models', name: 'GitHub Models', authType: 'pat', configured: true },
+      { id: 'chatgpt-oauth', name: 'ChatGPT', authType: 'oauth', configured: false },
+    ]);
+    expect(JSON.stringify(state)).not.toContain('token');
+  });
+});

--- a/ClassNoteAI/src/services/agentAiStateService.ts
+++ b/ClassNoteAI/src/services/agentAiStateService.ts
@@ -1,0 +1,95 @@
+import { invoke } from '@tauri-apps/api/core';
+import { useEffect } from 'react';
+
+import {
+  getProvider,
+  listProviders,
+  readPreferredProviderId,
+  resolveActiveProvider,
+} from './llm';
+
+const UPDATE_COMMAND = 'agent_bridge_update_ai_state';
+
+export type AgentAiProviderState = {
+  id: string;
+  name: string;
+  authType: string;
+  configured: boolean;
+};
+
+export type AgentAiState = {
+  schemaVersion: 1;
+  type: 'ai_config';
+  source: 'renderer-llm';
+  capturedAt: string;
+  defaultProviderId: string | null;
+  activeProviderId: string | null;
+  readyForText: boolean;
+  readyForVision: boolean;
+  providers: AgentAiProviderState[];
+};
+
+export async function collectAgentAiState(): Promise<AgentAiState> {
+  const defaultProviderId = await readPreferredProviderId();
+  const providers = await Promise.all(
+    listProviders().map(async (descriptor) => {
+      let configured = false;
+      try {
+        configured = await getProvider(descriptor.id).isConfigured();
+      } catch {
+        configured = false;
+      }
+      return {
+        id: descriptor.id,
+        name: descriptor.displayName,
+        authType: descriptor.authType,
+        configured,
+      };
+    }),
+  );
+
+  const activeProvider = await resolveActiveProvider(defaultProviderId).catch(() => null);
+  const models = activeProvider ? await activeProvider.listModels().catch(() => []) : [];
+
+  return {
+    schemaVersion: 1,
+    type: 'ai_config',
+    source: 'renderer-llm',
+    capturedAt: new Date().toISOString(),
+    defaultProviderId: defaultProviderId ?? null,
+    activeProviderId: activeProvider?.descriptor.id ?? null,
+    readyForText: Boolean(activeProvider),
+    readyForVision: models.some((model) => model.capabilities?.vision),
+    providers,
+  };
+}
+
+export function useAgentAiStateBridge() {
+  useEffect(() => {
+    let disposed = false;
+    let timer: number | undefined;
+
+    const publish = () => {
+      window.clearTimeout(timer);
+      timer = window.setTimeout(() => {
+        if (disposed) return;
+        void collectAgentAiState()
+          .then((state) => invoke(UPDATE_COMMAND, { state }))
+          .catch(() => undefined);
+      }, 100);
+    };
+
+    publish();
+    const interval = window.setInterval(publish, 10_000);
+    window.addEventListener('storage', publish);
+    window.addEventListener('focus', publish);
+
+    return () => {
+      disposed = true;
+      window.clearTimeout(timer);
+      window.clearInterval(interval);
+      window.removeEventListener('storage', publish);
+      window.removeEventListener('focus', publish);
+    };
+  }, []);
+}

--- a/ClassNoteAI/src/services/llm/index.ts
+++ b/ClassNoteAI/src/services/llm/index.ts
@@ -2,6 +2,12 @@ export * from './types';
 export { keyStore } from './keyStore';
 export { listProviders, getProvider, resolveActiveProvider } from './registry';
 export {
+  DEFAULT_PROVIDER_KEY,
+  readPreferredProviderId,
+  readPreferredProviderFromLocalStorage,
+  writePreferredProviderId,
+} from './providerState';
+export {
   summarize,
   summarizeStream,
   chunkForSummarization,

--- a/ClassNoteAI/src/services/llm/providerState.ts
+++ b/ClassNoteAI/src/services/llm/providerState.ts
@@ -1,0 +1,35 @@
+import { storageService } from '../storageService';
+
+export const DEFAULT_PROVIDER_KEY = 'llm.defaultProvider';
+
+export function readPreferredProviderFromLocalStorage(): string | undefined {
+  if (typeof localStorage === 'undefined') return undefined;
+  return localStorage.getItem(DEFAULT_PROVIDER_KEY) || undefined;
+}
+
+export async function readPreferredProviderId(): Promise<string | undefined> {
+  const shared = await storageService.getSetting(DEFAULT_PROVIDER_KEY).catch(() => null);
+  if (shared) return shared;
+
+  const legacy = readPreferredProviderFromLocalStorage();
+  if (legacy) {
+    await storageService.saveSetting(DEFAULT_PROVIDER_KEY, legacy).catch(() => undefined);
+  }
+  return legacy;
+}
+
+export async function writePreferredProviderId(providerId: string | null): Promise<void> {
+  if (typeof localStorage !== 'undefined') {
+    if (providerId) {
+      localStorage.setItem(DEFAULT_PROVIDER_KEY, providerId);
+    } else {
+      localStorage.removeItem(DEFAULT_PROVIDER_KEY);
+    }
+  }
+
+  if (providerId) {
+    await storageService.saveSetting(DEFAULT_PROVIDER_KEY, providerId);
+  } else {
+    await storageService.saveSetting(DEFAULT_PROVIDER_KEY, '');
+  }
+}

--- a/ClassNoteAI/src/services/llm/tasks.ts
+++ b/ClassNoteAI/src/services/llm/tasks.ts
@@ -9,6 +9,7 @@
  */
 
 import { resolveActiveProvider } from './registry';
+import { readPreferredProviderId } from './providerState';
 import type { LLMMessage } from './types';
 import { LLMError } from './types';
 import { usageTracker, type UsageTask } from './usageTracker';
@@ -36,12 +37,6 @@ function trackUsage(
     outputTokens: usage.outputTokens ?? 0,
     segments,
   });
-}
-
-const DEFAULT_PROVIDER_KEY = 'llm.defaultProvider';
-
-function preferredProvider(): string | undefined {
-  return localStorage.getItem(DEFAULT_PROVIDER_KEY) || undefined;
 }
 
 /**
@@ -97,7 +92,7 @@ function pickModelForTier(models: { id: string }[], tier: ModelTier): string {
 async function activeProviderAndModel(
   tier: ModelTier = 'high',
 ): Promise<{ providerId: string; model: string; provider: Awaited<ReturnType<typeof resolveActiveProvider>> }> {
-  const provider = await resolveActiveProvider(preferredProvider());
+  const provider = await resolveActiveProvider(await readPreferredProviderId());
   if (!provider) {
     throw new LLMError(
       'No AI provider configured. Open Settings → AI 增強 to set one up.',


### PR DESCRIPTION
## Summary
- mirror the preferred LLM provider into shared app settings instead of reading only webview localStorage
- publish a renderer AI readiness snapshot to the bridge without exposing credentials
- expose `/v1/config/ai`, `app ai-status`, and app-bridge smoke coverage for AI provider readiness

## Verification
- `npx vitest run src/services/__tests__/agentAiStateService.test.ts evals/scripts/__tests__/cnai-agent.test.ts`
- `npm exec tsc -- --noEmit`
- `cargo test --lib agent_bridge`
- live desktop smoke: `node scripts/cnai-agent.mjs smoke --profile app-bridge --launch-app --json --attach-file <temp> --timeout-ms 180000`
- `npx vitest run`
- `npm run build`
- `cargo check --lib`

Part of #112. Stacked on #149.