### PR TITLE
fix: timeout hung recording stop finalization

### DIFF
--- a/ClassNoteAI/src/services/__tests__/recordingSessionService.test.ts
+++ b/ClassNoteAI/src/services/__tests__/recordingSessionService.test.ts
@@ -22,6 +22,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { recordingSessionService } from '../recordingSessionService';
+import { transcriptionService } from '../transcriptionService';
 import {
     RECORDING_CHANGE_EVENT,
     type RecordingChangeDetail,
@@ -302,6 +303,22 @@ describe('recordingSessionService — state machine', () => {
         expect(recordingSessionService.getState().error).toMatch(
             /subtitles save failed/i,
         );
+    });
+
+    it('stop() times out a hung final ASR drain and still completes', async () => {
+        vi.useFakeTimers();
+        vi.mocked(transcriptionService.stop).mockImplementationOnce(
+            () => new Promise<void>(() => undefined),
+        );
+
+        await recordingSessionService.start('c', 'l');
+        const stopPromise = recordingSessionService.stop();
+
+        await vi.advanceTimersByTimeAsync(10_000);
+        await stopPromise;
+
+        expect(recordingSessionService.getState().status).toBe('stopped');
+        expect(recordingSessionService.getState().stopPhase).toBe('done');
     });
 });
 

--- a/ClassNoteAI/src/services/recordingSessionService.ts
+++ b/ClassNoteAI/src/services/recordingSessionService.ts
@@ -103,6 +103,34 @@ const VISIBILITY_SLEEP_THRESHOLD_MS = 30_000;
  *  smooth for the running clock without blowing CPU. */
 const ELAPSED_TICK_MS = 250;
 
+/**
+ * #177 regression guard: final ASR / translation drain must never keep the
+ * stop pipeline pending forever. Native sidecars and local LLM translators can
+ * hang; stop() should preserve already-committed data and continue to segment /
+ * save instead of trapping the user on "processing final transcription".
+ */
+const STOP_FINALIZE_STEP_TIMEOUT_MS = 10_000;
+
+async function withStopTimeout<T>(
+    promise: Promise<T>,
+    label: string,
+    timeoutMs = STOP_FINALIZE_STEP_TIMEOUT_MS,
+): Promise<T> {
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    try {
+        return await Promise.race([
+            promise,
+            new Promise<never>((_, reject) => {
+                timer = setTimeout(() => {
+                    reject(new Error(`${label} timed out after ${timeoutMs}ms`));
+                }, timeoutMs);
+            }),
+        ]);
+    } finally {
+        if (timer) clearTimeout(timer);
+    }
+}
+
 class RecordingSessionServiceImpl implements RecordingSessionService {
     private state: RecordingSessionState = { ...INITIAL_STATE, segments: [] };
     private subscribers = new Set<(s: RecordingSessionState) => void>();
@@ -500,7 +528,10 @@ class RecordingSessionServiceImpl implements RecordingSessionService {
         // everything that was already committed by step-2 onward.
         // ──────────────────────────────────────────────────────────────
         try {
-            await transcriptionService.stop();
+            await withStopTimeout(
+                transcriptionService.stop(),
+                'transcriptionService.stop',
+            );
         } catch (err) {
             console.error(
                 '[recordingSession.stop] step 1 (transcribe) failed:',
@@ -509,7 +540,10 @@ class RecordingSessionServiceImpl implements RecordingSessionService {
             // not fatal — keep going
         }
         try {
-            await translationPipeline.awaitDrain();
+            await withStopTimeout(
+                translationPipeline.awaitDrain(),
+                'translationPipeline.awaitDrain',
+            );
         } catch (err) {
             console.error(
                 '[recordingSession.stop] step 1 (translation drain) failed:',
@@ -1350,7 +1384,10 @@ class RecordingSessionServiceImpl implements RecordingSessionService {
         try {
             // 1. ASR drain
             try {
-                await transcriptionService.stop();
+                await withStopTimeout(
+                    transcriptionService.stop(),
+                    'mustFinalizeSync transcriptionService.stop',
+                );
             } catch (err) {
                 console.warn('[recordingSessionService] mustFinalizeSync: stop ASR failed:', err);
             }


### PR DESCRIPTION
## Summary

Fixes #177 by preventing the recording stop pipeline from waiting forever when final ASR or translation drain hangs.

- Add a 10s timeout guard around final ASR drain and translation drain during `recordingSessionService.stop()`.
- Apply the same timeout guard to the app-close `mustFinalizeSync()` ASR drain path.
- Add a regression test where `transcriptionService.stop()` never resolves; `stop()` still advances to `stopped` / `done`.

## Verification

- `npm test -- --run src/services/__tests__/recordingSessionService.test.ts -t 'hung final ASR drain'`
- `npm test -- --run src/services/__tests__/recordingSessionService.test.ts`
- `npm run build`

## Notes

The timeout is intentionally non-fatal: stop finalization preserves already-committed data and continues to segment/save instead of trapping the user on the final transcription processing state.
