### PR TITLE
fix(review): avoid transcript collapse with shifted timestamps

### DIFF
--- a/ClassNoteAI/src/components/h18/__tests__/H18ReviewPage.paragraphGrouping.test.tsx
+++ b/ClassNoteAI/src/components/h18/__tests__/H18ReviewPage.paragraphGrouping.test.tsx
@@ -101,6 +101,55 @@ describe('groupSubsBySections · cp75.28', () => {
         expect(paras[0].items).toHaveLength(3);
     });
 
+    it('does not collapse everything into the final section when subtitle timestamps share a constant positive offset', () => {
+        // Regression for #169: Review could show a correct 13-item TOC while
+        // the transcript rendered as one giant paragraph under the last
+        // section. The failure shape is the mirror image of the cp75.28 all-0
+        // timestamps bug: section breakpoints are distinct, but every subtitle
+        // timestamp is shifted past the final section timestamp.
+        const subs: Subtitle[] = [
+            {
+                id: '1',
+                lecture_id: 'L',
+                timestamp: 300,
+                text_en: 'intro',
+                type: 'rough',
+                created_at: '',
+            },
+            {
+                id: '2',
+                lecture_id: 'L',
+                timestamp: 360,
+                text_en: 'middle',
+                type: 'rough',
+                created_at: '',
+            },
+            {
+                id: '3',
+                lecture_id: 'L',
+                timestamp: 420,
+                text_en: 'end',
+                type: 'rough',
+                created_at: '',
+            },
+        ];
+        const sections: Section[] = [
+            { title: 'A', content: '', timestamp: 0 },
+            { title: 'B', content: '', timestamp: 60 },
+            { title: 'C', content: '', timestamp: 120 },
+        ];
+
+        const paras = groupSubsBySections(subs, sections);
+
+        expect(paras).toHaveLength(3);
+        expect(paras.map((p) => p.section?.title)).toEqual(['A', 'B', 'C']);
+        expect(paras.map((p) => p.items.map((s) => s.id))).toEqual([
+            ['1'],
+            ['2'],
+            ['3'],
+        ]);
+    });
+
     it('returns single pre-section bucket when sections is empty', () => {
         const subs: Subtitle[] = [
             {

--- a/ClassNoteAI/src/components/h18/groupSubsBySections.ts
+++ b/ClassNoteAI/src/components/h18/groupSubsBySections.ts
@@ -49,6 +49,29 @@ export function groupSubsBySections(
     const sortedSections = [...sections].sort(
         (a, b) => a.timestamp - b.timestamp,
     );
+    const firstSectionTs = sortedSections[0]?.timestamp ?? 0;
+    const lastSectionTs =
+        sortedSections[sortedSections.length - 1]?.timestamp ?? firstSectionTs;
+    const distinctSectionTimestamps = new Set(
+        sortedSections.map((s) => s.timestamp),
+    ).size;
+    const firstSubTs = sortedSubs[0]?.timestamp;
+
+    // #169 regression guard: sometimes TOC sections carry the correct
+    // lecture-relative breakpoints (e.g. 00:00, 05:35, ... 66:59), while
+    // every subtitle timestamp is shifted forward by a constant offset and
+    // therefore appears >= the final section timestamp. A naive
+    // latest-section walk then buckets the whole transcript under the last
+    // chapter. When that shape is detected, use an offset-corrected timestamp
+    // only for choosing the bucket; keep the original Subtitle object/time for
+    // rendering and seek behaviour.
+    const groupingOffset =
+        distinctSectionTimestamps > 1 &&
+        firstSubTs !== undefined &&
+        firstSubTs >= lastSectionTs
+            ? firstSubTs - firstSectionTs
+            : 0;
+
     const groups: Para[] = sortedSections.map((sec, i) => ({
         section: sec,
         sectionIndex: i,
@@ -57,9 +80,10 @@ export function groupSubsBySections(
     // pre-section bucket for any subs before the first section's timestamp
     const preSection: Para = { section: null, sectionIndex: -1, items: [] };
     for (const sub of sortedSubs) {
+        const groupingTimestamp = sub.timestamp - groupingOffset;
         let placed = false;
         for (let i = sortedSections.length - 1; i >= 0; i--) {
-            if (sub.timestamp >= sortedSections[i].timestamp) {
+            if (groupingTimestamp >= sortedSections[i].timestamp) {
                 groups[i].items.push(sub);
                 placed = true;
                 break;


### PR DESCRIPTION
## Summary
- Fix #169 by detecting constant positive subtitle timestamp offsets before grouping Review transcript paragraphs
- Preserve original subtitle timestamps for rendering/seek; only use corrected timestamps for bucket selection
- Add regression test for the “all subtitles collapse into final section” shape

Fixes #169

## Verification
- npx vitest run src/components/h18/__tests__/H18ReviewPage.paragraphGrouping.test.tsx src/__tests__/App.close.test.tsx → 12/12 passed
- npx vitest run → 119 files / 1259 tests passed
- npm run build → passed, built in 3.57s
- Tauri app-backed smoke → 13/13 steps passed, launch 49.854s, total 52.427s

## Notes
- #178 close-flow code already exists on main and unit tests pass, but this headless Xvfb environment exposes no mapped Tauri window, so I did not close #178; it still needs real desktop/titlebar close verification.