### PR TITLE
fix: close button lifecycle in H18 (fixes #178)

### DIFF
--- a/ClassNoteAI/src-tauri/capabilities/default.json
+++ b/ClassNoteAI/src-tauri/capabilities/default.json
@@ -16,6 +16,7 @@
     "core:window:allow-inner-size",
     "core:window:allow-scale-factor",
     "core:window:allow-close",
+    "core:window:allow-destroy",
     "core:window:allow-minimize",
     "core:window:allow-toggle-maximize",
     "core:window:allow-start-dragging",

--- a/ClassNoteAI/src/App.tsx
+++ b/ClassNoteAI/src/App.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 
 import H18DeepApp from "./components/h18/H18DeepApp";
 import LoginScreen from "./components/LoginScreen";
@@ -596,6 +596,40 @@ function App() {
     };
   }, [appState, user]);
 
+  // Issue #178 — the custom traffic-light close button does not go through
+  // the OS window manager, so it must explicitly run the same recording-safe
+  // lifecycle as the Tauri close-request listener. For idle state we destroy
+  // the window directly because renderer-initiated `close()` is observable in
+  // Linux app-backed smoke as a no-op while WM_DELETE works.
+  const handleWindowControlClose = useCallback(async () => {
+    if (appState !== 'ready' || !user) return;
+    const win = getCurrentWindow();
+    const state = recordingSessionService.getState();
+    const recording = state.status === 'recording' || state.status === 'paused';
+
+    if (!recording) {
+      await win.destroy();
+      return;
+    }
+
+    await handleCloseRequest(
+      { preventDefault: () => undefined },
+      {
+        recordingSession: {
+          getState: () => recordingSessionService.getState(),
+          mustFinalizeSync: () => recordingSessionService.mustFinalizeSync(),
+        },
+        confirm: { ask: (req) => confirmService.ask(req) },
+        toast: {
+          success: (message, detail) => toastService.success(message, detail),
+          warning: (message, detail) => toastService.warning(message, detail),
+        },
+        win: { close: () => win.destroy() },
+        sleep: (ms) => new Promise((r) => setTimeout(r, ms)),
+      },
+    );
+  }, [appState, user]);
+
   const handleSetupComplete = () => {
     setAppState('ready');
   };
@@ -624,7 +658,7 @@ function App() {
 
   return (
     <ErrorBoundary>
-      <H18DeepApp />
+      <H18DeepApp onRequestClose={handleWindowControlClose} />
       <RecoveryPromptModal
         sessions={recoverableSessions}
         onSessionResolved={(id) =>

--- a/ClassNoteAI/src/components/WindowControls.tsx
+++ b/ClassNoteAI/src/components/WindowControls.tsx
@@ -14,6 +14,7 @@
  *     回饋是否要 hide-on-close
  */
 
+import { getCurrentWindow } from '@tauri-apps/api/window';
 import s from './WindowControls.module.css';
 
 export interface WindowControlsProps {
@@ -23,12 +24,12 @@ export interface WindowControlsProps {
 }
 
 const callTauri = (method: 'close' | 'minimize' | 'toggleMaximize') => {
-  import('@tauri-apps/api/webviewWindow')
-    .then(({ getCurrentWebviewWindow }) => {
-      const win = getCurrentWebviewWindow();
-      return win[method]();
-    })
-    .catch(() => {});
+  try {
+    const win = getCurrentWindow();
+    void win[method]().catch(() => {});
+  } catch {
+    // Window controls are rendered in browser-backed tests too; keep them non-fatal.
+  }
 };
 
 export default function WindowControls({ onClose, onMinimize, onMaximize }: WindowControlsProps) {

--- a/ClassNoteAI/src/components/__tests__/WindowControls.test.tsx
+++ b/ClassNoteAI/src/components/__tests__/WindowControls.test.tsx
@@ -20,8 +20,8 @@ const closeMock = vi.fn(() => Promise.resolve());
 const minimizeMock = vi.fn(() => Promise.resolve());
 const toggleMaximizeMock = vi.fn(() => Promise.resolve());
 
-vi.mock('@tauri-apps/api/webviewWindow', () => ({
-  getCurrentWebviewWindow: () => ({
+vi.mock('@tauri-apps/api/window', () => ({
+  getCurrentWindow: () => ({
     close: closeMock,
     minimize: minimizeMock,
     toggleMaximize: toggleMaximizeMock,
@@ -89,7 +89,7 @@ describe('WindowControls · prop callbacks', () => {
 });
 
 describe('WindowControls · default Tauri behavior', () => {
-  it('calls webviewWindow.close() when no onClose prop supplied', async () => {
+  it('calls window.close() when no onClose prop supplied', async () => {
     const user = userEvent.setup();
     render(<WindowControls />);
     await user.click(screen.getByRole('button', { name: '關閉視窗' }));

--- a/ClassNoteAI/src/components/h18/H18DeepApp.tsx
+++ b/ClassNoteAI/src/components/h18/H18DeepApp.tsx
@@ -70,7 +70,11 @@ import s from './H18DeepApp.module.css';
 
 // (Placeholder helper removed in P6.9 — every nav target now has a real component)
 
-export default function H18DeepApp() {
+export interface H18DeepAppProps {
+    onRequestClose?: () => void;
+}
+
+export default function H18DeepApp({ onRequestClose }: H18DeepAppProps) {
     const [activeNav, setActiveNav] = useState<H18ActiveNav>('home');
     const [overlayNav, setOverlayNav] = useState<H18OverlayNav>(null);
     const [theme, setTheme] = useState<'light' | 'dark'>('light');
@@ -940,6 +944,7 @@ export default function H18DeepApp() {
         <div className={s.root}>
             <H18TopBar
                 showWindowControls
+                onRequestClose={onRequestClose}
                 onOpenSearch={() => setOverlayNav('search')}
                 effectiveTheme={theme}
                 onToggleTheme={() => void toggleTheme()}

--- a/ClassNoteAI/src/components/h18/H18TopBar.tsx
+++ b/ClassNoteAI/src/components/h18/H18TopBar.tsx
@@ -39,6 +39,8 @@ export interface H18TopBarProps {
     /** Inbox unread count (留白 — schema 沒做時固定 0)。 */
     inboxCount?: number;
     onOpenInbox?: () => void;
+    /** Custom close lifecycle owner (App wires recording-safe close handling). */
+    onRequestClose?: () => void;
     /** Currently active recording session, displayed as center island. */
     activeRecording?: ActiveRecording | null;
 }
@@ -72,6 +74,7 @@ export default function H18TopBar({
     onToggleTheme,
     inboxCount = 0,
     onOpenInbox,
+    onRequestClose,
     activeRecording,
 }: H18TopBarProps) {
     const [now, setNow] = useState(() => formatDateTime(new Date()));
@@ -102,7 +105,7 @@ export default function H18TopBar({
                 {showWindowControls && (
                     <>
                         <span data-tauri-drag-region="false">
-                            <WindowControls />
+                            <WindowControls onClose={onRequestClose} />
                         </span>
                         <div className={s.divider} />
                     </>


### PR DESCRIPTION
## Problem

Issue #178: The custom traffic-light close button in H18 doesn't actually close the app.
- Clicking the custom \u201cclose window\u201d button logs `ui_click status=ok` but `target/debug/classnoteai` process stays alive
- WM close (xdotool windowclose) works fine — the bug is only in the custom close path

## Fix

6 files, +57/-13:

- `src-tauri/capabilities/default.json` — adds `core:window:allow-destroy` permission
- `src/App.tsx` — App owns close lifecycle
- `src/components/WindowControls.tsx` — new `onClose` prop
- `src/components/__tests__/WindowControls.test.tsx` — updated tests
- `src/components/h18/H18DeepApp.tsx` — passes `onRequestClose`
- `src/components/h18/H18TopBar.tsx` — passes `onRequestClose`

## Verification

- Unit tests: 16/16 passed (WindowControls 9 + App.close 7)
- Build: passed (3.51s)
- App-backed smoke: 12/12 passed
- Final close verification: clicking `auto:button:0` after bridge is unavailable → process terminates correctly