### PR TITLE
chore: pause Dependabot version update PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,7 +20,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 5
+    open-pull-requests-limit: 0  # paused by Reina per maintainer request
     groups:
       patch-updates:
         patterns: ["*"]
@@ -35,7 +35,7 @@ updates:
     schedule:
       interval: "weekly"
       day: "monday"
-    open-pull-requests-limit: 3
+    open-pull-requests-limit: 0  # paused by Reina per maintainer request
     ignore:
       # Vendor-patched or heavy native-build crates — manual bump only.
       # These fail in Dependabot's sandbox (no LLVM/MSVC/CUDA toolchain)


### PR DESCRIPTION
## Summary
- Pause Dependabot version-update PR creation by setting both configured ecosystems to `open-pull-requests-limit: 0`.
- Keeps existing security advisory behavior documented in the file unchanged.

## Verification
- Reviewed `.github/dependabot.yml` diff: only npm/cargo open PR limits changed from 5/3 to 0.

Requested by maintainer to stop dependency bot noise.